### PR TITLE
Add PK_Signature_Options

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -912,52 +912,309 @@ Name: ``Raw``
 Public Key Signature Schemes
 ---------------------------------
 
+Signatures are generated using :cpp:class:`PK_Signer` and verified using
+:cpp:class:`PK_Verifier`. Both are configured with a
+:cpp:class:`PK_Signature_Options` object, which specifies every detail of how the
+signature is formed: the hash function, any padding scheme, the signature
+encoding, and so on.
+
+.. _pk_signature_options:
+
+Signature Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.14.0
+
+.. cpp:class:: PK_Signature_Options
+
+   Describes how a signature is to be generated or verified. The object is
+   built up in a builder style; each ``with_xxx`` function returns a new
+   options object with that option added, so the calls can be chained::
+
+      auto opts = Botan::PK_Signature_Options()
+                     .with_hash("SHA-256")
+                     .with_der_encoded_signature();
+
+      Botan::PK_Signer signer(key, rng, opts);
+      Botan::PK_Verifier verifier(key, opts);
+
+   Every option that is set must be understood and acted upon by the signature
+   scheme in use. If a scheme does not support an option (for example a context
+   for RSA, or a padding scheme for Ed25519) then constructing the
+   :cpp:class:`PK_Signer` or :cpp:class:`PK_Verifier` throws an exception which
+   names the offending option(s); an option is never silently ignored. The
+   options are validated when the signer or verifier is constructed, not when
+   they are set.
+
+   Each option can be set at most once; attempting to set an option a second time
+   throws ``Invalid_State``.
+
+   The signer and verifier must be configured compatibly. Most options (the
+   hash, padding, encoding, context, and the prehash options) affect the
+   signature itself and so must match on both sides. The exception is
+   :cpp:func:`PK_Signature_Options::with_deterministic_signature`, which only
+   affects signature generation and is ignored by :cpp:class:`PK_Verifier`.
+
+   .. cpp:function:: PK_Signature_Options()
+
+      Creates an empty set of options. This is sufficient for schemes which
+      take no parameters (such as Ed25519, ML-DSA, or XMSS).
+
+   .. cpp:function:: PK_Signature_Options with_hash(std::string_view hash)
+
+      Specify the hash function used for signing and verification. Most, but not
+      all, schemes require this; RSA, DSA, ECDSA, ECGDSA, ECKCDSA and GOST 34.10
+      must be given a hash, while SM2 defaults to SM3 if none is given.
+
+      Schemes where the hash is fixed by the key (XMSS, HSS-LMS, SLH-DSA) accept
+      this option only if it names the hash the operation uses, as reported by
+      :cpp:func:`PK_Signer::hash_function`; so that name can always be passed
+      to a verifier. Note that for SLH-DSA this is the function used to hash
+      the message, which for the larger parameter sets is not the one named in
+      the parameter set (for example SLH-DSA-SHA2-192s reports ``SHA-512``).
+      Schemes which have no hash function parameter at all (Ed25519, Ed448,
+      ML-DSA) reject it.
+
+      An empty string is ignored, which allows passing through a possibly-unset
+      user configuration.
+
+   .. cpp:function:: PK_Signature_Options with_padding(std::string_view padding)
+
+      Specify a padding scheme. This is only used for RSA, which requires it;
+      see :ref:`rsa_padding` for the available schemes. All other schemes reject
+      this option.
+
+      An empty string is ignored.
+
+   .. cpp:function:: PK_Signature_Options with_der_encoded_signature(bool der = true)
+
+      Produce, or expect, a signature encoded as an ASN.1 ``SEQUENCE`` of two
+      integers, rather than the default fixed-length concatenation of the two
+      signature elements. This formatting is used in protocols such as TLS and
+      in X.509 certificates.
+
+      Supported by DSA, ECDSA, ECGDSA, ECKCDSA, GOST 34.10 and SM2; rejected by
+      all other schemes.
+
+   .. cpp:function:: PK_Signature_Options with_deterministic_signature(bool deterministic = true)
+
+      Request a deterministic signature, that is one which depends only on the
+      key and the message and not on the random number generator.
+
+      Some schemes are always deterministic (for example RSA PKCS #1 v1.5,
+      Ed25519, XMSS, HSS-LMS); these accept the option as it is trivially
+      satisfied. DSA and ECDSA are randomized by default but can produce
+      deterministic signatures using the RFC 6979 nonce derivation; this
+      requires the ``rfc6979`` module, and if it is not included in the build
+      the option is rejected with ``Not_Implemented``. ML-DSA and SLH-DSA use
+      their "hedged" (randomized) variants by default, and this option selects
+      the deterministic variant instead. Schemes which cannot produce a
+      deterministic signature (for example RSA-PSS with a non-zero salt) reject
+      the option.
+
+      This option is ignored for verification.
+
+   .. cpp:function:: PK_Signature_Options with_salt_size(size_t salt_size)
+
+      Specify the size in bytes of the random salt. This applies to RSA with the
+      ``PSS`` and ``ISO_9796_DS2`` padding schemes, where the salt size
+      otherwise defaults to the output length of the hash function. When
+      verifying a ``PSS`` signature, if a salt size is specified then the
+      signature is only accepted if its salt has exactly that size; otherwise
+      any salt size is accepted. For ``ISO_9796_DS2`` the salt size is part of
+      the encoding, so the verifier must use the same size as the signer.
+
+      ML-DSA also accepts this option, but only if the size equals the 32 bytes
+      of randomness the scheme uses (64 for Dilithium), and not in combination
+      with a deterministic signature.
+
+   .. cpp:function:: PK_Signature_Options with_context(std::span<const uint8_t> context)
+   .. cpp:function:: PK_Signature_Options with_context(std::string_view context)
+
+      Specify a context which is bound into the signature. Currently this is
+      only supported by SM2, where the context is the user identifier
+      ``IDA``; if no context is given SM2 uses the default identifier
+      ``1234567812345678`` specified in GM/T 0009-2012.
+
+   .. cpp:function:: PK_Signature_Options with_prehash(std::optional<std::string> prehash = std::nullopt)
+
+      Request that the library hash the message before signing it, for schemes
+      which normally sign the entire message directly. Ed25519 and Ed448 are
+      such schemes; they sign the full message (which consequently must be
+      buffered in memory), but also define prehashed variants Ed25519ph and
+      Ed448ph. Calling this with no argument selects the scheme's standard
+      prehash (SHA-512 for Ed25519ph, SHAKE-256(512) for Ed448ph). Naming a
+      hash function instead uses that function; for Ed25519 this selects the
+      hash-then-sign construction used by GnuPG, which is not compatible with
+      Ed25519ph even if SHA-512 is named. See :ref:`Ed25519_Ed448_variants`.
+
+      The caller still provides the complete message, and the library computes
+      the hash. Schemes which always hash the message as part of signing (DSA,
+      ECDSA, RSA, ...) do not offer a separate prehash mode and reject this
+      option, with the exception that DSA, ECDSA, ECGDSA and GOST 34.10 accept
+      it if the named prehash is the same as the signature hash.
+
+      This cannot be combined with
+      :cpp:func:`PK_Signature_Options::with_externally_computed_prehash`.
+
+   .. cpp:function:: PK_Signature_Options with_externally_computed_prehash(std::optional<std::string> hash = std::nullopt)
+
+      Specify that the caller has already hashed the message. The data passed
+      to the signer or verifier is then not the message but a digest of it, and
+      is signed (or verified) directly without being hashed again.
+
+      .. warning::
+
+         This is intended for situations where the hash is computed by another
+         component and only the digest is available for signing. Many ways of
+         doing this are insecure. Don't use this unless you know what you are
+         doing.
+
+      The hash function the caller used may be named, either as the argument
+      here or using :cpp:func:`PK_Signature_Options::with_hash` (if both are
+      given they must agree). Naming it allows the scheme to check that the
+      input has the correct length, and to identify the hash in the signature
+      where the format requires it; for example a signature created with RSA
+      ``PKCS1v15`` and an externally computed SHA-256 digest is identical to one
+      created over the original message with ``PKCS1v15`` and ``SHA-256``. If no
+      hash is named the input is signed as an opaque byte string of any length.
+
+      This is supported by DSA, ECDSA, ECGDSA, GOST 34.10 (these four require
+      the ``raw_hash`` module, and reject the option with ``Lookup_Error`` if
+      it is not included in the build), SM2 (where the ``ZA`` identifier hash
+      is then not computed and any context is rejected) and RSA with the
+      ``PKCS1v15`` or ``Raw`` padding schemes. It is rejected by
+      ECKCDSA (whose hash input includes a key-derived prefix), by the RSA
+      padding schemes which must hash the message themselves, and by all other
+      schemes.
+
+      This cannot be combined with :cpp:func:`PK_Signature_Options::with_prehash`.
+
+   .. cpp:function:: PK_Signature_Options with_explicit_trailer_field(bool trailer = true)
+
+      Use the "explicit" trailer field, which identifies the hash function,
+      rather than the "implicit" one. This only applies to the RSA
+      ``ISO_9796_DS2`` and ``ISO_9796_DS3`` padding schemes, which default to
+      the explicit trailer; all other schemes reject it.
+
+   .. cpp:function:: PK_Signature_Options with_provider(std::string_view provider)
+
+      Request a specific implementation. This is rarely needed; the main use is
+      with keys held in hardware (providers ``pkcs11``, ``tpm2``), which accept
+      only their own provider name. The default (an empty string, or ``base``)
+      selects the software implementation.
+
+      Hardware providers support a subset of the options described here. For
+      RSA they require a padding scheme and a hash (PKCS#11 additionally
+      accepts ``Raw`` padding, and an unnamed externally computed prehash with
+      ``PKCS1v15``, ``PSS`` or ``X9.31``), accept a deterministic signature
+      only for the deterministic padding schemes (not ``PSS``), and do not
+      allow choosing the PSS salt size (TPM2) beyond the sizes the token
+      supports (PKCS#11).
+
+   .. cpp:function:: std::string to_string() const
+
+      Formats the options as a string, for debugging and error messages. The
+      format is not fixed.
+
+Options Accepted by Each Scheme
+""""""""""""""""""""""""""""""""""""
+
+The following summarizes which options each signature scheme accepts; any
+option not listed is rejected when the signer or verifier is constructed.
+
+- **RSA**: requires a padding scheme, and (except for ``Raw`` padding) a hash.
+  See :ref:`rsa_padding`. Additionally accepts a salt size (``PSS``,
+  ``ISO_9796_DS2``), an explicit trailer field (``ISO_9796_DS2``,
+  ``ISO_9796_DS3``), an externally computed prehash (``PKCS1v15``, ``Raw``),
+  and a deterministic signature (``PKCS1v15``, ``X9.31``, ``ISO_9796_DS3``,
+  and ``PSS`` or ``ISO_9796_DS2`` with a salt size of zero).
+- **DSA** and **ECDSA**: require a hash. Accept DER encoding, a deterministic
+  signature (RFC 6979), and an externally computed prehash.
+- **ECGDSA** and **GOST 34.10**: require a hash. Accept DER encoding and an
+  externally computed prehash.
+- **ECKCDSA**: requires a hash. Accepts DER encoding.
+- **SM2**: accepts a hash (default SM3), a context (the user identifier), DER
+  encoding, and an externally computed prehash.
+- **Ed25519** and **Ed448**: take no hash. Accept a prehash and a deterministic
+  signature (they are always deterministic).
+- **ML-DSA** (and Dilithium): accept a deterministic signature, and a salt size
+  equal to the scheme's randomness length.
+- **SLH-DSA**, **XMSS**, **HSS-LMS**: accept a hash only if it names the hash
+  the operation reports, and a deterministic signature (SLH-DSA is randomized
+  by default; XMSS and HSS-LMS are always deterministic).
+
+Signing and Verifying
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
 Signature generation is performed using
 
 .. cpp:class:: PK_Signer
 
    .. cpp:function:: PK_Signer(const Private_Key& key, \
-      const std::string& padding, \
-      Signature_Format format = Signature_Format::Standard)
+      RandomNumberGenerator& rng, \
+      const PK_Signature_Options& options = PK_Signature_Options())
 
-     Constructs a new signer object for the private key *key* using the
-     hash/padding specified in *padding*. The key must support signature operations. In
-     the current version of the library, this includes RSA, ECDSA, ML-DSA, ECKCDSA,
-     ECGDSA, SM2, and others.
+      Constructs a new signer object for the private key *key*, configured as
+      described by *options* (see :ref:`pk_signature_options`). The key must
+      support signature operations. In the current version of the library, this
+      includes RSA, ECDSA, ML-DSA, ECKCDSA, ECGDSA, SM2, and others.
 
-     .. note::
+      Most common algorithms, including RSA and ECDSA, require the options to
+      specify at least a hash function (and for RSA, a padding scheme). Schemes
+      without any parameters, such as Ed25519, ML-DSA or XMSS, can be used with
+      the default options.
 
-       Botan both supports non-deterministic and deterministic (as per RFC
-       6979) DSA and ECDSA signatures. Either type of signature can be verified
-       by any other (EC)DSA library, regardless of which mode it prefers. If the
-       ``rfc6979`` module is enabled at build time, deterministic DSA and ECDSA
-       signatures will be created.
+      Any option not supported by the key's algorithm causes an exception.
 
-     The proper value of *padding* depends on the algorithm. For many signature
-     schemes including ECDSA and DSA, simply naming a hash function like "SHA-256"
-     is all that is required.
+   .. cpp:function:: PK_Signer(const Private_Key& key, \
+      RandomNumberGenerator& rng, \
+      std::string_view padding, \
+      Signature_Format format = Signature_Format::Standard, \
+      std::string_view provider = "")
 
-     For RSA, more complicated padding is required. The two most common schemes
-     for RSA signature padding are PSS and PKCS1v1.5, so you must specify both
-     the padding mechanism as well as a hash, for example "PSS(SHA-256)"
-     or "PKCS1v15(SHA-256)".
+      Constructs a new signer using the hash/padding specified by the string
+      *padding*, which is the interface available in previous versions of
+      Botan. The string is translated into the equivalent
+      :cpp:class:`PK_Signature_Options`; new code should prefer to construct
+      the options directly.
 
-     Certain newer signature schemes, especially post-quantum based ones, hardcode the
-     hash function associated with their signatures, and no configuration is
-     possible. In this case *padding* should be left blank, or may possibly be used to identify
-     some algorithm-specific option. For instance ML-DSA may be parameterized with
-     "Randomized" or "Deterministic" to choose if the generated signature is randomized or
-     not. If left blank, a default is chosen.
+      The proper value of *padding* depends on the algorithm. For many signature
+      schemes including ECDSA and DSA, simply naming a hash function like
+      "SHA-256" is all that is required.
 
-     Another available option, usable in certain specialized scenarios, is using
-     padding scheme "Raw", where the provided input is treated as if it was
-     already hashed, and directly signed with no other processing.
+      For RSA, more complicated padding is required. The two most common schemes
+      for RSA signature padding are PSS and PKCS1v1.5, so you must specify both
+      the padding mechanism as well as a hash, for example "PSS(SHA-256)"
+      or "PKCS1v15(SHA-256)".
 
-     The *format* defaults to ``Standard`` which is either the usual, or the
-     only, available formatting method, depending on the algorithm. For certain
-     signature schemes including ECDSA, DSA, ECGDSA and ECKCDSA you can also use
-     ``DerSequence``, which will format the signature as an ASN.1 SEQUENCE
-     value. This formatting is used in protocols such as TLS and Bitcoin.
+      Certain newer signature schemes, especially post-quantum based ones, hardcode the
+      hash function associated with their signatures, and no configuration is
+      possible. In this case *padding* should be left blank, or may possibly be used to identify
+      some algorithm-specific option. For instance ML-DSA may be parameterized with
+      "Randomized" or "Deterministic" to choose if the generated signature is randomized or
+      not. If left blank, a default is chosen.
+
+      Another available option, usable in certain specialized scenarios, is using
+      padding scheme "Raw", where the provided input is treated as if it was
+      already hashed, and directly signed with no other processing. This
+      corresponds to :cpp:func:`PK_Signature_Options::with_externally_computed_prehash`.
+
+      The *format* defaults to ``Standard`` which is either the usual, or the
+      only, available formatting method, depending on the algorithm. For certain
+      signature schemes including ECDSA, DSA, ECGDSA and ECKCDSA you can also use
+      ``DerSequence``, which will format the signature as an ASN.1 SEQUENCE
+      value. This formatting is used in protocols such as TLS and Bitcoin. This
+      corresponds to :cpp:func:`PK_Signature_Options::with_der_encoded_signature`.
+
+      .. note::
+
+         Botan both supports non-deterministic and deterministic (as per RFC
+         6979) DSA and ECDSA signatures. Either type of signature can be verified
+         by any other (EC)DSA library, regardless of which mode it prefers. With
+         the string interface, a deterministic signature can be requested by
+         appending ",Deterministic" to the hash name, eg "SHA-256,Deterministic";
+         this requires the ``rfc6979`` module.
 
    .. cpp:function:: void update(const uint8_t* in, size_t length)
    .. cpp:function:: void update(std::span<const uint8_t> in)
@@ -999,10 +1256,22 @@ Signatures are verified using
 .. cpp:class:: PK_Verifier
 
    .. cpp:function:: PK_Verifier(const Public_Key& pub_key, \
-          const std::string& padding, Signature_Format format = Signature_Format::Standard)
+          const PK_Signature_Options& options = PK_Signature_Options())
+
+      Construct a new verifier for signatures associated with public key
+      *pub_key*. The *options* should be the same as those used by the signer
+      (see :ref:`pk_signature_options`); the deterministic signature option is
+      ignored, as it does not affect verification.
+
+   .. cpp:function:: PK_Verifier(const Public_Key& pub_key, \
+          std::string_view padding, \
+          Signature_Format format = Signature_Format::Standard, \
+          std::string_view provider = "")
 
       Construct a new verifier for signatures associated with public key *pub_key*. The
-      *padding* and *format* should be the same as that used by the signer.
+      *padding* and *format* should be the same as that used by the signer. As
+      with :cpp:class:`PK_Signer`, the string is translated into the equivalent
+      :cpp:class:`PK_Signature_Options`.
 
    .. cpp:function:: void update(const uint8_t* in, size_t length)
    .. cpp:function:: void update(std::span<const uint8_t> in)
@@ -1029,7 +1298,9 @@ Signatures are verified using
       calling :cpp:func:`PK_Verifier::check_signature` on *sig*. Any data previously
       provided to :cpp:func:`PK_Verifier::update` will also be included.
 
-Botan implements the following signature algorithms:
+Botan implements the following signature algorithms. The string parameter
+each accepts in the string based constructors is described below; the
+equivalent options are listed in :ref:`pk_signature_options`.
 
 1. RSA. Requires a :ref:`padding scheme <rsa_padding>` as parameter.
 #. DSA. Requires a :ref:`hash function <sig_with_hash>` as parameter.
@@ -1099,7 +1370,9 @@ PKCS #1 v1.5 Type 1 (signature) padding, aka EMSA3 in IEEE 1363.
   - ``(Raw,<optional HashFunction>)``
 
 - The raw variant encodes a precomputed hash,
-  optionally with the digest ID of the given hash.
+  optionally with the digest ID of the given hash. With
+  :cpp:class:`PK_Signature_Options` this is selected using
+  :cpp:func:`PK_Signature_Options::with_externally_computed_prehash`.
 - Examples:
   ``PKCS1v15(SHA-256)``,
   ``PKCS1v15(Raw)``,
@@ -1197,6 +1470,8 @@ Sign inputs directly with no hashing or padding
 - Examples:
   ``Raw``,
   ``Raw(SHA-256)``
+- With :cpp:class:`PK_Signature_Options`, the optional hash is given using
+  :cpp:func:`PK_Signature_Options::with_externally_computed_prehash`.
 
 .. _sig_with_hash:
 
@@ -1232,6 +1507,9 @@ Parameters specification:
 - ``Raw``
 - ``Raw(<HashFunction>)``
 
+With :cpp:class:`PK_Signature_Options`, this mode is selected using
+:cpp:func:`PK_Signature_Options::with_externally_computed_prehash`.
+
 .. _Ed25519_Ed448_variants:
 
 Ed25519 and Ed448 Variants
@@ -1260,15 +1538,16 @@ Parameter specification:
 
 Ed25519ph (or Ed448) (pre-hashed) instead hashes the message with SHA-512 (or SHAKE256(512))
 and then signs the digest plus a special prefix specified in RFC 8032. To use it, specify
-padding name "Ed25519ph" (or "Ed448ph").
+padding name "Ed25519ph" (or "Ed448ph"), or with :cpp:class:`PK_Signature_Options`
+call :cpp:func:`PK_Signature_Options::with_prehash` with no argument.
 
 Parameter specification:
 ``Ed25519ph``
 
 Another variant of pre-hashing is used by GnuPG. There the message is digested
 with any hash function, then the digest is signed. To use it, specify any valid
-hash function. Even if SHA-512 is used, this variant is not compatible with
-Ed25519ph.
+hash function (or pass its name to :cpp:func:`PK_Signature_Options::with_prehash`).
+Even if SHA-512 is used, this variant is not compatible with Ed25519ph.
 
 Parameter specification:
 ``<HashFunction>``

--- a/doc/cli.rst
+++ b/doc/cli.rst
@@ -111,16 +111,45 @@ Public Key Cryptography
   the passphrase passed as *pass-out*. The parameters *cipher*, *pbkdf*, and
   *pbkdf-ms* work similarly to ``keygen``.
 
-``sign --der-format --passphrase= --hash=SHA-256 --padding= --provider= key file``
+``sign --der-format --passphrase= --hash= --padding= --prehash= --prehashed --context= --salt-size= --deterministic --provider= key file``
 
-  Sign the data in *file* using the PKCS #8 private key *key* and cryptographic
-  hash *hash*. If *key* is encrypted, the used passphrase must be passed as
-  *pass-in*.
+  Sign the data in *file* using the PKCS #8 private key *key*. If *key* is
+  encrypted, the used passphrase must be passed as *passphrase*.
+
+  The options map onto the library's ``PK_Signature_Options``; an option that
+  the key's signature scheme does not support is rejected rather than ignored.
+
+  The *hash* option selects the hash function for schemes which require one
+  (RSA, DSA, ECDSA, ECGDSA, ECKCDSA, GOST 34.10); if not specified SHA-256 is
+  used. Schemes which do not take a hash (Ed25519, Ed448, ML-DSA, SLH-DSA,
+  XMSS, HSS-LMS) or which fix it (SM2) must be used without this option.
 
   The *padding* option can be used to control padding for algorithms that have
   divergent methods; this mostly applies to RSA. For RSA, if the option is not
   specified PSS signatures are used. You can select generating a PKCS #1 v1.5
-  formatted signature instead by providing ``--padding=PKCS1v15``.
+  formatted signature instead by providing ``--padding=PKCS1v15``. The
+  *salt-size* option sets the PSS salt length in bytes.
+
+  The *prehash* option signs a hash of the input rather than the input itself,
+  for schemes which offer such a mode. ``--prehash=default`` selects the
+  scheme's standard prehash mode (Ed25519ph, Ed448ph); a hash function name
+  selects that specific function. The hash is computed by Botan.
+
+  The *prehashed* flag instead indicates that the input file already contains
+  a digest computed elsewhere, which is signed directly without being hashed
+  again. If *hash* is also given it names the function used to compute the
+  digest, allowing its length to be checked (and, for RSA PKCS #1 v1.5, the
+  hash to be identified in the signature); otherwise the digest is signed as
+  an opaque byte string. Only schemes which can sign a caller-provided digest
+  (RSA, DSA, ECDSA, ECGDSA, GOST 34.10, SM2) accept this flag.
+
+  The *context* option provides a context string, for schemes which accept
+  one (for example the SM2 user identifier).
+
+  The *deterministic* option requests a deterministic signature, for schemes
+  which support both randomized and deterministic signing (for example ECDSA
+  using RFC 6979). Schemes which are always deterministic accept it; schemes
+  which cannot produce a deterministic signature reject it.
 
   For ECDSA and DSA, the option ``--der-format`` outputs the signature as an
   ASN.1 encoded blob. Some other tools (including ``openssl``) default to this
@@ -128,11 +157,10 @@ Public Key Cryptography
 
   The signature is formatted for your screen using base64.
 
-``verify --der-format --hash=SHA-256 --padding= pubkey file signature``
+``verify --der-format --hash= --padding= --prehash= --prehashed --context= --salt-size= pubkey file signature``
   Verify the authenticity of the data in *file* with the provided signature
-  *signature* and the public key *pubkey*. Similarly to the signing process,
-  *padding* specifies the padding scheme and *hash* the cryptographic hash
-  function to use.
+  *signature* and the public key *pubkey*. The options have the same meaning
+  as for ``sign`` and must match those used to create the signature.
 
 ``gen_dl_group --pbits=1024 --qbits=0 --seed= --type=subgroup``
   Generate ANSI X9.42 encoded Diffie-Hellman group parameters.

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -16,12 +16,12 @@
    #include <botan/hex.h>
    #include <botan/pk_algs.h>
    #include <botan/pk_keys.h>
+   #include <botan/pk_options.h>
    #include <botan/pkcs8.h>
    #include <botan/pubkey.h>
    #include <botan/x509_key.h>
    #include <botan/internal/workfactor.h>
    #include <fstream>
-   #include <sstream>
 
    #if defined(BOTAN_HAS_DL_GROUP)
       #include <botan/dl_group.h>
@@ -96,26 +96,17 @@ BOTAN_REGISTER_COMMAND("keygen", PK_Keygen);
 
 namespace {
 
-std::string choose_sig_padding(const std::string& key, const std::string& padding, const std::string& hash) {
-   if(key == "RSA") {
-      std::ostringstream oss;
-      if(padding.empty()) {
-         oss << "PSS";
-      } else {
-         oss << padding;
-      }
-
-      oss << "(" << hash << ")";
-      return oss.str();
-   } else if(padding.empty()) {
-      return hash;
-   } else if(hash.empty()) {
-      return padding;
-   } else {
-      std::ostringstream oss;
-      oss << padding << "(" << hash << ")";
-      return oss.str();
+Botan::PK_Signature_Options sig_options(
+   std::string_view key, std::string_view padding, std::string_view hash, bool use_der, std::string_view provider) {
+   if(key == "RSA" && padding.empty()) {
+      return sig_options(key, "PSS", hash, use_der, provider);
    }
+
+   return Botan::PK_Signature_Options()
+      .with_hash(hash)
+      .with_padding(padding)
+      .with_der_encoded_signature(use_der)
+      .with_provider(provider);
 }
 
 }  // namespace
@@ -198,21 +189,14 @@ class PK_Sign final : public Command {
             throw CLI_Error_Unsupported("hashing", hash_fn);
          }
 
-         const std::string sig_padding = choose_sig_padding(key->algo_name(), get_arg("padding"), hash_fn);
-
-         auto format = Botan::Signature_Format::Standard;
-
-         if(flag_set("der-format")) {
-            if(!key->_signature_element_size_for_DER_encoding()) {
-               throw CLI_Usage_Error("Key type " + key->algo_name() +
-                                     " does not support DER formatting for signatures");
-            }
-            format = Botan::Signature_Format::DerSequence;
+         if(flag_set("der-format") && !key->_signature_element_size_for_DER_encoding()) {
+            throw CLI_Usage_Error("Key type " + key->algo_name() + " does not support DER formatting for signatures");
          }
 
-         const std::string provider = get_arg("provider");
+         const auto options =
+            sig_options(key->algo_name(), get_arg("padding"), hash_fn, flag_set("der-format"), get_arg("provider"));
 
-         Botan::PK_Signer signer(*key, rng(), sig_padding, format, provider);
+         Botan::PK_Signer signer(*key, rng(), options);
 
          auto onData = [&signer](const uint8_t b[], size_t l) { signer.update(b, l); };
          Command::read_file(get_arg("file"), onData);
@@ -256,18 +240,9 @@ class PK_Verify final : public Command {
             throw CLI_Error_Unsupported("hashing", hash_fn);
          }
 
-         const std::string sig_padding = choose_sig_padding(key->algo_name(), get_arg("padding"), hash_fn);
+         const auto options = sig_options(key->algo_name(), get_arg("padding"), hash_fn, flag_set("der-format"), "");
 
-         auto format = Botan::Signature_Format::Standard;
-         if(flag_set("der-format")) {
-            if(key->message_parts() == 1) {
-               throw CLI_Usage_Error("Key type " + key->algo_name() +
-                                     " does not support DER formatting for signatures");
-            }
-            format = Botan::Signature_Format::DerSequence;
-         }
-
-         Botan::PK_Verifier verifier(*key, sig_padding, format);
+         Botan::PK_Verifier verifier(*key, options);
          auto onData = [&verifier](const uint8_t b[], size_t l) { verifier.update(b, l); };
          Command::read_file(get_arg("file"), onData);
 

--- a/src/cli/pubkey.cpp
+++ b/src/cli/pubkey.cpp
@@ -16,12 +16,12 @@
    #include <botan/hex.h>
    #include <botan/pk_algs.h>
    #include <botan/pk_keys.h>
+   #include <botan/pk_options.h>
    #include <botan/pkcs8.h>
    #include <botan/pubkey.h>
    #include <botan/x509_key.h>
    #include <botan/internal/workfactor.h>
    #include <fstream>
-   #include <sstream>
 
    #if defined(BOTAN_HAS_DL_GROUP)
       #include <botan/dl_group.h>
@@ -96,29 +96,83 @@ BOTAN_REGISTER_COMMAND("keygen", PK_Keygen);
 
 namespace {
 
-std::string choose_sig_padding(const std::string& key, const std::string& padding, const std::string& hash) {
-   if(key == "RSA") {
-      std::ostringstream oss;
-      if(padding.empty()) {
-         oss << "PSS";
-      } else {
-         oss << padding;
-      }
-
-      oss << "(" << hash << ")";
-      return oss.str();
-   } else if(padding.empty()) {
-      return hash;
-   } else if(hash.empty()) {
-      return padding;
-   } else {
-      std::ostringstream oss;
-      oss << padding << "(" << hash << ")";
-      return oss.str();
-   }
+/*
+* Signature schemes for which the caller must select a hash function; the
+* other schemes either fix the hash by the key type or do not use one.
+*/
+bool signature_scheme_requires_hash(std::string_view algo_name) {
+   return algo_name == "RSA" || algo_name == "DSA" || algo_name == "ECDSA" || algo_name == "ECGDSA" ||
+          algo_name == "ECKCDSA" || algo_name.starts_with("GOST-34.10");
 }
 
 }  // namespace
+
+/*
+* Shared handling of the signature related options of the sign and verify commands
+*/
+class PK_Signature_Command : public Command {
+   protected:
+      using Command::Command;
+
+      Botan::PK_Signature_Options signature_options(const Botan::Public_Key& key) const {
+         const std::string algo_name = key.algo_name();
+
+         auto options = Botan::PK_Signature_Options();
+
+         const bool prehashed = flag_set("prehashed");
+
+         std::string hash_fn = get_arg("hash");
+         // With a prehashed input an unnamed hash means the digest is signed as is
+         if(hash_fn.empty() && !prehashed && signature_scheme_requires_hash(algo_name)) {
+            hash_fn = "SHA-256";
+         }
+         if(!hash_fn.empty() && !Botan::HashFunction::create(hash_fn)) {
+            throw CLI_Error_Unsupported("hashing", hash_fn);
+         }
+         options = options.with_hash(hash_fn);
+
+         if(prehashed) {
+            options = options.with_externally_computed_prehash();
+         }
+
+         std::string padding = get_arg("padding");
+         if(padding.empty() && algo_name == "RSA") {
+            padding = "PSS";
+         }
+         options = options.with_padding(padding);
+
+         if(const auto prehash = get_arg_maybe("prehash")) {
+            if(*prehash == "default") {
+               options = options.with_prehash();
+            } else {
+               options = options.with_prehash(prehash);
+            }
+         }
+
+         if(const auto context = get_arg_maybe("context")) {
+            options = options.with_context(*context);
+         }
+
+         if(get_arg_maybe("salt-size")) {
+            options = options.with_salt_size(get_arg_sz("salt-size"));
+         }
+
+         if(flag_set("deterministic")) {
+            options = options.with_deterministic_signature();
+         }
+
+         if(flag_set("der-format")) {
+            if(!key._signature_element_size_for_DER_encoding()) {
+               throw CLI_Usage_Error("Key type " + algo_name + " does not support DER formatting for signatures");
+            }
+            options = options.with_der_encoded_signature();
+         }
+
+         options = options.with_provider(get_arg_or("provider", ""));
+
+         return options;
+      }
+};
 
 class PK_Fingerprint final : public Command {
    public:
@@ -175,12 +229,12 @@ std::unique_ptr<Botan::Private_Key> load_private_key(const std::string& key_file
 
 }  // namespace
 
-class PK_Sign final : public Command {
+class PK_Sign final : public PK_Signature_Command {
    public:
       PK_Sign() :
-            Command(
-               "sign --der-format --passphrase= --hash=SHA-256 --padding= --provider= --rng-type= --drbg-seed= key file") {
-      }
+            PK_Signature_Command(
+               "sign --der-format --passphrase= --hash= --padding= --prehash= --prehashed --context= --salt-size= "
+               "--deterministic --provider= --rng-type= --drbg-seed= key file") {}
 
       std::string group() const override { return "pubkey"; }
 
@@ -192,27 +246,7 @@ class PK_Sign final : public Command {
 
          auto key = load_private_key(key_file, passphrase);
 
-         const std::string hash_fn = get_arg("hash");
-
-         if(!hash_fn.empty() && !Botan::HashFunction::create(hash_fn)) {
-            throw CLI_Error_Unsupported("hashing", hash_fn);
-         }
-
-         const std::string sig_padding = choose_sig_padding(key->algo_name(), get_arg("padding"), hash_fn);
-
-         auto format = Botan::Signature_Format::Standard;
-
-         if(flag_set("der-format")) {
-            if(!key->_signature_element_size_for_DER_encoding()) {
-               throw CLI_Usage_Error("Key type " + key->algo_name() +
-                                     " does not support DER formatting for signatures");
-            }
-            format = Botan::Signature_Format::DerSequence;
-         }
-
-         const std::string provider = get_arg("provider");
-
-         Botan::PK_Signer signer(*key, rng(), sig_padding, format, provider);
+         Botan::PK_Signer signer(*key, rng(), signature_options(*key));
 
          auto onData = [&signer](const uint8_t b[], size_t l) { signer.update(b, l); };
          Command::read_file(get_arg("file"), onData);
@@ -234,9 +268,12 @@ class PK_Sign final : public Command {
 
 BOTAN_REGISTER_COMMAND("sign", PK_Sign);
 
-class PK_Verify final : public Command {
+class PK_Verify final : public PK_Signature_Command {
    public:
-      PK_Verify() : Command("verify --der-format --hash=SHA-256 --padding= pubkey file signature") {}
+      PK_Verify() :
+            PK_Signature_Command(
+               "verify --der-format --hash= --padding= --prehash= --prehashed --context= --salt-size= pubkey file "
+               "signature") {}
 
       std::string group() const override { return "pubkey"; }
 
@@ -250,24 +287,7 @@ class PK_Verify final : public Command {
             throw CLI_Error("Unable to load public key");
          }
 
-         const std::string hash_fn = get_arg("hash");
-
-         if(!hash_fn.empty() && !Botan::HashFunction::create(hash_fn)) {
-            throw CLI_Error_Unsupported("hashing", hash_fn);
-         }
-
-         const std::string sig_padding = choose_sig_padding(key->algo_name(), get_arg("padding"), hash_fn);
-
-         auto format = Botan::Signature_Format::Standard;
-         if(flag_set("der-format")) {
-            if(key->message_parts() == 1) {
-               throw CLI_Usage_Error("Key type " + key->algo_name() +
-                                     " does not support DER formatting for signatures");
-            }
-            format = Botan::Signature_Format::DerSequence;
-         }
-
-         Botan::PK_Verifier verifier(*key, sig_padding, format);
+         Botan::PK_Verifier verifier(*key, signature_options(*key));
          auto onData = [&verifier](const uint8_t b[], size_t l) { verifier.update(b, l); };
          Command::read_file(get_arg("file"), onData);
 

--- a/src/examples/ecdsa.cpp
+++ b/src/examples/ecdsa.cpp
@@ -15,13 +15,13 @@ int main() {
    const std::string message("This is a tasty burger!");
 
    // sign data
-   Botan::PK_Signer signer(key, rng, "SHA-256");
+   Botan::PK_Signer signer(key, rng, Botan::PK_Signature_Options().with_hash("SHA-256"));
    signer.update(message);
    std::vector<uint8_t> signature = signer.signature(rng);
    std::cout << "Signature:\n" << Botan::hex_encode(signature);
 
    // now verify the signature
-   Botan::PK_Verifier verifier(key, "SHA-256");
+   Botan::PK_Verifier verifier(key, Botan::PK_Signature_Options().with_hash("SHA-256"));
    verifier.update(message);
    std::cout << "\nis " << (verifier.check_signature(signature) ? "valid" : "invalid");
    return 0;

--- a/src/examples/pkcs11_ecdsa.cpp
+++ b/src/examples/pkcs11_ecdsa.cpp
@@ -95,7 +95,7 @@ int main() {
 
    std::vector<uint8_t> plaintext(20, 0x01);
 
-   Botan::PK_Signer signer(key_pair.second, rng, "Raw", Botan::Signature_Format::Standard, "pkcs11");
+   Botan::PK_Signer signer(key_pair.second, rng, Botan::PK_Signature_Options().with_hash("Raw"));
    auto signature = signer.sign_message(plaintext, rng);
 
    Botan::PK_Verifier token_verifier(key_pair.first, "Raw", Botan::Signature_Format::Standard, "pkcs11");

--- a/src/examples/pkcs11_ecdsa.cpp
+++ b/src/examples/pkcs11_ecdsa.cpp
@@ -93,13 +93,16 @@ int main() {
 
    /************ PKCS#11 ECDSA sign and verify *************/
 
-   std::vector<uint8_t> plaintext(20, 0x01);
+   // The token signs this digest directly (CKM_ECDSA) without hashing it
+   std::vector<uint8_t> digest(20, 0x01);
 
-   Botan::PK_Signer signer(key_pair.second, rng, "Raw", Botan::Signature_Format::Standard, "pkcs11");
-   auto signature = signer.sign_message(plaintext, rng);
+   const auto options = Botan::PK_Signature_Options().with_externally_computed_prehash().with_provider("pkcs11");
 
-   Botan::PK_Verifier token_verifier(key_pair.first, "Raw", Botan::Signature_Format::Standard, "pkcs11");
-   const bool ecdsa_ok = token_verifier.verify_message(plaintext, signature);
+   Botan::PK_Signer signer(key_pair.second, rng, options);
+   auto signature = signer.sign_message(digest, rng);
+
+   Botan::PK_Verifier token_verifier(key_pair.first, options);
+   const bool ecdsa_ok = token_verifier.verify_message(digest, signature);
 
    return ecdsa_ok ? 0 : 1;
 }

--- a/src/examples/xmss.cpp
+++ b/src/examples/xmss.cpp
@@ -16,14 +16,14 @@ int main() {
    const Botan::XMSS_PublicKey& public_key(private_key);
 
    // create Public Key Signer using the private key.
-   Botan::PK_Signer signer(private_key, rng, "");
+   Botan::PK_Signer signer(private_key, rng);
 
    // create and sign a message using the Public Key Signer.
    Botan::secure_vector<uint8_t> msg{0x01, 0x02, 0x03, 0x04};
    auto sig = signer.sign_message(msg, rng);
 
    // create Public Key Verifier using the public key
-   Botan::PK_Verifier verifier(public_key, "");
+   Botan::PK_Verifier verifier(public_key);
 
    // verify the signature for the previously generated message.
    if(verifier.verify_message(msg, sig)) {

--- a/src/lib/pk_pad/raw_hash/raw_hash.cpp
+++ b/src/lib/pk_pad/raw_hash/raw_hash.cpp
@@ -17,9 +17,10 @@ void RawHashFunction::add_data(std::span<const uint8_t> input) {
 
 void RawHashFunction::final_result(std::span<uint8_t> out) {
    if(m_output_length > 0 && m_bits.size() != m_output_length) {
+      const size_t provided = m_bits.size();
       m_bits.clear();
       throw Invalid_Argument("Raw padding was configured to use a " + std::to_string(m_output_length) +
-                             " byte hash but instead was used for a " + std::to_string(m_bits.size()) + " byte hash");
+                             " byte hash but instead was used for a " + std::to_string(provided) + " byte hash");
    }
 
    copy_mem(out.data(), m_bits.data(), m_bits.size());

--- a/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
@@ -7,9 +7,11 @@
 
 #include <botan/internal/pkcs1_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
@@ -75,8 +77,12 @@ bool PKCS1v15_SignaturePaddingScheme::verify(std::span<const uint8_t> coded,
    }
 }
 
-PKCS1v15_SignaturePaddingScheme::PKCS1v15_SignaturePaddingScheme(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)) {
+PKCS1v15_SignaturePaddingScheme::PKCS1v15_SignaturePaddingScheme(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())) {
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "PKCS1v15 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "PKCS1v15 does not support a padding trailer field");
+   BOTAN_ARG_CHECK(!options.using_prehash(), "PKCS1v15 does not support prehashing");
+
    m_hash_id = pkcs_hash_id(m_hash->name());
 }
 
@@ -96,15 +102,19 @@ std::string PKCS1v15_Raw_SignaturePaddingScheme::name() const {
    }
 }
 
-PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme() : m_hash_output_len(0) {
-   // m_hash_id, m_hash_name left empty
-}
+PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme(const PK_Signature_Options& options) {
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "PKCS1v15 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "PKCS1v15 does not support a padding trailer field");
 
-PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme(std::string_view hash_algo) {
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_algo));
-   m_hash_id = pkcs_hash_id(hash_algo);
-   m_hash_name = hash->name();
-   m_hash_output_len = hash->output_length();
+   if(const auto& hash_algo = options.prehash_function()) {
+      std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_algo.value()));
+      m_hash_id = pkcs_hash_id(hash->name());
+      m_hash_name = hash->name();
+      m_hash_output_len = hash->output_length();
+   } else {
+      m_hash_output_len = 0;
+      // m_hash_id, m_hash_name left empty
+   }
 }
 
 void PKCS1v15_Raw_SignaturePaddingScheme::update(const uint8_t input[], size_t length) {

--- a/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
@@ -7,12 +7,15 @@
 
 #include <botan/internal/pkcs1_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -75,8 +78,9 @@ bool PKCS1v15_SignaturePaddingScheme::verify(std::span<const uint8_t> coded,
    }
 }
 
-PKCS1v15_SignaturePaddingScheme::PKCS1v15_SignaturePaddingScheme(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)) {
+PKCS1v15_SignaturePaddingScheme::PKCS1v15_SignaturePaddingScheme(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())) {
+   acknowledge_always_deterministic(options);
    m_hash_id = pkcs_hash_id(m_hash->name());
 }
 
@@ -96,15 +100,21 @@ std::string PKCS1v15_Raw_SignaturePaddingScheme::name() const {
    }
 }
 
-PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme() : m_hash_output_len(0) {
-   // m_hash_id, m_hash_name left empty
-}
+PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme(const PK_Signature_Options& options) {
+   acknowledge_always_deterministic(options);
 
-PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme(std::string_view hash_algo) {
-   std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(hash_algo));
-   m_hash_id = pkcs_hash_id(hash_algo);
-   m_hash_name = hash->name();
-   m_hash_output_len = hash->output_length();
+   BOTAN_ARG_CHECK(options.using_externally_computed_prehash(),
+                   "PKCS1v15 raw signing requires an externally computed prehash");
+
+   if(auto hash_algo = externally_computed_prehash_name(options)) {
+      std::unique_ptr<HashFunction> hash(HashFunction::create_or_throw(*hash_algo));
+      m_hash_id = pkcs_hash_id(hash->name());
+      m_hash_name = hash->name();
+      m_hash_output_len = hash->output_length();
+   } else {
+      m_hash_output_len = 0;
+      // m_hash_id, m_hash_name left empty
+   }
 }
 
 void PKCS1v15_Raw_SignaturePaddingScheme::update(const uint8_t input[], size_t length) {

--- a/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.h
+++ b/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.h
@@ -12,12 +12,12 @@
 
 #include <memory>
 #include <string>
-#include <string_view>
 #include <vector>
 
 namespace Botan {
 
 class HashFunction;
+class PK_Signature_Options;
 
 /**
 * PKCS #1 v1.5 signature padding
@@ -26,10 +26,7 @@ class HashFunction;
 */
 class PKCS1v15_SignaturePaddingScheme final : public SignaturePaddingScheme {
    public:
-      /**
-      * @param hash the hash function to use
-      */
-      explicit PKCS1v15_SignaturePaddingScheme(std::unique_ptr<HashFunction> hash);
+      explicit PKCS1v15_SignaturePaddingScheme(const PK_Signature_Options& options);
 
       void update(const uint8_t input[], size_t length) override;
 
@@ -57,6 +54,8 @@ class PKCS1v15_SignaturePaddingScheme final : public SignaturePaddingScheme {
 */
 class PKCS1v15_Raw_SignaturePaddingScheme final : public SignaturePaddingScheme {
    public:
+      explicit PKCS1v15_Raw_SignaturePaddingScheme(const PK_Signature_Options& options);
+
       void update(const uint8_t input[], size_t length) override;
 
       std::vector<uint8_t> raw_data() override;
@@ -66,14 +65,6 @@ class PKCS1v15_Raw_SignaturePaddingScheme final : public SignaturePaddingScheme 
                                        RandomNumberGenerator& rng) override;
 
       bool verify(std::span<const uint8_t> coded, std::span<const uint8_t> raw, size_t key_bits) override;
-
-      PKCS1v15_Raw_SignaturePaddingScheme();
-
-      /**
-      * @param hash_algo the digest id for that hash is included in
-      * the signature.
-      */
-      explicit PKCS1v15_Raw_SignaturePaddingScheme(std::string_view hash_algo);
 
       std::string hash_function() const override { return m_hash_name; }
 

--- a/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
@@ -7,8 +7,10 @@
 
 #include <botan/internal/pssr.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
@@ -146,11 +148,17 @@ bool pss_verify(HashFunction& hash,
 
 }  // namespace
 
-PSSR::PSSR(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)), m_salt_size(m_hash->output_length()), m_required_salt_len(false) {}
+PSSR::PSSR(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_salt_size(options.salt_size().value_or(m_hash->output_length())),
+      m_required_salt_len(options.using_salt_size()) {
+   BOTAN_ARG_CHECK(!options.using_prehash(), "PSS does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "PSS does not support a padding trailer field");
 
-PSSR::PSSR(std::unique_ptr<HashFunction> hash, size_t salt_size) :
-      m_hash(std::move(hash)), m_salt_size(salt_size), m_required_salt_len(true) {}
+   if(options.using_deterministic_signature() && m_salt_size > 0) {
+      throw Invalid_Argument("PSS with a non-zero salt cannot produce deterministic signatures");
+   }
+}
 
 /*
 * PSSR Update Operation
@@ -193,11 +201,17 @@ std::string PSSR::name() const {
    return fmt("PSS({},MGF1,{})", m_hash->name(), m_salt_size);
 }
 
-PSS_Raw::PSS_Raw(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)), m_salt_size(m_hash->output_length()), m_required_salt_len(false) {}
+PSS_Raw::PSS_Raw(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_salt_size(options.salt_size().value_or(m_hash->output_length())),
+      m_required_salt_len(options.using_salt_size()) {
+   BOTAN_ARG_CHECK(!options.using_prehash(), "PSS_Raw does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "PSS does not support a padding trailer field");
 
-PSS_Raw::PSS_Raw(std::unique_ptr<HashFunction> hash, size_t salt_size) :
-      m_hash(std::move(hash)), m_salt_size(salt_size), m_required_salt_len(true) {}
+   if(options.using_deterministic_signature() && m_salt_size > 0) {
+      throw Invalid_Argument("PSS with a non-zero salt cannot produce deterministic signatures");
+   }
+}
 
 /*
 * PSS_Raw Update Operation

--- a/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
@@ -7,8 +7,10 @@
 
 #include <botan/internal/pssr.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
@@ -146,11 +148,14 @@ bool pss_verify(HashFunction& hash,
 
 }  // namespace
 
-PSSR::PSSR(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)), m_salt_size(m_hash->output_length()), m_required_salt_len(false) {}
-
-PSSR::PSSR(std::unique_ptr<HashFunction> hash, size_t salt_size) :
-      m_hash(std::move(hash)), m_salt_size(salt_size), m_required_salt_len(true) {}
+PSSR::PSSR(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_salt_size(options.salt_size().value_or(m_hash->output_length())),
+      m_required_salt_len(options.using_salt_size()) {
+   if(options.using_deterministic_signature() && m_salt_size > 0) {
+      throw Invalid_Argument("PSS with a non-zero salt cannot produce deterministic signatures");
+   }
+}
 
 /*
 * PSSR Update Operation
@@ -193,11 +198,14 @@ std::string PSSR::name() const {
    return fmt("PSS({},MGF1,{})", m_hash->name(), m_salt_size);
 }
 
-PSS_Raw::PSS_Raw(std::unique_ptr<HashFunction> hash) :
-      m_hash(std::move(hash)), m_salt_size(m_hash->output_length()), m_required_salt_len(false) {}
-
-PSS_Raw::PSS_Raw(std::unique_ptr<HashFunction> hash, size_t salt_size) :
-      m_hash(std::move(hash)), m_salt_size(salt_size), m_required_salt_len(true) {}
+PSS_Raw::PSS_Raw(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_salt_size(options.salt_size().value_or(m_hash->output_length())),
+      m_required_salt_len(options.using_salt_size()) {
+   if(options.using_deterministic_signature() && m_salt_size > 0) {
+      throw Invalid_Argument("PSS with a non-zero salt cannot produce deterministic signatures");
+   }
+}
 
 /*
 * PSS_Raw Update Operation

--- a/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.h
+++ b/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.h
@@ -17,22 +17,14 @@ namespace Botan {
 
 class RandomNumberGenerator;
 class HashFunction;
+class PK_Signature_Options;
 
 /**
 * PSSR (called EMSA4 in IEEE 1363 and in old versions of the library)
 */
 class PSSR final : public SignaturePaddingScheme {
    public:
-      /**
-      * @param hash the hash function to use
-      */
-      explicit PSSR(std::unique_ptr<HashFunction> hash);
-
-      /**
-      * @param hash the hash function to use
-      * @param salt_size the size of the salt to use in bytes
-      */
-      PSSR(std::unique_ptr<HashFunction> hash, size_t salt_size);
+      explicit PSSR(const PK_Signature_Options& options);
 
       std::string name() const override;
 
@@ -60,16 +52,7 @@ class PSSR final : public SignaturePaddingScheme {
 */
 class PSS_Raw final : public SignaturePaddingScheme {
    public:
-      /**
-      * @param hash the hash function to use
-      */
-      explicit PSS_Raw(std::unique_ptr<HashFunction> hash);
-
-      /**
-      * @param hash the hash function to use
-      * @param salt_size the size of the salt to use in bytes
-      */
-      PSS_Raw(std::unique_ptr<HashFunction> hash, size_t salt_size);
+      explicit PSS_Raw(const PK_Signature_Options& options);
 
       std::string hash_function() const override;
 

--- a/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.cpp
@@ -6,12 +6,29 @@
 
 #include <botan/internal/raw_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
+#include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 
 namespace Botan {
+
+SignRawBytes::SignRawBytes(const PK_Signature_Options& options) :
+      m_expected_size([&]() -> size_t {
+         BOTAN_ARG_CHECK(!options.using_salt_size(), "Raw signing does not support a salt");
+         BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(),
+                         "Raw signing does not support a padding trailer field");
+
+         if(options.using_prehash()) {
+            if(auto hash = HashFunction::create(options.prehash_function().value())) {
+               return hash->output_length();
+            }
+         }
+         return 0;
+      }()) {}
 
 std::string SignRawBytes::name() const {
    if(m_expected_size > 0) {

--- a/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.cpp
@@ -6,12 +6,29 @@
 
 #include <botan/internal/raw_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
+#include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
+
+SignRawBytes::SignRawBytes(const PK_Signature_Options& options) :
+      m_expected_size([&]() -> size_t {
+         acknowledge_always_deterministic(options);
+
+         // If the caller named the hash they used, the input length is checked against it
+         if(options.using_externally_computed_prehash()) {
+            if(auto prehash = externally_computed_prehash_name(options)) {
+               return HashFunction::create_or_throw(*prehash)->output_length();
+            }
+         }
+         return 0;
+      }()) {}
 
 std::string SignRawBytes::name() const {
    if(m_expected_size > 0) {

--- a/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.h
+++ b/src/lib/pk_pad/sig_padding/emsa_raw/raw_sig_padding.h
@@ -13,6 +13,7 @@
 
 namespace Botan {
 
+class PK_Signature_Options;
 class RandomNumberGenerator;
 
 /**
@@ -22,7 +23,7 @@ class RandomNumberGenerator;
 */
 class SignRawBytes final : public SignaturePaddingScheme {
    public:
-      explicit SignRawBytes(size_t expected_hash_size = 0) : m_expected_size(expected_hash_size) {}
+      explicit SignRawBytes(const PK_Signature_Options& options);
 
       std::string hash_function() const override { return "Raw"; }
 

--- a/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.cpp
@@ -6,9 +6,11 @@
 
 #include <botan/internal/x931_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
@@ -90,7 +92,12 @@ bool X931_SignaturePadding::verify(std::span<const uint8_t> coded, std::span<con
 /*
 * X931_SignaturePadding Constructor
 */
-X931_SignaturePadding::X931_SignaturePadding(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {
+X931_SignaturePadding::X931_SignaturePadding(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())) {
+   BOTAN_ARG_CHECK(!options.using_prehash(), "X9.31 does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "X9.31 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "X9.31 does not support a padding trailer field");
+
    m_empty_hash = m_hash->final_stdvec();
 
    m_hash_id = ieee1363_hash_id(m_hash->name());

--- a/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.cpp
@@ -6,12 +6,15 @@
 
 #include <botan/internal/x931_sig_padding.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
+#include <botan/pk_options.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -90,7 +93,10 @@ bool X931_SignaturePadding::verify(std::span<const uint8_t> coded, std::span<con
 /*
 * X931_SignaturePadding Constructor
 */
-X931_SignaturePadding::X931_SignaturePadding(std::unique_ptr<HashFunction> hash) : m_hash(std::move(hash)) {
+X931_SignaturePadding::X931_SignaturePadding(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())) {
+   acknowledge_always_deterministic(options);
+
    m_empty_hash = m_hash->final_stdvec();
 
    m_hash_id = ieee1363_hash_id(m_hash->name());

--- a/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.h
+++ b/src/lib/pk_pad/sig_padding/emsa_x931/x931_sig_padding.h
@@ -12,6 +12,7 @@
 namespace Botan {
 
 class HashFunction;
+class PK_Signature_Options;
 
 /**
 * Padding scheme from X9.31 (aka EMSA2 in IEEE 1363)
@@ -23,10 +24,7 @@ class HashFunction;
 */
 class X931_SignaturePadding final : public SignaturePaddingScheme {
    public:
-      /**
-      * @param hash the hash function to use
-      */
-      explicit X931_SignaturePadding(std::unique_ptr<HashFunction> hash);
+      explicit X931_SignaturePadding(const PK_Signature_Options& options);
 
       std::string name() const override;
 

--- a/src/lib/pk_pad/sig_padding/info.txt
+++ b/src/lib/pk_pad/sig_padding/info.txt
@@ -9,5 +9,6 @@ brief -> "Implementations of public key signature padding schemes"
 
 <requires>
 hash
+pubkey
 rng
 </requires>

--- a/src/lib/pk_pad/sig_padding/iso9796/iso9796.cpp
+++ b/src/lib/pk_pad/sig_padding/iso9796/iso9796.cpp
@@ -8,8 +8,10 @@
 
 #include <botan/internal/iso9796.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
@@ -211,6 +213,17 @@ bool iso9796_verification(std::span<const uint8_t> repr,
 
 }  // namespace
 
+ISO_9796_DS2::ISO_9796_DS2(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_implicit(!options.using_explicit_trailer_field()),
+      m_salt_len(options.salt_size().value_or(m_hash->output_length())) {
+   BOTAN_ARG_CHECK(!options.using_prehash(), "ISO_9796_DS2 does not support prehashing");
+
+   if(options.using_deterministic_signature() && m_salt_len > 0) {
+      throw Invalid_Argument("ISO_9796_DS2 with a non-zero salt cannot produce deterministic signatures");
+   }
+}
+
 /*
  *  ISO-9796-2 signature scheme 2
  *  DS 2 is probabilistic
@@ -254,6 +267,13 @@ std::string ISO_9796_DS2::hash_function() const {
  */
 std::string ISO_9796_DS2::name() const {
    return fmt("ISO_9796_DS2({},{},{})", m_hash->name(), (m_implicit ? "imp" : "exp"), m_salt_len);
+}
+
+ISO_9796_DS3::ISO_9796_DS3(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_implicit(!options.using_explicit_trailer_field()) {
+   BOTAN_ARG_CHECK(!options.using_prehash(), "ISO_9796_DS3 does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "ISO_9796_DS3 does not support a salt");
 }
 
 /*

--- a/src/lib/pk_pad/sig_padding/iso9796/iso9796.cpp
+++ b/src/lib/pk_pad/sig_padding/iso9796/iso9796.cpp
@@ -8,14 +8,17 @@
 
 #include <botan/internal/iso9796.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
 #include <botan/internal/mgf1.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -237,6 +240,15 @@ bool iso9796_verification(std::span<const uint8_t> repr,
 
 }  // namespace
 
+ISO_9796_DS2::ISO_9796_DS2(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_implicit(!options.using_explicit_trailer_field()),
+      m_salt_len(options.salt_size().value_or(m_hash->output_length())) {
+   if(options.using_deterministic_signature() && m_salt_len > 0) {
+      throw Invalid_Argument("ISO_9796_DS2 with a non-zero salt cannot produce deterministic signatures");
+   }
+}
+
 /*
  *  ISO-9796-2 signature scheme 2
  *  DS 2 is probabilistic
@@ -282,6 +294,12 @@ std::string ISO_9796_DS2::hash_function() const {
  */
 std::string ISO_9796_DS2::name() const {
    return fmt("ISO_9796_DS2({},{},{})", m_hash->name(), (m_implicit ? "imp" : "exp"), m_salt_len);
+}
+
+ISO_9796_DS3::ISO_9796_DS3(const PK_Signature_Options& options) :
+      m_hash(HashFunction::create_or_throw(options.hash_function_name())),
+      m_implicit(!options.using_explicit_trailer_field()) {
+   acknowledge_always_deterministic(options);
 }
 
 /*

--- a/src/lib/pk_pad/sig_padding/iso9796/iso9796.h
+++ b/src/lib/pk_pad/sig_padding/iso9796/iso9796.h
@@ -16,19 +16,14 @@
 namespace Botan {
 
 class HashFunction;
+class PK_Signature_Options;
 
 /**
 * ISO-9796-2 - Digital signature scheme 2 (probabilistic)
 */
 class ISO_9796_DS2 final : public SignaturePaddingScheme {
    public:
-      /**
-       * @param hash function to use
-       * @param implicit whether or not the trailer is implicit
-       * @param salt_size size of the salt to use in bytes
-       */
-      ISO_9796_DS2(std::unique_ptr<HashFunction> hash, bool implicit, size_t salt_size) :
-            m_hash(std::move(hash)), m_implicit(implicit), m_salt_len(salt_size) {}
+      explicit ISO_9796_DS2(const PK_Signature_Options& options);
 
       std::string hash_function() const override;
 
@@ -56,12 +51,7 @@ class ISO_9796_DS2 final : public SignaturePaddingScheme {
 */
 class ISO_9796_DS3 final : public SignaturePaddingScheme {
    public:
-      /**
-       * @param hash function to use
-       * @param implicit whether or not the trailer is implicit
-       */
-      explicit ISO_9796_DS3(std::unique_ptr<HashFunction> hash, bool implicit = false) :
-            m_hash(std::move(hash)), m_implicit(implicit) {}
+      explicit ISO_9796_DS3(const PK_Signature_Options& options);
 
       std::string name() const override;
 

--- a/src/lib/pk_pad/sig_padding/sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/sig_padding.cpp
@@ -8,7 +8,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/hash.h>
-#include <botan/internal/scan_name.h>
+#include <botan/pk_options.h>
 
 #if defined(BOTAN_HAS_X931_SIGNATURE_PADDING)
    #include <botan/internal/x931_sig_padding.h>
@@ -32,112 +32,57 @@
 
 namespace Botan {
 
-std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create(std::string_view algo_spec) {
-   const SCAN_Name req(algo_spec);
+std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create_or_throw(const PK_Signature_Options& options) {
+   const bool is_raw_hash = !options.using_hash() || options.hash_function_name() == "Raw";
+
+   if(!options.using_padding() || options.padding() == "Raw") {
+#if defined(BOTAN_HAS_EMSA_RAW)
+      if(is_raw_hash) {
+         return std::make_unique<SignRawBytes>(options);
+      }
+#endif
+   } else {
+      const std::string padding = options.padding().value();
+      const bool hash_available = !is_raw_hash && HashFunction::create(options.hash_function_name()) != nullptr;
 
 #if defined(BOTAN_HAS_EMSA_PKCS1)
-   // TODO(Botan4) Remove all but "PKCS1v15"
-   if(req.algo_name() == "EMSA_PKCS1" || req.algo_name() == "PKCS1v15" || req.algo_name() == "EMSA-PKCS1-v1_5" ||
-      req.algo_name() == "EMSA3") {
-      if(req.arg_count() == 2 && req.arg(0) == "Raw") {
-         return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>(req.arg(1));
-      } else if(req.arg_count() == 1) {
-         if(req.arg(0) == "Raw") {
-            return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>();
-         } else {
-            if(auto hash = HashFunction::create(req.arg(0))) {
-               return std::make_unique<PKCS1v15_SignaturePaddingScheme>(std::move(hash));
-            }
+      if(padding == "PKCS1v15") {
+         if(is_raw_hash) {
+            return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>(options);
+         } else if(hash_available) {
+            return std::make_unique<PKCS1v15_SignaturePaddingScheme>(options);
          }
       }
-   }
 #endif
 
-#if defined(BOTAN_HAS_EMSA_PSSR)
-   // TODO(Botan4) Remove all but "PSS_Raw"
-   if(req.algo_name() == "PSS_Raw" || req.algo_name() == "PSSR_Raw") {
-      if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            if(req.arg_count() == 3) {
-               const size_t salt_size = req.arg_as_integer(2, 0);
-               return std::make_unique<PSS_Raw>(std::move(hash), salt_size);
-            } else {
-               return std::make_unique<PSS_Raw>(std::move(hash));
-            }
-         }
+#if defined(BOTAN_HAS_PSS)
+      if(padding == "PSS_Raw" && hash_available) {
+         return std::make_unique<PSS_Raw>(options);
       }
-   }
 
-   // TODO(Botan4) Remove all but "PSS"
-   if(req.algo_name() == "PSS" || req.algo_name() == "PSSR" || req.algo_name() == "EMSA-PSS" ||
-      req.algo_name() == "PSS-MGF1" || req.algo_name() == "EMSA4") {
-      if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            if(req.arg_count() == 3) {
-               const size_t salt_size = req.arg_as_integer(2, 0);
-               return std::make_unique<PSSR>(std::move(hash), salt_size);
-            } else {
-               return std::make_unique<PSSR>(std::move(hash));
-            }
-         }
+      if(padding == "PSS" && hash_available) {
+         return std::make_unique<PSSR>(options);
       }
-   }
 #endif
 
 #if defined(BOTAN_HAS_ISO_9796)
-   if(req.algo_name() == "ISO_9796_DS2") {
-      if(req.arg_count_between(1, 3)) {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            const size_t salt_size = req.arg_as_integer(2, hash->output_length());
-            const bool implicit = req.arg(1, "exp") == "imp";
-            return std::make_unique<ISO_9796_DS2>(std::move(hash), implicit, salt_size);
-         }
+      if(padding == "ISO_9796_DS2" && hash_available) {
+         return std::make_unique<ISO_9796_DS2>(options);
       }
-   }
-   //ISO-9796-2 DS 3 is deterministic and DS2 without a salt
-   if(req.algo_name() == "ISO_9796_DS3") {
-      if(req.arg_count_between(1, 2)) {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            const bool implicit = req.arg(1, "exp") == "imp";
-            return std::make_unique<ISO_9796_DS3>(std::move(hash), implicit);
-         }
+
+      if(padding == "ISO_9796_DS3" && hash_available) {
+         return std::make_unique<ISO_9796_DS3>(options);
       }
-   }
 #endif
 
-#if defined(BOTAN_HAS_X931_SIGNATURE_PADDING)
-   // TODO(Botan4) Remove all but "X9.31"
-   if(req.algo_name() == "EMSA_X931" || req.algo_name() == "EMSA2" || req.algo_name() == "X9.31") {
-      if(req.arg_count() == 1) {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            return std::make_unique<X931_SignaturePadding>(std::move(hash));
-         }
+#if defined(BOTAN_HAS_EMSA_X931)
+      if(padding == "X9.31" && hash_available) {
+         return std::make_unique<X931_SignaturePadding>(options);
       }
-   }
 #endif
-
-#if defined(BOTAN_HAS_RAW_SIGNATURE_PADDING)
-   if(req.algo_name() == "Raw") {
-      if(req.arg_count() == 0) {
-         return std::make_unique<SignRawBytes>();
-      } else {
-         auto hash = HashFunction::create(req.arg(0));
-         if(hash) {
-            return std::make_unique<SignRawBytes>(hash->output_length());
-         }
-      }
    }
-#endif
 
-   return nullptr;
-}
-
-std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create_or_throw(std::string_view algo_spec) {
-   if(auto padding = SignaturePaddingScheme::create(algo_spec)) {
-      return padding;
-   } else {
-      throw Algorithm_Not_Found(algo_spec);
-   }
+   throw Lookup_Error("Invalid or unavailable signature padding scheme " + options.to_string());
 }
 
 }  // namespace Botan

--- a/src/lib/pk_pad/sig_padding/sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/sig_padding.cpp
@@ -8,7 +8,8 @@
 
 #include <botan/exceptn.h>
 #include <botan/hash.h>
-#include <botan/internal/scan_name.h>
+#include <botan/pk_options.h>
+#include <botan/internal/fmt.h>
 
 #if defined(BOTAN_HAS_X931_SIGNATURE_PADDING)
    #include <botan/internal/x931_sig_padding.h>
@@ -32,118 +33,68 @@
 
 namespace Botan {
 
-std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create(std::string_view algo_spec) {
-   const SCAN_Name req(algo_spec);
-
-#if defined(BOTAN_HAS_EMSA_PKCS1)
-   // TODO(Botan4) Remove all but "PKCS1v15"
-   if(req.algo_name() == "EMSA_PKCS1" || req.algo_name() == "PKCS1v15" || req.algo_name() == "EMSA-PKCS1-v1_5" ||
-      req.algo_name() == "EMSA3") {
-      if(req.arg_count() == 2 && req.arg(0) == "Raw") {
-         return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>(req.arg(1));
-      } else if(req.arg_count() == 1) {
-         if(req.arg(0) == "Raw") {
-            return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>();
-         } else {
-            if(auto hash = HashFunction::create(req.arg(0))) {
-               return std::make_unique<PKCS1v15_SignaturePaddingScheme>(std::move(hash));
-            }
-         }
-      }
+std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create_or_throw(const PK_Signature_Options& options) {
+   // Signing without padding is dangerous, so it must be requested explicitly
+   if(!options.using_padding()) {
+      throw Lookup_Error("RSA signatures require specifying a padding scheme");
    }
+
+   const std::string padding = options.padding().value();
+
+   if(padding == "Raw") {
+#if defined(BOTAN_HAS_EMSA_RAW)
+      // Raw padding signs the input directly, so no hash function is involved
+      return std::make_unique<SignRawBytes>(options);
+#endif
+   } else {
+#if defined(BOTAN_HAS_EMSA_PKCS1)
+      // PKCS1v15 can also sign a digest the caller computed
+      if(padding == "PKCS1v15" && options.using_externally_computed_prehash()) {
+         return std::make_unique<PKCS1v15_Raw_SignaturePaddingScheme>(options);
+      }
 #endif
 
-#if defined(BOTAN_HAS_EMSA_PSSR)
-   // TODO(Botan4) Remove all but "PSS_Raw"
-   if(req.algo_name() == "PSS_Raw" || req.algo_name() == "PSSR_Raw") {
-      if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            if(req.arg_count() == 3) {
-               const size_t salt_size = req.arg_as_integer(2, 0);
-               return std::make_unique<PSS_Raw>(std::move(hash), salt_size);
-            } else {
-               return std::make_unique<PSS_Raw>(std::move(hash));
-            }
-         }
+      if(!options.using_hash()) {
+         throw Lookup_Error(fmt("RSA/{} signatures require specifying a hash function", padding));
       }
-   }
 
-   // TODO(Botan4) Remove all but "PSS"
-   if(req.algo_name() == "PSS" || req.algo_name() == "PSSR" || req.algo_name() == "EMSA-PSS" ||
-      req.algo_name() == "PSS-MGF1" || req.algo_name() == "EMSA4") {
-      if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            if(req.arg_count() == 3) {
-               const size_t salt_size = req.arg_as_integer(2, 0);
-               return std::make_unique<PSSR>(std::move(hash), salt_size);
-            } else {
-               return std::make_unique<PSSR>(std::move(hash));
-            }
-         }
+      const std::string hash_fn = options.hash_function_name();
+      const bool hash_available = HashFunction::create(hash_fn) != nullptr;
+
+#if defined(BOTAN_HAS_EMSA_PKCS1)
+      if(padding == "PKCS1v15" && hash_available) {
+         return std::make_unique<PKCS1v15_SignaturePaddingScheme>(options);
       }
-   }
+#endif
+
+#if defined(BOTAN_HAS_PSS)
+      if(padding == "PSS_Raw" && hash_available) {
+         return std::make_unique<PSS_Raw>(options);
+      }
+
+      if(padding == "PSS" && hash_available) {
+         return std::make_unique<PSSR>(options);
+      }
 #endif
 
 #if defined(BOTAN_HAS_ISO_9796)
-   if(req.algo_name() == "ISO_9796_DS2") {
-      if(req.arg_count_between(1, 3)) {
-         const std::string trailer = req.arg(1, "exp");
-         if(trailer != "imp" && trailer != "exp") {
-            return nullptr;
-         }
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            const size_t salt_size = req.arg_as_integer(2, hash->output_length());
-            return std::make_unique<ISO_9796_DS2>(std::move(hash), trailer == "imp", salt_size);
-         }
+      if(padding == "ISO_9796_DS2" && hash_available) {
+         return std::make_unique<ISO_9796_DS2>(options);
       }
-   }
-   //ISO-9796-2 DS 3 is deterministic and DS2 without a salt
-   if(req.algo_name() == "ISO_9796_DS3") {
-      if(req.arg_count_between(1, 2)) {
-         const std::string trailer = req.arg(1, "exp");
-         if(trailer != "imp" && trailer != "exp") {
-            return nullptr;
-         }
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            return std::make_unique<ISO_9796_DS3>(std::move(hash), trailer == "imp");
-         }
+
+      if(padding == "ISO_9796_DS3" && hash_available) {
+         return std::make_unique<ISO_9796_DS3>(options);
       }
-   }
 #endif
 
-#if defined(BOTAN_HAS_X931_SIGNATURE_PADDING)
-   // TODO(Botan4) Remove all but "X9.31"
-   if(req.algo_name() == "EMSA_X931" || req.algo_name() == "EMSA2" || req.algo_name() == "X9.31") {
-      if(req.arg_count() == 1) {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            return std::make_unique<X931_SignaturePadding>(std::move(hash));
-         }
+#if defined(BOTAN_HAS_EMSA_X931)
+      if(padding == "X9.31" && hash_available) {
+         return std::make_unique<X931_SignaturePadding>(options);
       }
-   }
 #endif
-
-#if defined(BOTAN_HAS_RAW_SIGNATURE_PADDING)
-   if(req.algo_name() == "Raw") {
-      if(req.arg_count() == 0) {
-         return std::make_unique<SignRawBytes>();
-      } else {
-         auto hash = HashFunction::create(req.arg(0));
-         if(hash) {
-            return std::make_unique<SignRawBytes>(hash->output_length());
-         }
-      }
    }
-#endif
 
-   return nullptr;
-}
-
-std::unique_ptr<SignaturePaddingScheme> SignaturePaddingScheme::create_or_throw(std::string_view algo_spec) {
-   if(auto padding = SignaturePaddingScheme::create(algo_spec)) {
-      return padding;
-   } else {
-      throw Algorithm_Not_Found(algo_spec);
-   }
+   throw Lookup_Error("Invalid or unavailable signature padding scheme " + options.to_string());
 }
 
 }  // namespace Botan

--- a/src/lib/pk_pad/sig_padding/sig_padding.h
+++ b/src/lib/pk_pad/sig_padding/sig_padding.h
@@ -16,6 +16,7 @@
 namespace Botan {
 
 class RandomNumberGenerator;
+class PK_Signature_Options;
 
 /**
 * RSA Signature Padding Scheme
@@ -27,20 +28,12 @@ class BOTAN_TEST_API SignaturePaddingScheme /* NOLINT(*-special-member-functions
       virtual ~SignaturePaddingScheme() = default;
 
       /**
-      * Factory method for SignaturePaddingScheme (message-encoding methods for signatures
-      * with appendix) objects
-      * @param algo_spec the name of the SignaturePaddingScheme to create
-      * @return pointer to newly allocated object of that type, or nullptr
-      */
-      static std::unique_ptr<SignaturePaddingScheme> create(std::string_view algo_spec);
-
-      /**
-      * Factory method for SignaturePaddingScheme (message-encoding methods for signatures
-      * with appendix) objects
-      * @param algo_spec the name of the SignaturePaddingScheme to create
+      * Factory method for SignaturePaddingScheme objects
+      *
+      * @param options the algorithm parameters
       * @return pointer to newly allocated object of that type, or throws
       */
-      static std::unique_ptr<SignaturePaddingScheme> create_or_throw(std::string_view algo_spec);
+      static std::unique_ptr<SignaturePaddingScheme> create_or_throw(const PK_Signature_Options& options);
 
       /**
       * Add more data to the signature computation

--- a/src/lib/prov/pkcs11/p11_ecdsa.cpp
+++ b/src/lib/prov/pkcs11/p11_ecdsa.cpp
@@ -10,11 +10,13 @@
 
 #if defined(BOTAN_HAS_ECDSA)
 
+   #include <botan/assert.h>
    #include <botan/p11_mechanism.h>
    #include <botan/pk_ops.h>
+   #include <botan/pk_options.h>
    #include <botan/rng.h>
    #include <botan/internal/keypair.h>
-   #include <botan/internal/scan_name.h>
+   #include <botan/internal/pk_options_impl.h>
 
 namespace Botan::PKCS11 {
 
@@ -48,25 +50,32 @@ std::unique_ptr<Public_Key> PKCS11_ECDSA_PrivateKey::public_key() const {
 
 namespace {
 
-// PKCS#11 ECDSA accepts EMSA1(X) as an alias for X; unwrap so callers like
-// algorithm_identifier() see the normalized hash name (e.g. "SHA-256" instead
-// of "EMSA1(SHA-256)") and produce a registered OID such as ECDSA/SHA-256.
-std::string canonical_ecdsa_hash(std::string_view hash) {
-   const SCAN_Name req((std::string(hash)));
-   if(req.algo_name() == "EMSA1" && req.arg_count() == 1) {
-      return req.arg(0);
+/*
+* The mechanism hashes the input itself, unless the caller provides the
+* digest, in which case the plain CKM_ECDSA mechanism is used
+*/
+std::string p11_ecdsa_mechanism_hash(const PK_Signature_Options& options) {
+   if(options.using_externally_computed_prehash()) {
+      return "Raw";
    }
-   return std::string(hash);
+   return options.hash_function_name();
+}
+
+std::string p11_ecdsa_hash_name(const PK_Signature_Options& options) {
+   if(options.using_externally_computed_prehash()) {
+      return externally_computed_prehash_name(options).value_or("Raw");
+   }
+   return options.hash_function_name();
 }
 
 class PKCS11_ECDSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      PKCS11_ECDSA_Signature_Operation(const PKCS11_ECDSA_PrivateKey& key, std::string_view hash) :
+      PKCS11_ECDSA_Signature_Operation(const PKCS11_ECDSA_PrivateKey& key, const PK_Signature_Options& options) :
             PK_Ops::Signature(),
             m_key(key),
             m_order_bytes(key.domain().get_order_bytes()),
-            m_mechanism(MechanismWrapper::create_ecdsa_mechanism(hash)),
-            m_hash(canonical_ecdsa_hash(hash)) {}
+            m_mechanism(MechanismWrapper::create_ecdsa_mechanism(p11_ecdsa_mechanism_hash(options))),
+            m_hash(p11_ecdsa_hash_name(options)) {}
 
       void update(std::span<const uint8_t> input) override {
          if(!m_initialized) {
@@ -133,11 +142,11 @@ AlgorithmIdentifier PKCS11_ECDSA_Signature_Operation::algorithm_identifier() con
 
 class PKCS11_ECDSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      PKCS11_ECDSA_Verification_Operation(const PKCS11_ECDSA_PublicKey& key, std::string_view hash) :
+      PKCS11_ECDSA_Verification_Operation(const PKCS11_ECDSA_PublicKey& key, const PK_Signature_Options& options) :
             PK_Ops::Verification(),
             m_key(key),
-            m_mechanism(MechanismWrapper::create_ecdsa_mechanism(hash)),
-            m_hash(canonical_ecdsa_hash(hash)) {}
+            m_mechanism(MechanismWrapper::create_ecdsa_mechanism(p11_ecdsa_mechanism_hash(options))),
+            m_hash(p11_ecdsa_hash_name(options)) {}
 
       void update(std::span<const uint8_t> input) override {
          if(!m_initialized) {
@@ -205,15 +214,21 @@ class PKCS11_ECDSA_Verification_Operation final : public PK_Ops::Verification {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> PKCS11_ECDSA_PublicKey::create_verification_op(
-   std::string_view params, std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_ECDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> PKCS11_ECDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(options.using_provider() && options.provider().value() != "pkcs11") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<PKCS11_ECDSA_Verification_Operation>(*this, options);
 }
 
-std::unique_ptr<PK_Ops::Signature> PKCS11_ECDSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                                std::string_view params,
-                                                                                std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_ECDSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> PKCS11_ECDSA_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(options.using_provider() && options.provider().value() != "pkcs11") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<PKCS11_ECDSA_Signature_Operation>(*this, options);
 }
 
 PKCS11_ECDSA_KeyPair generate_ecdsa_keypair(Session& session,

--- a/src/lib/prov/pkcs11/p11_ecdsa.h
+++ b/src/lib/prov/pkcs11/p11_ecdsa.h
@@ -57,8 +57,7 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_ECDSA_PublicKey final : public PKCS11_EC_Pub
          throw Not_Implemented("Cannot generate a new PKCS#11 ECDSA keypair from this public key");
       }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP
@@ -117,9 +116,8 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_ECDSA_PrivateKey final : public PKCS11_EC_Pr
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 using PKCS11_ECDSA_KeyPair = std::pair<PKCS11_ECDSA_PublicKey, PKCS11_ECDSA_PrivateKey>;

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/p11_mechanism.h>
 
+#include <botan/pk_options.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/scan_name.h>
@@ -154,7 +155,7 @@ MechanismWrapper MechanismWrapper::create_rsa_crypt_mechanism(std::string_view p
    return mech;
 }
 
-MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(std::string_view padding) {
+MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(const PK_Signature_Options& options) {
    // note: when updating this map, update the documentation for `MechanismWrapper::create_rsa_sign_mechanism`
    static const std::map<std::string_view, RSA_SignMechanism> SignMechanisms = {
       {"Raw", RSA_SignMechanism(MechanismType::RsaX509)},
@@ -226,6 +227,22 @@ MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(std::string_view pa
       {"EMSA4(SHA-512,MGF1,64)", RSA_SignMechanism(MechanismType::Sha512RsaPkcsPss)},
       {"PSSR(SHA-512,MGF1,64)", RSA_SignMechanism(MechanismType::Sha512RsaPkcsPss)},
    };
+
+   const std::string padding = [&]() {
+      if(options.using_hash() && options.using_padding()) {
+         return fmt("{}({})", options.padding().value(), options.hash_function_name());
+      }
+
+      if(options.using_padding()) {
+         return options.padding().value();
+      }
+
+      if(options.using_hash()) {
+         return options.hash_function_name();
+      }
+
+      throw Invalid_Argument("RSA signature requires a padding scheme");
+   }();
 
    auto mechanism_info_it = SignMechanisms.find(padding);
    if(mechanism_info_it == SignMechanisms.end()) {

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -8,8 +8,10 @@
 
 #include <botan/p11_mechanism.h>
 
+#include <botan/pk_options.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/scan_name.h>
 #include <botan/internal/stl_util.h>
 #include <tuple>
@@ -155,7 +157,7 @@ MechanismWrapper MechanismWrapper::create_rsa_crypt_mechanism(std::string_view p
    return mech;
 }
 
-MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(std::string_view padding) {
+MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(const PK_Signature_Options& options) {
    // note: when updating this map, update the documentation for `MechanismWrapper::create_rsa_sign_mechanism`
    static const std::map<std::string_view, RSA_SignMechanism> SignMechanisms = {
       {"Raw", RSA_SignMechanism(MechanismType::RsaX509)},
@@ -165,6 +167,7 @@ MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(std::string_view pa
       {"X9.31(SHA-1)", RSA_SignMechanism(MechanismType::Sha1RsaX931)},
 
       // RSASSA PKCS#1 v1.5
+      {"PKCS1v15(Raw)", RSA_SignMechanism(MechanismType::RsaPkcs)},
       {"PKCS1v15(SHA-1)", RSA_SignMechanism(MechanismType::Sha1RsaPkcs)},
       {"PKCS1v15(SHA-224)", RSA_SignMechanism(MechanismType::Sha224RsaPkcs)},
       {"PKCS1v15(SHA-256)", RSA_SignMechanism(MechanismType::Sha256RsaPkcs)},
@@ -228,12 +231,42 @@ MechanismWrapper MechanismWrapper::create_rsa_sign_mechanism(std::string_view pa
       {"PSSR(SHA-512,MGF1,64)", RSA_SignMechanism(MechanismType::Sha512RsaPkcsPss)},
    };
 
+   const std::string padding = [&]() {
+      if(!options.using_padding()) {
+         throw Invalid_Argument("PKCS#11 RSA signature requires a padding scheme");
+      }
+
+      const std::string scheme = options.padding().value();
+
+      if(options.using_externally_computed_prehash()) {
+         // The token pads the digest as given, so it cannot add a DigestInfo for a named hash
+         if(auto prehash = externally_computed_prehash_name(options)) {
+            throw Not_Implemented(fmt("PKCS#11 RSA {} signing of an externally computed {} prehash", scheme, *prehash));
+         }
+         return (scheme == "Raw") ? scheme : fmt("{}(Raw)", scheme);
+      }
+
+      if(options.using_hash()) {
+         if(options.using_salt_size()) {
+            return fmt("{}({},MGF1,{})", scheme, options.hash_function_name(), options.salt_size().value());
+         }
+         return fmt("{}({})", scheme, options.hash_function_name());
+      }
+
+      return scheme;  // NOLINT(*-no-automatic-move)
+   }();
+
    auto mechanism_info_it = SignMechanisms.find(padding);
    if(mechanism_info_it == SignMechanisms.end()) {
       // at this point it would be possible to support additional configurations that are not predefined above by parsing `padding`
       throw Lookup_Error(fmt("PKCS#11 RSA sign/verify does not support padding with '{}'", padding));
    }
    const RSA_SignMechanism mechanism_info = mechanism_info_it->second;
+
+   // Only PSS is randomized; the token generates the salt itself
+   if(options.using_deterministic_signature() && PssOptions().contains(mechanism_info.type())) {
+      throw Invalid_Argument(fmt("PKCS#11 RSA signing with {} cannot produce deterministic signatures", padding));
+   }
 
    MechanismWrapper mech(mechanism_info.type());
    if(PssOptions().contains(mechanism_info.type())) {

--- a/src/lib/prov/pkcs11/p11_mechanism.h
+++ b/src/lib/prov/pkcs11/p11_mechanism.h
@@ -15,6 +15,12 @@
 #include <memory>
 #include <string_view>
 
+namespace Botan {
+
+class PK_Signature_Options;
+
+}  // namespace Botan
+
 namespace Botan::PKCS11 {
 
 /**
@@ -35,10 +41,10 @@ class BOTAN_PUBLIC_API(3, 7) MechanismWrapper final {
 
       /**
       * Creates the CK_MECHANISM data for RSA signature/verification
-      * @param padding supported paddings are Raw (X.509), EMSA3 (PKCS#1 v1.5), EMSA4 (PKCS#1 PSS),
+      * @param options supported paddings are Raw (X.509), EMSA3 (PKCS#1 v1.5), EMSA4 (PKCS#1 PSS),
       * EMSA2 (ANSI X9.31) and ISO9796 (ISO/IEC 9796)
       */
-      static MechanismWrapper create_rsa_sign_mechanism(std::string_view padding);
+      static MechanismWrapper create_rsa_sign_mechanism(const PK_Signature_Options& options);
 
       /**
       * Creates the CK_MECHANISM data for ECDSA signature/verification

--- a/src/lib/prov/pkcs11/p11_mechanism.h
+++ b/src/lib/prov/pkcs11/p11_mechanism.h
@@ -15,6 +15,12 @@
 #include <memory>
 #include <string_view>
 
+namespace Botan {
+
+class PK_Signature_Options;
+
+}  // namespace Botan
+
 namespace Botan::PKCS11 {
 
 /**
@@ -35,10 +41,10 @@ class BOTAN_PUBLIC_API(3, 7) MechanismWrapper final {
 
       /**
       * Creates the CK_MECHANISM data for RSA signature/verification
-      * @param padding supported paddings are Raw (X.509), EMSA3 (PKCS#1 v1.5), EMSA4 (PKCS#1 PSS),
-      * EMSA2 (ANSI X9.31) and ISO9796 (ISO/IEC 9796)
+      * @param options supported paddings are Raw (X.509), PKCS1v15 (PKCS#1 v1.5), PSS (PKCS#1 PSS),
+      * X9.31 (ANSI X9.31) and ISO9796 (ISO/IEC 9796)
       */
-      static MechanismWrapper create_rsa_sign_mechanism(std::string_view padding);
+      static MechanismWrapper create_rsa_sign_mechanism(const PK_Signature_Options& options);
 
       /**
       * Creates the CK_MECHANISM data for ECDSA signature/verification

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -222,8 +222,8 @@ class PKCS11_RSA_Encryption_Operation final : public PK_Ops::Encryption {
 
 class PKCS11_RSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      PKCS11_RSA_Signature_Operation(const PKCS11_RSA_PrivateKey& key, std::string_view padding) :
-            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(padding)) {}
+      PKCS11_RSA_Signature_Operation(const PKCS11_RSA_PrivateKey& key, const PK_Signature_Options& options) :
+            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(options)) {}
 
       size_t signature_length() const override { return m_key.get_n().bytes(); }
 
@@ -339,8 +339,8 @@ AlgorithmIdentifier PKCS11_RSA_Signature_Operation::algorithm_identifier() const
 
 class PKCS11_RSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      PKCS11_RSA_Verification_Operation(const PKCS11_RSA_PublicKey& key, std::string_view padding) :
-            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(padding)) {}
+      PKCS11_RSA_Verification_Operation(const PKCS11_RSA_PublicKey& key, const PK_Signature_Options& options) :
+            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(options)) {}
 
       void update(std::span<const uint8_t> input) override {
          if(!m_initialized) {
@@ -404,9 +404,9 @@ std::unique_ptr<PK_Ops::Encryption> PKCS11_RSA_PublicKey::create_encryption_op(R
    return std::make_unique<PKCS11_RSA_Encryption_Operation>(*this, params);
 }
 
-std::unique_ptr<PK_Ops::Verification> PKCS11_RSA_PublicKey::create_verification_op(
-   std::string_view params, std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_RSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> PKCS11_RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   return std::make_unique<PKCS11_RSA_Verification_Operation>(*this, options);
 }
 
 std::unique_ptr<PK_Ops::Decryption> PKCS11_RSA_PrivateKey::create_decryption_op(RandomNumberGenerator& rng,
@@ -419,10 +419,10 @@ std::unique_ptr<PK_Ops::Decryption> PKCS11_RSA_PrivateKey::create_decryption_op(
    }
 }
 
-std::unique_ptr<PK_Ops::Signature> PKCS11_RSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                              std::string_view params,
-                                                                              std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_RSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> PKCS11_RSA_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   return std::make_unique<PKCS11_RSA_Signature_Operation>(*this, options);
 }
 
 PKCS11_RSA_KeyPair generate_rsa_keypair(Session& session,

--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -259,8 +259,8 @@ class PKCS11_RSA_Encryption_Operation final : public PK_Ops::Encryption {
 
 class PKCS11_RSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      PKCS11_RSA_Signature_Operation(const PKCS11_RSA_PrivateKey& key, std::string_view padding) :
-            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(padding)) {}
+      PKCS11_RSA_Signature_Operation(const PKCS11_RSA_PrivateKey& key, const PK_Signature_Options& options) :
+            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(options)) {}
 
       size_t signature_length() const override { return m_key.get_n().bytes(); }
 
@@ -386,8 +386,8 @@ AlgorithmIdentifier PKCS11_RSA_Signature_Operation::algorithm_identifier() const
 
 class PKCS11_RSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      PKCS11_RSA_Verification_Operation(const PKCS11_RSA_PublicKey& key, std::string_view padding) :
-            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(padding)) {}
+      PKCS11_RSA_Verification_Operation(const PKCS11_RSA_PublicKey& key, const PK_Signature_Options& options) :
+            m_key(key), m_mechanism(MechanismWrapper::create_rsa_sign_mechanism(options)) {}
 
       void update(std::span<const uint8_t> input) override {
          if(!m_initialized) {
@@ -464,9 +464,12 @@ std::unique_ptr<PK_Ops::Encryption> PKCS11_RSA_PublicKey::create_encryption_op(R
    return std::make_unique<PKCS11_RSA_Encryption_Operation>(*this, params);
 }
 
-std::unique_ptr<PK_Ops::Verification> PKCS11_RSA_PublicKey::create_verification_op(
-   std::string_view params, std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_RSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> PKCS11_RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(options.using_provider() && options.provider().value() != "pkcs11") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<PKCS11_RSA_Verification_Operation>(*this, options);
 }
 
 std::unique_ptr<PK_Ops::Decryption> PKCS11_RSA_PrivateKey::create_decryption_op(RandomNumberGenerator& rng,
@@ -479,10 +482,13 @@ std::unique_ptr<PK_Ops::Decryption> PKCS11_RSA_PrivateKey::create_decryption_op(
    }
 }
 
-std::unique_ptr<PK_Ops::Signature> PKCS11_RSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                              std::string_view params,
-                                                                              std::string_view /*provider*/) const {
-   return std::make_unique<PKCS11_RSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> PKCS11_RSA_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(options.using_provider() && options.provider().value() != "pkcs11") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<PKCS11_RSA_Signature_Operation>(*this, options);
 }
 
 PKCS11_RSA_KeyPair generate_rsa_keypair(Session& session,

--- a/src/lib/prov/pkcs11/p11_rsa.h
+++ b/src/lib/prov/pkcs11/p11_rsa.h
@@ -81,8 +81,7 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_RSA_PublicKey : public Object,
                                                                std::string_view params,
                                                                std::string_view provider) const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 };
 
 /// Properties for importing a PKCS#11 RSA private key
@@ -183,9 +182,8 @@ class BOTAN_PUBLIC_API(2, 0) PKCS11_RSA_PrivateKey final : public Object,
                                                                std::string_view params,
                                                                std::string_view provider) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       bool m_use_software_padding = false;

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -11,6 +11,7 @@
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
 #include <botan/pk_ops.h>
+#include <botan/pk_options.h>
 #include <botan/rsa.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
@@ -372,10 +373,13 @@ class TPM_Signing_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> TPM_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                       std::string_view params,
-                                                                       std::string_view /*provider*/) const {
-   return std::make_unique<TPM_Signing_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> TPM_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(!options.using_padding() || options.padding().value() != "PKCS1v15") {
+      throw Invalid_Argument("TPMv1 can only sign using PKCS1v15 padding");
+   }
+   return std::make_unique<TPM_Signing_Operation>(*this, options.hash_function_name());
 }
 
 }  // namespace Botan

--- a/src/lib/prov/tpm/tpm.cpp
+++ b/src/lib/prov/tpm/tpm.cpp
@@ -11,9 +11,11 @@
 #include <botan/hash.h>
 #include <botan/mem_ops.h>
 #include <botan/pk_ops.h>
+#include <botan/pk_options.h>
 #include <botan/rsa.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/hash_id.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/workfactor.h>
 #include <limits>
 
@@ -372,10 +374,18 @@ class TPM_Signing_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> TPM_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                       std::string_view params,
-                                                                       std::string_view /*provider*/) const {
-   return std::make_unique<TPM_Signing_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> TPM_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(options.using_provider() && options.provider().value() != "tpm") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   // Historically only a hash was specified, in which case PKCS1v15 is implied
+   if(options.using_padding() && options.padding().value() != "PKCS1v15") {
+      throw Invalid_Argument("TPMv1 can only sign using PKCS1v15 padding");
+   }
+   acknowledge_always_deterministic(options);
+   return std::make_unique<TPM_Signing_Operation>(*this, options.hash_function_name());
 }
 
 }  // namespace Botan

--- a/src/lib/prov/tpm/tpm.h
+++ b/src/lib/prov/tpm/tpm.h
@@ -172,9 +172,8 @@ class BOTAN_PUBLIC_API(2, 0) TPM_PrivateKey final : public Private_Key {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       TPM_Context& m_ctx;

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/tpm2_ecc.h>
 
+#include <botan/pk_options.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>
 #include <botan/internal/tpm2_hash.h>
@@ -161,7 +162,8 @@ std::unique_ptr<TPM2::PrivateKey> EC_PrivateKey::create_unrestricted_transient(c
 
 namespace {
 
-SignatureAlgorithmSelection make_signature_scheme(std::string_view hash_name) {
+SignatureAlgorithmSelection make_signature_scheme(const PK_Signature_Options& options) {
+   const std::string hash_name = options.hash_function_name();
    return {
       .signature_scheme =
          TPMT_SIG_SCHEME{
@@ -185,8 +187,8 @@ size_t signature_length_for_ecdsa_key_handle(const SessionBundle& sessions, cons
 
 class EC_Signature_Operation final : public Signature_Operation {
    public:
-      EC_Signature_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
-            Signature_Operation(object, sessions, make_signature_scheme(hash)) {}
+      EC_Signature_Operation(const Object& object, const SessionBundle& sessions, const PK_Signature_Options& options) :
+            Signature_Operation(object, sessions, make_signature_scheme(options)) {}
 
       size_t signature_length() const override {
          return signature_length_for_ecdsa_key_handle(sessions(), key_handle());
@@ -215,8 +217,10 @@ class EC_Signature_Operation final : public Signature_Operation {
 
 class EC_Verification_Operation final : public Verification_Operation {
    public:
-      EC_Verification_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
-            Verification_Operation(object, sessions, make_signature_scheme(hash)) {}
+      EC_Verification_Operation(const Object& object,
+                                const SessionBundle& sessions,
+                                const PK_Signature_Options& options) :
+            Verification_Operation(object, sessions, make_signature_scheme(options)) {}
 
    private:
       TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> sig_data) const override {
@@ -243,17 +247,14 @@ class EC_Verification_Operation final : public Verification_Operation {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> EC_PublicKey::create_verification_op(std::string_view params,
-                                                                           std::string_view provider) const {
-   BOTAN_UNUSED(provider);
-   return std::make_unique<EC_Verification_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Verification> EC_PublicKey::_create_verification_op(const PK_Signature_Options& options) const {
+   return std::make_unique<EC_Verification_Operation>(handles(), sessions(), options);
 }
 
-std::unique_ptr<PK_Ops::Signature> EC_PrivateKey::create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                                      std::string_view params,
-                                                                      std::string_view provider) const {
-   BOTAN_UNUSED(rng, provider);
-   return std::make_unique<EC_Signature_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Signature> EC_PrivateKey::_create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                                       const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   return std::make_unique<EC_Signature_Operation>(handles(), sessions(), options);
 }
 
 }  // namespace Botan::TPM2

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/tpm2_ecc.h>
 
+#include <botan/pk_options.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>
 #include <botan/internal/tpm2_hash.h>
@@ -161,7 +162,8 @@ std::unique_ptr<TPM2::PrivateKey> EC_PrivateKey::create_unrestricted_transient(c
 
 namespace {
 
-SignatureAlgorithmSelection make_signature_scheme(std::string_view hash_name) {
+SignatureAlgorithmSelection make_signature_scheme(const PK_Signature_Options& options) {
+   const std::string hash_name = options.hash_function_name();
    return {
       .signature_scheme =
          TPMT_SIG_SCHEME{
@@ -185,8 +187,8 @@ size_t signature_length_for_ecdsa_key_handle(const SessionBundle& sessions, cons
 
 class EC_Signature_Operation final : public Signature_Operation {
    public:
-      EC_Signature_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
-            Signature_Operation(object, sessions, make_signature_scheme(hash)) {}
+      EC_Signature_Operation(const Object& object, const SessionBundle& sessions, const PK_Signature_Options& options) :
+            Signature_Operation(object, sessions, make_signature_scheme(options)) {}
 
       size_t signature_length() const override {
          return signature_length_for_ecdsa_key_handle(sessions(), key_handle());
@@ -215,8 +217,10 @@ class EC_Signature_Operation final : public Signature_Operation {
 
 class EC_Verification_Operation final : public Verification_Operation {
    public:
-      EC_Verification_Operation(const Object& object, const SessionBundle& sessions, std::string_view hash) :
-            Verification_Operation(object, sessions, make_signature_scheme(hash)) {}
+      EC_Verification_Operation(const Object& object,
+                                const SessionBundle& sessions,
+                                const PK_Signature_Options& options) :
+            Verification_Operation(object, sessions, make_signature_scheme(options)) {}
 
    private:
       TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> sig_data) const override {
@@ -243,17 +247,20 @@ class EC_Verification_Operation final : public Verification_Operation {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> EC_PublicKey::create_verification_op(std::string_view params,
-                                                                           std::string_view provider) const {
-   BOTAN_UNUSED(provider);
-   return std::make_unique<EC_Verification_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Verification> EC_PublicKey::_create_verification_op(const PK_Signature_Options& options) const {
+   if(options.using_provider() && options.provider().value() != "tpm2") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<EC_Verification_Operation>(handles(), sessions(), options);
 }
 
-std::unique_ptr<PK_Ops::Signature> EC_PrivateKey::create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                                      std::string_view params,
-                                                                      std::string_view provider) const {
-   BOTAN_UNUSED(rng, provider);
-   return std::make_unique<EC_Signature_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Signature> EC_PrivateKey::_create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                                       const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(options.using_provider() && options.provider().value() != "tpm2") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<EC_Signature_Operation>(handles(), sessions(), options);
 }
 
 }  // namespace Botan::TPM2

--- a/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
+++ b/src/lib/prov/tpm2/tpm2_ecc/tpm2_ecc.h
@@ -37,8 +37,7 @@ class BOTAN_PUBLIC_API(3, 6) EC_PublicKey final : public virtual Botan::TPM2::Pu
          return op == PublicKeyOperation::Signature;
       }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
    protected:
       friend class TPM2::PublicKey;
@@ -96,9 +95,8 @@ class BOTAN_PUBLIC_API(3, 6) EC_PrivateKey final : public virtual Botan::TPM2::P
 
       bool supports_operation(PublicKeyOperation op) const override { return op == PublicKeyOperation::Signature; }
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    protected:
       friend class TPM2::PrivateKey;

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -9,6 +9,7 @@
 #include <botan/tpm2_rsa.h>
 
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/pss_params.h>
 #include <botan/rsa.h>
 
@@ -142,22 +143,23 @@ std::unique_ptr<TPM2::PrivateKey> RSA_PrivateKey::create_unrestricted_transient(
 
 namespace {
 
-SignatureAlgorithmSelection select_signature_algorithms(std::string_view padding) {
-   const SCAN_Name req(padding);
-   if(req.arg_count() == 0) {
-      throw Invalid_Argument("RSA signing padding scheme must at least specify a hash function");
-   }
+SignatureAlgorithmSelection select_signature_algorithms(const PK_Signature_Options& options) {
+   const std::string hash_name = options.hash_function_name();
 
-   auto sig_scheme = rsa_signature_scheme_botan_to_tss2(padding);
-   if(!sig_scheme) {
-      throw Not_Implemented(Botan::fmt("RSA signing with padding scheme {}", padding));
-   }
+   if(auto padding = options.padding()) {
+      auto sig_scheme = rsa_signature_scheme_botan_to_tss2(*padding);
+      if(!sig_scheme) {
+         throw Not_Implemented(Botan::fmt("RSA signing with padding scheme {}", *padding));
+      }
 
-   return {
-      .signature_scheme = sig_scheme.value(),
-      .hash_name = req.arg(0),
-      .padding = std::string(padding),
-   };
+      return {
+         .signature_scheme = sig_scheme.value(),
+         .hash_name = hash_name,
+         .padding = std::string(*padding),
+      };
+   } else {
+      throw Not_Implemented("TPM2 RSA signing without padding is not supported");
+   }
 }
 
 size_t signature_length_for_rsa_key_handle(const SessionBundle& sessions, const Object& key_handle) {
@@ -166,8 +168,10 @@ size_t signature_length_for_rsa_key_handle(const SessionBundle& sessions, const 
 
 class RSA_Signature_Operation final : public Signature_Operation {
    public:
-      RSA_Signature_Operation(const Object& object, const SessionBundle& sessions, std::string_view padding) :
-            Signature_Operation(object, sessions, select_signature_algorithms(padding)) {}
+      RSA_Signature_Operation(const Object& object,
+                              const SessionBundle& sessions,
+                              const PK_Signature_Options& options) :
+            Signature_Operation(object, sessions, select_signature_algorithms(options)) {}
 
       size_t signature_length() const override { return signature_length_for_rsa_key_handle(sessions(), key_handle()); }
 
@@ -215,8 +219,10 @@ class RSA_Signature_Operation final : public Signature_Operation {
 
 class RSA_Verification_Operation final : public Verification_Operation {
    public:
-      RSA_Verification_Operation(const Object& object, const SessionBundle& sessions, std::string_view padding) :
-            Verification_Operation(object, sessions, select_signature_algorithms(padding)) {}
+      RSA_Verification_Operation(const Object& object,
+                                 const SessionBundle& sessions,
+                                 const PK_Signature_Options& options) :
+            Verification_Operation(object, sessions, select_signature_algorithms(options)) {}
 
    private:
       TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> signature) const override {
@@ -389,17 +395,15 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   BOTAN_UNUSED(provider);
-   return std::make_unique<RSA_Verification_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   return std::make_unique<RSA_Verification_Operation>(handles(), sessions(), options);
 }
 
-std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   BOTAN_UNUSED(rng, provider);
-   return std::make_unique<RSA_Signature_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::_create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   return std::make_unique<RSA_Signature_Operation>(handles(), sessions(), options);
 }
 
 std::unique_ptr<PK_Ops::Encryption> RSA_PublicKey::create_encryption_op(Botan::RandomNumberGenerator& rng,

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -9,12 +9,12 @@
 #include <botan/tpm2_rsa.h>
 
 #include <botan/hash.h>
+#include <botan/pk_options.h>
 #include <botan/pss_params.h>
 #include <botan/rsa.h>
 
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
-#include <botan/internal/scan_name.h>
 #include <botan/internal/sig_padding.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tpm2_algo_mappings.h>
@@ -142,10 +142,26 @@ std::unique_ptr<TPM2::PrivateKey> RSA_PrivateKey::create_unrestricted_transient(
 
 namespace {
 
-SignatureAlgorithmSelection select_signature_algorithms(std::string_view padding) {
-   const SCAN_Name req(padding);
-   if(req.arg_count() == 0) {
+SignatureAlgorithmSelection select_signature_algorithms(const PK_Signature_Options& options) {
+   if(!options.using_padding()) {
+      throw Not_Implemented("TPM2 RSA signing without padding is not supported");
+   }
+
+   if(!options.using_hash()) {
       throw Invalid_Argument("RSA signing padding scheme must at least specify a hash function");
+   }
+
+   // The TPM chooses the PSS salt length itself, and PKCS#1 v1.5 has no salt
+   if(options.using_salt_size()) {
+      throw Not_Implemented("TPM2 RSA signing does not support specifying the salt size");
+   }
+
+   const std::string hash_name = options.hash_function_name();
+   const std::string padding = fmt("{}({})", options.padding().value(), hash_name);
+
+   // PKCS#1 v1.5 is deterministic, while the TPM generates the PSS salt itself
+   if(options.using_deterministic_signature() && options.padding().value() != "PKCS1v15") {
+      throw Invalid_Argument(fmt("TPM2 RSA signing with {} cannot produce deterministic signatures", padding));
    }
 
    auto sig_scheme = rsa_signature_scheme_botan_to_tss2(padding);
@@ -155,8 +171,8 @@ SignatureAlgorithmSelection select_signature_algorithms(std::string_view padding
 
    return {
       .signature_scheme = sig_scheme.value(),
-      .hash_name = req.arg(0),
-      .padding = std::string(padding),
+      .hash_name = hash_name,
+      .padding = padding,
    };
 }
 
@@ -166,8 +182,10 @@ size_t signature_length_for_rsa_key_handle(const SessionBundle& sessions, const 
 
 class RSA_Signature_Operation final : public Signature_Operation {
    public:
-      RSA_Signature_Operation(const Object& object, const SessionBundle& sessions, std::string_view padding) :
-            Signature_Operation(object, sessions, select_signature_algorithms(padding)) {}
+      RSA_Signature_Operation(const Object& object,
+                              const SessionBundle& sessions,
+                              const PK_Signature_Options& options) :
+            Signature_Operation(object, sessions, select_signature_algorithms(options)), m_options(options) {}
 
       size_t signature_length() const override { return signature_length_for_rsa_key_handle(sessions(), key_handle()); }
 
@@ -180,8 +198,7 @@ class RSA_Signature_Operation final : public Signature_Operation {
          // conveniently figure out the algorithm identifier.
          //
          // TODO: This is a hack, and we should clean this up.
-         BOTAN_STATE_CHECK(padding().has_value());
-         const std::string padding_name = SignaturePaddingScheme::create_or_throw(padding().value())->name();
+         const std::string padding_name = SignaturePaddingScheme::create_or_throw(m_options)->name();
 
          try {
             const std::string full_name = "RSA/" + padding_name;
@@ -211,12 +228,16 @@ class RSA_Signature_Operation final : public Signature_Operation {
          BOTAN_ASSERT_NOMSG(sig.sig.size == signature_length());
          return copy_into<std::vector<uint8_t>>(sig.sig);
       }
+
+      PK_Signature_Options m_options;
 };
 
 class RSA_Verification_Operation final : public Verification_Operation {
    public:
-      RSA_Verification_Operation(const Object& object, const SessionBundle& sessions, std::string_view padding) :
-            Verification_Operation(object, sessions, select_signature_algorithms(padding)) {}
+      RSA_Verification_Operation(const Object& object,
+                                 const SessionBundle& sessions,
+                                 const PK_Signature_Options& options) :
+            Verification_Operation(object, sessions, select_signature_algorithms(options)) {}
 
    private:
       TPMT_SIGNATURE unmarshal_signature(std::span<const uint8_t> signature) const override {
@@ -397,17 +418,21 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   BOTAN_UNUSED(provider);
-   return std::make_unique<RSA_Verification_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(options.using_provider() && options.provider().value() != "tpm2") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<RSA_Verification_Operation>(handles(), sessions(), options);
 }
 
-std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   BOTAN_UNUSED(rng, provider);
-   return std::make_unique<RSA_Signature_Operation>(handles(), sessions(), params);
+std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::_create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(options.using_provider() && options.provider().value() != "tpm2") {
+      throw Provider_Not_Found(algo_name(), options.provider().value());
+   }
+   return std::make_unique<RSA_Signature_Operation>(handles(), sessions(), options);
 }
 
 std::unique_ptr<PK_Ops::Encryption> RSA_PublicKey::create_encryption_op(Botan::RandomNumberGenerator& rng,

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.h
@@ -8,6 +8,7 @@
 #ifndef BOTAN_TPM2_RSA_H_
 #define BOTAN_TPM2_RSA_H_
 
+#include "botan/pk_keys.h"
 #include <botan/rsa.h>
 #include <botan/tpm2_key.h>
 
@@ -30,8 +31,7 @@ class BOTAN_PUBLIC_API(3, 6) RSA_PublicKey final : public virtual Botan::TPM2::P
          return op == PublicKeyOperation::Encryption || op == PublicKeyOperation::Signature;
       }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Encryption> create_encryption_op(Botan::RandomNumberGenerator& rng,
                                                                std::string_view params,
@@ -95,9 +95,8 @@ class BOTAN_PUBLIC_API(3, 6) RSA_PrivateKey final : public virtual Botan::TPM2::
          return op == PublicKeyOperation::Encryption || op == PublicKeyOperation::Signature;
       }
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(Botan::RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(Botan::RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Decryption> create_decryption_op(Botan::RandomNumberGenerator& rng,
                                                                std::string_view params,

--- a/src/lib/pubkey/curve448/ed448/ed448.cpp
+++ b/src/lib/pubkey/curve448/ed448/ed448.cpp
@@ -15,6 +15,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ed448_internal.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 #include <utility>
 
@@ -213,18 +214,22 @@ AlgorithmIdentifier Ed448_Sign_Operation::algorithm_identifier() const {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_verification_op(std::string_view params,
-                                                                              std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Verify_Operation>(*this);
-      } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Verify_Operation>(*this, "SHAKE-256(512)");
+std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   BOTAN_ARG_CHECK(!options.using_padding(), "Ed448 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_hash(), "Ed448 does not support specifying a hash function");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "Ed448 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "Ed448 does not support a padding trailer field");
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         return std::make_unique<Ed448_Verify_Operation>(*this, options.prehash_function().value_or("SHAKE-256(512)"));
       } else {
-         return std::make_unique<Ed448_Verify_Operation>(*this, std::string(params));
+         return std::make_unique<Ed448_Verify_Operation>(*this);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
@@ -239,19 +244,23 @@ std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_x509_verification_
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> Ed448_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                         std::string_view params,
-                                                                         std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Sign_Operation>(*this);
-      } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Sign_Operation>(*this, "SHAKE-256(512)");
+std::unique_ptr<PK_Ops::Signature> Ed448_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                          const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   BOTAN_ARG_CHECK(!options.using_padding(), "Ed448 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_hash(), "Ed448 does not support specifying a hash function");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "Ed448 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "Ed448 does not support a padding trailer field");
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         return std::make_unique<Ed448_Sign_Operation>(*this, options.prehash_function().value_or("SHAKE-256(512)"));
       } else {
-         return std::make_unique<Ed448_Sign_Operation>(*this, std::string(params));
+         return std::make_unique<Ed448_Sign_Operation>(*this);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/curve448/ed448/ed448.cpp
+++ b/src/lib/pubkey/curve448/ed448/ed448.cpp
@@ -15,6 +15,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ed448_internal.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 #include <utility>
 
@@ -266,18 +267,18 @@ AlgorithmIdentifier Ed448_Sign_Operation::algorithm_identifier() const {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_verification_op(std::string_view params,
-                                                                              std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Verify_Operation>(m_public);
-      } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Verify_Operation>(m_public, "SHAKE-256(512)");
+std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         return std::make_unique<Ed448_Verify_Operation>(m_public,
+                                                         options.prehash_function().value_or("SHAKE-256(512)"));
       } else {
-         return std::make_unique<Ed448_Verify_Operation>(m_public, std::string(params));
+         return std::make_unique<Ed448_Verify_Operation>(m_public);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
@@ -292,19 +293,21 @@ std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_x509_verification_
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> Ed448_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                         std::string_view params,
-                                                                         std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private);
-      } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private, "SHAKE-256(512)");
+std::unique_ptr<PK_Ops::Signature> Ed448_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                          const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   acknowledge_always_deterministic(options);
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         return std::make_unique<Ed448_Sign_Operation>(
+            m_public, m_private, options.prehash_function().value_or("SHAKE-256(512)"));
       } else {
-         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private, std::string(params));
+         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/curve448/ed448/ed448.h
+++ b/src/lib/pubkey/curve448/ed448/ed448.h
@@ -20,7 +20,7 @@ namespace Botan {
  *
  * By default, Ed448 without prehash is used (recommended). To use
  * Ed448ph, "Ed448ph" or a custom hash function identifier is passed
- * as a parameter to the create_verification_op method.
+ * as a parameter to the _create_verification_op method.
  *
  * Note that contexts (i.e. Ed448ctx) are not supported by this interface.
  */
@@ -56,8 +56,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PublicKey : public virtual Public_Key {
       */
       BOTAN_FUTURE_EXPLICIT Ed448_PublicKey(std::span<const uint8_t> key_bits);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -75,7 +74,7 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
  *
  * By default, Ed448 without prehash is used (recommended). To use
  * Ed448ph, "Ed448ph" or a custom hash function identifier is passed
- * as a parameter to the create_verification_op method.
+ * as a parameter to the _create_verification_op method.
  *
  * Note that contexts (i.e. Ed448ctx) are not supported by this interface.
  */
@@ -112,9 +111,8 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PrivateKey final : public Ed448_PublicKey,
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       secure_vector<uint8_t> m_private;

--- a/src/lib/pubkey/curve448/ed448/ed448.h
+++ b/src/lib/pubkey/curve448/ed448/ed448.h
@@ -24,7 +24,7 @@ class Ed448_PrivateKey_Data;
  *
  * By default, Ed448 without prehash is used (recommended). To use
  * Ed448ph, "Ed448ph" or a custom hash function identifier is passed
- * as a parameter to the create_verification_op method.
+ * as a parameter to the _create_verification_op method.
  *
  * Note that contexts (i.e. Ed448ctx) are not supported by this interface.
  */
@@ -60,8 +60,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PublicKey : public virtual Public_Key {
       */
       BOTAN_FUTURE_EXPLICIT Ed448_PublicKey(std::span<const uint8_t> key_bits);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -79,7 +78,7 @@ BOTAN_DIAGNOSTIC_IGNORE_INHERITED_VIA_DOMINANCE
  *
  * By default, Ed448 without prehash is used (recommended). To use
  * Ed448ph, "Ed448ph" or a custom hash function identifier is passed
- * as a parameter to the create_verification_op method.
+ * as a parameter to the _create_verification_op method.
  *
  * Note that contexts (i.e. Ed448ctx) are not supported by this interface.
  */
@@ -116,9 +115,8 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PrivateKey final : public Ed448_PublicKey,
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       std::shared_ptr<const Ed448_PrivateKey_Data> m_private;

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -126,16 +126,46 @@ bool DilithiumMode::is_available() const {
    return false;
 }
 
+namespace {
+
+// Return true if randomized signatures were requested
+void validate_dilithium_options(const PK_Signature_Options& options) {
+   BOTAN_ARG_CHECK(!options.using_hash(), "Dilithium does not allow specifying the hash function");
+   BOTAN_ARG_CHECK(!options.using_padding(), "Dilithium does not support padding");
+
+   if(options.using_salt_size()) {
+      BOTAN_ARG_CHECK(!options.using_deterministic_signature(),
+                      "Dilithium cannot support a salt while also being deterministic");
+      BOTAN_ARG_CHECK(options.salt_size().value() == 32, "Dilithium can only be used with a 32 byte salt");
+   }
+
+   // This is available in ML-DSA and might be supported in the future
+   BOTAN_ARG_CHECK(!options.using_prehash(), "Dilithium does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "Dilithium does not support a padding trailer field");
+}
+
+}  // namespace
+
+// The signature and verification operations should be in an anonymous namespace
+// as well, but cannot due to an apparent bug in MSVC
+
 class Dilithium_Signature_Operation final : public PK_Ops::Signature {
    public:
-      Dilithium_Signature_Operation(DilithiumInternalKeypair keypair, bool randomized) :
+      Dilithium_Signature_Operation(DilithiumInternalKeypair keypair, const PK_Signature_Options& options) :
             m_keypair(std::move(keypair)),
-            m_randomized(randomized),
+
+            // FIPS 204, Section 3.4
+            //   By default, this standard specifies the signing algorithm to use both
+            //   types of randomness [fresh from the RNG and a value in the private key].
+            //   This is referred to as the “hedged” variant of the signing procedure.
+            m_randomized(!options.using_deterministic_signature()),
             m_h(m_keypair.second->mode().symmetric_primitives().get_message_hash(m_keypair.first->tr())),
             m_s1(ntt(m_keypair.second->s1().clone())),
             m_s2(ntt(m_keypair.second->s2().clone())),
             m_t0(ntt(m_keypair.second->t0().clone())),
-            m_A(Dilithium_Algos::expand_A(m_keypair.first->rho(), m_keypair.second->mode())) {}
+            m_A(Dilithium_Algos::expand_A(m_keypair.first->rho(), m_keypair.second->mode())) {
+         validate_dilithium_options(options);
+      }
 
       void update(std::span<const uint8_t> input) override { m_h->update(input); }
 
@@ -373,13 +403,14 @@ std::unique_ptr<Private_Key> Dilithium_PublicKey::generate_another(RandomNumberG
    return std::make_unique<Dilithium_PrivateKey>(rng, m_public->mode().mode());
 }
 
-std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::create_verification_op(std::string_view params,
-                                                                                  std::string_view provider) const {
-   BOTAN_ARG_CHECK(params.empty() || params == "Pure", "Unexpected parameters for verifying with Dilithium");
-   if(provider.empty() || provider == "base") {
+std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_dilithium_options(options);
+
+   if(!options.using_provider()) {
       return std::make_unique<Dilithium_Verification_Operation>(m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::create_x509_verification_op(
@@ -427,23 +458,14 @@ secure_vector<uint8_t> Dilithium_PrivateKey::private_key_bits() const {
    return m_private->mode().keypair_codec().encode_keypair({m_public, m_private});
 }
 
-std::unique_ptr<PK_Ops::Signature> Dilithium_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                             std::string_view params,
-                                                                             std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> Dilithium_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
 
-   BOTAN_ARG_CHECK(params.empty() || params == "Deterministic" || params == "Randomized",
-                   "Unexpected parameters for signing with ML-DSA/Dilithium");
-
-   // FIPS 204, Section 3.4
-   //   By default, this standard specifies the signing algorithm to use both
-   //   types of randomness [fresh from the RNG and a value in the private key].
-   //   This is referred to as the “hedged” variant of the signing procedure.
-   const bool randomized = (params.empty() || params == "Randomized");
-   if(provider.empty() || provider == "base") {
-      return std::make_unique<Dilithium_Signature_Operation>(DilithiumInternalKeypair{m_public, m_private}, randomized);
+   if(!options.using_provider()) {
+      return std::make_unique<Dilithium_Signature_Operation>(DilithiumInternalKeypair{m_public, m_private}, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<Public_Key> Dilithium_PrivateKey::public_key() const {

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -135,16 +135,50 @@ bool DilithiumMode::is_available() const {
    return false;
 }
 
+namespace {
+
+void validate_dilithium_options(const PK_Signature_Options& options, const DilithiumMode& mode) {
+   /*
+   * The "salt" is the randomness drawn during hedged signing. Its size is fixed
+   * by the scheme, so the option is accepted only if it names that size:
+   * ML-DSA hashes a 32 byte rnd (FIPS 204, Algorithm 2), while randomized
+   * Dilithium round 3 samples the entire 64 byte rho' (Figure 4, line 12).
+   */
+   if(options.using_salt_size()) {
+      BOTAN_ARG_CHECK(!options.using_deterministic_signature(),
+                      "Dilithium cannot support a salt while also being deterministic");
+
+      const size_t randomness_bytes =
+         mode.is_ml_dsa() ? DilithiumConstants::OPTIONAL_RANDOMNESS_BYTES : DilithiumConstants::SEED_RHOPRIME_BYTES;
+
+      if(options.salt_size().value() != randomness_bytes) {
+         throw Invalid_Argument(fmt("{} can only be used with a {} byte salt", mode.to_string(), randomness_bytes));
+      }
+   }
+}
+
+}  // namespace
+
+// The signature and verification operations should be in an anonymous namespace
+// as well, but cannot due to an apparent bug in MSVC
+
 class Dilithium_Signature_Operation final : public PK_Ops::Signature {
    public:
-      Dilithium_Signature_Operation(DilithiumInternalKeypair keypair, bool randomized) :
+      Dilithium_Signature_Operation(DilithiumInternalKeypair keypair, const PK_Signature_Options& options) :
             m_keypair(std::move(keypair)),
-            m_randomized(randomized),
+
+            // FIPS 204, Section 3.4
+            //   By default, this standard specifies the signing algorithm to use both
+            //   types of randomness [fresh from the RNG and a value in the private key].
+            //   This is referred to as the “hedged” variant of the signing procedure.
+            m_randomized(!options.using_deterministic_signature()),
             m_h(m_keypair.second->mode().symmetric_primitives().get_message_hash(m_keypair.first->tr())),
             m_s1(ntt(m_keypair.second->s1().clone())),
             m_s2(ntt(m_keypair.second->s2().clone())),
             m_t0(ntt(m_keypair.second->t0().clone())),
-            m_A(Dilithium_Algos::expand_A(m_keypair.first->rho(), m_keypair.second->mode())) {}
+            m_A(Dilithium_Algos::expand_A(m_keypair.first->rho(), m_keypair.second->mode())) {
+         validate_dilithium_options(options, m_keypair.second->mode().mode());
+      }
 
       void update(std::span<const uint8_t> input) override { m_h->update(input); }
 
@@ -393,13 +427,14 @@ std::unique_ptr<Private_Key> Dilithium_PublicKey::generate_another(RandomNumberG
    return std::make_unique<Dilithium_PrivateKey>(rng, m_public->mode().mode());
 }
 
-std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::create_verification_op(std::string_view params,
-                                                                                  std::string_view provider) const {
-   BOTAN_ARG_CHECK(params.empty() || params == "Pure", "Unexpected parameters for verifying with Dilithium");
-   if(provider.empty() || provider == "base") {
+std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_dilithium_options(options, m_public->mode().mode());
+
+   if(!options.using_provider()) {
       return std::make_unique<Dilithium_Verification_Operation>(m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Dilithium_PublicKey::create_x509_verification_op(
@@ -452,23 +487,14 @@ secure_vector<uint8_t> Dilithium_PrivateKey::private_key_bits() const {
    return m_private->mode().keypair_codec().encode_keypair({m_public, m_private});
 }
 
-std::unique_ptr<PK_Ops::Signature> Dilithium_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                             std::string_view params,
-                                                                             std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> Dilithium_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
 
-   BOTAN_ARG_CHECK(params.empty() || params == "Deterministic" || params == "Randomized",
-                   "Unexpected parameters for signing with ML-DSA/Dilithium");
-
-   // FIPS 204, Section 3.4
-   //   By default, this standard specifies the signing algorithm to use both
-   //   types of randomness [fresh from the RNG and a value in the private key].
-   //   This is referred to as the “hedged” variant of the signing procedure.
-   const bool randomized = (params.empty() || params == "Randomized");
-   if(provider.empty() || provider == "base") {
-      return std::make_unique<Dilithium_Signature_Operation>(DilithiumInternalKeypair{m_public, m_private}, randomized);
+   if(!options.using_provider()) {
+      return std::make_unique<Dilithium_Signature_Operation>(DilithiumInternalKeypair{m_public, m_private}, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 bool Dilithium_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -91,8 +91,7 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key {
 
       Dilithium_PublicKey(std::span<const uint8_t> pk, DilithiumMode mode);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -133,14 +132,8 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PrivateKey final : public virtual Dilithi
 
       secure_vector<uint8_t> raw_private_key_bits() const override;
 
-      /**
-       * Create a signature operation that produces a Dilithium signature either
-       * with "Randomized" or "Deterministic" rhoprime. Pass either of those
-       * strings as @p params. Default (i.e. empty @p params is "Randomized").
-       */
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       friend class Dilithium_Signature_Operation;

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -91,8 +91,7 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key {
 
       Dilithium_PublicKey(std::span<const uint8_t> pk, DilithiumMode mode);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -135,14 +134,8 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PrivateKey final : public virtual Dilithi
 
       secure_vector<uint8_t> raw_private_key_bits() const override;
 
-      /**
-       * Create a signature operation that produces a Dilithium signature either
-       * with "Randomized" or "Deterministic" rhoprime. Pass either of those
-       * strings as @p params. Default (i.e. empty @p params is "Randomized").
-       */
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       friend class Dilithium_Signature_Operation;

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -127,9 +127,12 @@ namespace {
 class DSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
       DSA_Signature_Operation(const std::shared_ptr<const DL_PrivateKey>& key,
-                              std::string_view hash_fn,
+                              const PK_Signature_Options& options,
                               RandomNumberGenerator& rng) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_key(key) {
+            PK_Ops::Signature_with_Hash(options), m_key(key), m_deterministic(options.using_deterministic_signature()) {
+#if !defined(BOTAN_HAS_RFC6979_GENERATOR)
+         BOTAN_ARG_CHECK(!m_deterministic, "Deterministic DSA signatures require RFC 6979 support");
+#endif
          m_b = BigInt::random_integer(rng, BigInt::from_s32(2), m_key->group().get_q());
          m_b_inv = m_key->group().inverse_mod_q(m_b);
       }
@@ -142,6 +145,7 @@ class DSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
 
    private:
       std::shared_ptr<const DL_PrivateKey> m_key;
+      bool m_deterministic;
       BigInt m_b, m_b_inv;
 };
 
@@ -162,8 +166,8 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
    }
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-   BOTAN_UNUSED(rng);
-   const BigInt k = generate_rfc6979_nonce(m_key->private_key(), q, m, this->rfc6979_hash_function());
+   const BigInt k = m_deterministic ? generate_rfc6979_nonce(m_key->private_key(), q, m, this->rfc6979_hash_function())
+                                    : BigInt::random_integer(rng, 1, q);
 #else
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif
@@ -210,8 +214,8 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
 */
 class DSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, std::string_view hash_fn) :
-            PK_Ops::Verification_with_Hash(hash_fn), m_key(key) {}
+      DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_key(key) {}
 
       DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "DSA"), m_key(key) {}
@@ -257,12 +261,12 @@ bool DSA_Verification_Operation::verify(std::span<const uint8_t> input, std::spa
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<DSA_Verification_Operation>(this->m_public_key, params);
+std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<DSA_Verification_Operation>(this->m_public_key, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_x509_verification_op(
@@ -274,13 +278,12 @@ std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_x509_verification_op
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> DSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<DSA_Signature_Operation>(this->m_private_key, params, rng);
+std::unique_ptr<PK_Ops::Signature> DSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<DSA_Signature_Operation>(this->m_private_key, options, rng);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/dsa/dsa.cpp
+++ b/src/lib/pubkey/dsa/dsa.cpp
@@ -137,9 +137,14 @@ namespace {
 class DSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
       DSA_Signature_Operation(const std::shared_ptr<const DL_PrivateKey>& key,
-                              std::string_view hash_fn,
+                              const PK_Signature_Options& options,
                               RandomNumberGenerator& rng) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_key(key) {
+            PK_Ops::Signature_with_Hash(options), m_key(key), m_deterministic(options.using_deterministic_signature()) {
+#if !defined(BOTAN_HAS_RFC6979_GENERATOR)
+         if(m_deterministic) {
+            throw Not_Implemented("Deterministic DSA signatures require RFC 6979 support");
+         }
+#endif
          m_b = BigInt::random_integer(rng, BigInt::from_s32(2), m_key->group().get_q());
          m_b_inv = m_key->group().inverse_mod_q(m_b);
       }
@@ -152,6 +157,7 @@ class DSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
 
    private:
       std::shared_ptr<const DL_PrivateKey> m_key;
+      bool m_deterministic;
       BigInt m_b, m_b_inv;
 };
 
@@ -172,8 +178,8 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
    }
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-   BOTAN_UNUSED(rng);
-   const BigInt k = generate_rfc6979_nonce(m_key->private_key(), q, m, this->rfc6979_hash_function());
+   const BigInt k = m_deterministic ? generate_rfc6979_nonce(m_key->private_key(), q, m, this->rfc6979_hash_function())
+                                    : BigInt::random_integer(rng, 1, q);
 #else
    const BigInt k = BigInt::random_integer(rng, 1, q);
 #endif
@@ -220,8 +226,8 @@ std::vector<uint8_t> DSA_Signature_Operation::raw_sign(std::span<const uint8_t> 
 */
 class DSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, std::string_view hash_fn) :
-            PK_Ops::Verification_with_Hash(hash_fn), m_key(key) {}
+      DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_key(key) {}
 
       DSA_Verification_Operation(const std::shared_ptr<const DL_PublicKey>& key, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "DSA"), m_key(key) {}
@@ -272,12 +278,12 @@ bool DSA_Verification_Operation::verify(std::span<const uint8_t> input, std::spa
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<DSA_Verification_Operation>(this->m_public_key, params);
+std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<DSA_Verification_Operation>(this->m_public_key, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_x509_verification_op(
@@ -289,13 +295,12 @@ std::unique_ptr<PK_Ops::Verification> DSA_PublicKey::create_x509_verification_op
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> DSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<DSA_Signature_Operation>(this->m_private_key, params, rng);
+std::unique_ptr<PK_Ops::Signature> DSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<DSA_Signature_Operation>(this->m_private_key, options, rng);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/dsa/dsa.h
+++ b/src/lib/pubkey/dsa/dsa.h
@@ -59,8 +59,7 @@ class BOTAN_PUBLIC_API(2, 0) DSA_PublicKey : public virtual Public_Key {
 
       const BigInt& get_int_field(std::string_view field) const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -115,9 +114,8 @@ class BOTAN_PUBLIC_API(2, 0) DSA_PrivateKey final : public DSA_PublicKey,
       const BigInt& get_int_field(std::string_view field) const override;
       secure_vector<uint8_t> raw_private_key_bits() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       std::shared_ptr<const DL_PrivateKey> m_private_key;

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/ecdsa.h>
 
+#include <botan/assert.h>
 #include <botan/ec_group.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -126,14 +127,21 @@ namespace {
 */
 class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      ECDSA_Signature_Operation(const ECDSA_PrivateKey& ecdsa, std::string_view padding, RandomNumberGenerator& rng) :
-            PK_Ops::Signature_with_Hash(padding),
+      ECDSA_Signature_Operation(const ECDSA_PrivateKey& ecdsa,
+                                const PK_Signature_Options& options,
+                                RandomNumberGenerator& rng) :
+            PK_Ops::Signature_with_Hash(options),
             m_group(ecdsa.domain()),
             m_x(ecdsa._private_key()),
             m_b(EC_Scalar::random(m_group, rng)) {
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-         m_rfc6979 = std::make_unique<RFC6979_Nonce_Generator>(
-            this->rfc6979_hash_function(), m_group.get_order_bits(), ecdsa._private_key());
+         if(options.using_deterministic_signature()) {
+            m_rfc6979 = std::make_unique<RFC6979_Nonce_Generator>(
+               this->rfc6979_hash_function(), m_group.get_order_bits(), ecdsa._private_key());
+         }
+#else
+         BOTAN_ARG_CHECK(!options.using_deterministic_signature(),
+                         "Deterministic ECDSA signatures require RFC 6979 support");
 #endif
       }
 
@@ -164,7 +172,7 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
    const auto m = EC_Scalar::from_bytes_with_trunc(m_group, msg);
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-   const auto k = m_rfc6979->nonce_for(m_group, m);
+   const auto k = m_rfc6979 ? m_rfc6979->nonce_for(m_group, m) : EC_Scalar::random(m_group, rng);
 #else
    const auto k = EC_Scalar::random(m_group, rng);
 #endif
@@ -212,8 +220,8 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
 */
 class ECDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_ec_point()) {}
+      ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_ec_point()) {}
 
       ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "ECDSA", true),
@@ -246,13 +254,12 @@ bool ECDSA_Verification_Operation::verify(std::span<const uint8_t> msg, std::spa
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                              std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECDSA_Verification_Operation>(*this, options);
    }
-
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_x509_verification_op(
@@ -264,14 +271,13 @@ std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_x509_verification_
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECDSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                         std::string_view params,
-                                                                         std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECDSA_Signature_Operation>(*this, params, rng);
+std::unique_ptr<PK_Ops::Signature> ECDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                          const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECDSA_Signature_Operation>(*this, options, rng);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/ecdsa.h>
 
+#include <botan/assert.h>
 #include <botan/ec_group.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -126,14 +127,22 @@ namespace {
 */
 class ECDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      ECDSA_Signature_Operation(const ECDSA_PrivateKey& ecdsa, std::string_view padding, RandomNumberGenerator& rng) :
-            PK_Ops::Signature_with_Hash(padding),
+      ECDSA_Signature_Operation(const ECDSA_PrivateKey& ecdsa,
+                                const PK_Signature_Options& options,
+                                RandomNumberGenerator& rng) :
+            PK_Ops::Signature_with_Hash(options),
             m_group(ecdsa.domain()),
             m_x(ecdsa._private_key()),
             m_b(EC_Scalar::random(m_group, rng)) {
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-         m_rfc6979 = std::make_unique<RFC6979_Nonce_Generator>(
-            this->rfc6979_hash_function(), m_group.get_order_bits(), ecdsa._private_key());
+         if(options.using_deterministic_signature()) {
+            m_rfc6979 = std::make_unique<RFC6979_Nonce_Generator>(
+               this->rfc6979_hash_function(), m_group.get_order_bits(), ecdsa._private_key());
+         }
+#else
+         if(options.using_deterministic_signature()) {
+            throw Not_Implemented("Deterministic ECDSA signatures require RFC 6979 support");
+         }
 #endif
       }
 
@@ -164,7 +173,7 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
    const auto m = EC_Scalar::from_bytes_with_trunc(m_group, msg);
 
 #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-   const auto k = m_rfc6979->nonce_for(m_group, m);
+   const auto k = m_rfc6979 ? m_rfc6979->nonce_for(m_group, m) : EC_Scalar::random(m_group, rng);
 #else
    const auto k = EC_Scalar::random(m_group, rng);
 #endif
@@ -214,8 +223,8 @@ std::vector<uint8_t> ECDSA_Signature_Operation::raw_sign(std::span<const uint8_t
 */
 class ECDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_ec_point()) {}
+      ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_ec_point()) {}
 
       ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const AlgorithmIdentifier& alg_id) :
             /*
@@ -260,13 +269,12 @@ bool ECDSA_Verification_Operation::verify(std::span<const uint8_t> msg, std::spa
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                              std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECDSA_Verification_Operation>(*this, options);
    }
-
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_x509_verification_op(
@@ -278,14 +286,13 @@ std::unique_ptr<PK_Ops::Verification> ECDSA_PublicKey::create_x509_verification_
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECDSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                         std::string_view params,
-                                                                         std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECDSA_Signature_Operation>(*this, params, rng);
+std::unique_ptr<PK_Ops::Signature> ECDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                          const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECDSA_Signature_Operation>(*this, options, rng);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -69,8 +69,7 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PublicKey : public virtual EC_PublicKey {
 
       uint8_t recovery_param(const std::vector<uint8_t>& msg, const BigInt& r, const BigInt& s) const;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -125,9 +124,8 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
 
       std::unique_ptr<Public_Key> public_key() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/ecgdsa.h>
 
+#include <botan/assert.h>
 #include <botan/ec_group.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -37,8 +38,10 @@ namespace {
 */
 class ECGDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      ECGDSA_Signature_Operation(const ECGDSA_PrivateKey& ecgdsa, std::string_view hash_fn) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_group(ecgdsa.domain()), m_x(ecgdsa._private_key()) {}
+      ECGDSA_Signature_Operation(const ECGDSA_PrivateKey& ecgdsa, const PK_Signature_Options& options) :
+            PK_Ops::Signature_with_Hash(options), m_group(ecgdsa.domain()), m_x(ecgdsa._private_key()) {
+         BOTAN_ARG_CHECK(!options.using_deterministic_signature(), "ECGDSA does not support deterministic signatures");
+      }
 
       std::vector<uint8_t> raw_sign(std::span<const uint8_t> msg, RandomNumberGenerator& rng) override;
 
@@ -79,8 +82,8 @@ std::vector<uint8_t> ECGDSA_Signature_Operation::raw_sign(std::span<const uint8_
 */
 class ECGDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(ecgdsa.domain()), m_gy_mul(ecgdsa._public_ec_point()) {}
+      ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(ecgdsa.domain()), m_gy_mul(ecgdsa._public_ec_point()) {}
 
       ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "ECGDSA"),
@@ -121,12 +124,12 @@ std::unique_ptr<Private_Key> ECGDSA_PublicKey::generate_another(RandomNumberGene
    return std::make_unique<ECGDSA_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                               std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECGDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECGDSA_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_x509_verification_op(
@@ -138,13 +141,13 @@ std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_x509_verification
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECGDSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                          std::string_view params,
-                                                                          std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECGDSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> ECGDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                           const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(!options.using_provider()) {
+      return std::make_unique<ECGDSA_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/ecgdsa/ecgdsa.cpp
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/ecgdsa.h>
 
+#include <botan/assert.h>
 #include <botan/ec_group.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -37,8 +38,8 @@ namespace {
 */
 class ECGDSA_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      ECGDSA_Signature_Operation(const ECGDSA_PrivateKey& ecgdsa, std::string_view hash_fn) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_group(ecgdsa.domain()), m_x(ecgdsa._private_key()) {}
+      ECGDSA_Signature_Operation(const ECGDSA_PrivateKey& ecgdsa, const PK_Signature_Options& options) :
+            PK_Ops::Signature_with_Hash(options), m_group(ecgdsa.domain()), m_x(ecgdsa._private_key()) {}
 
       std::vector<uint8_t> raw_sign(std::span<const uint8_t> msg, RandomNumberGenerator& rng) override;
 
@@ -79,8 +80,8 @@ std::vector<uint8_t> ECGDSA_Signature_Operation::raw_sign(std::span<const uint8_
 */
 class ECGDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(ecgdsa.domain()), m_gy_mul(ecgdsa._public_ec_point()) {}
+      ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(ecgdsa.domain()), m_gy_mul(ecgdsa._public_ec_point()) {}
 
       ECGDSA_Verification_Operation(const ECGDSA_PublicKey& ecgdsa, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(alg_id, "ECGDSA"),
@@ -121,12 +122,12 @@ std::unique_ptr<Private_Key> ECGDSA_PublicKey::generate_another(RandomNumberGene
    return std::make_unique<ECGDSA_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                               std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECGDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECGDSA_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_x509_verification_op(
@@ -138,13 +139,13 @@ std::unique_ptr<PK_Ops::Verification> ECGDSA_PublicKey::create_x509_verification
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECGDSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                          std::string_view params,
-                                                                          std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECGDSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> ECGDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                           const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+   if(!options.using_provider()) {
+      return std::make_unique<ECGDSA_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -53,8 +53,7 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PublicKey : public virtual EC_PublicKey {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -109,9 +108,8 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -40,23 +40,18 @@ bool ECKCDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) cons
 
 namespace {
 
-std::unique_ptr<HashFunction> eckcdsa_signature_hash(std::string_view padding) {
-   if(auto hash = HashFunction::create(padding)) {
-      return hash;
-   }
+std::unique_ptr<HashFunction> eckcdsa_signature_hash(const PK_Signature_Options& options) {
+   BOTAN_ARG_CHECK(!options.using_padding(), "ECKCDSA does not support padding modes");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "ECKCDSA does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "ECKCDSA does not support a padding trailer field");
 
-   const SCAN_Name req(padding);
+   // We could support this, but it's not standard
+   BOTAN_ARG_CHECK(!options.using_prehash(), "ECKCDSA does not support prehashing");
 
-   if(req.algo_name() == "EMSA1" && req.arg_count() == 1) {
-      if(auto hash = HashFunction::create(req.arg(0))) {
-         return hash;
-      }
-   }
-
-   // intentionally not supporting Raw for ECKCDSA, we need to know
+   // intentionally not supporting Raw for ECKCDSA, since we need to know
    // the length in advance which complicates the logic for Raw
 
-   throw Algorithm_Not_Found(padding);
+   return HashFunction::create_or_throw(options.hash_function_name());
 }
 
 std::unique_ptr<HashFunction> eckcdsa_signature_hash(const AlgorithmIdentifier& alg_id) {
@@ -117,12 +112,14 @@ void truncate_hash_if_needed(std::vector<uint8_t>& digest, size_t group_order_by
 */
 class ECKCDSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      ECKCDSA_Signature_Operation(const ECKCDSA_PrivateKey& eckcdsa, std::string_view padding) :
+      ECKCDSA_Signature_Operation(const ECKCDSA_PrivateKey& eckcdsa, const PK_Signature_Options& options) :
             m_group(eckcdsa.domain()),
             m_x(eckcdsa._private_key()),
-            m_hash(eckcdsa_signature_hash(padding)),
+            m_hash(eckcdsa_signature_hash(options)),
             m_prefix(eckcdsa_prefix(eckcdsa._public_ec_point(), m_hash->hash_block_size())),
-            m_prefix_used(false) {}
+            m_prefix_used(false) {
+         BOTAN_ARG_CHECK(!options.using_deterministic_signature(), "ECKCDSA does not support deterministic signatures");
+      }
 
       void update(std::span<const uint8_t> input) override {
          if(!m_prefix_used) {
@@ -188,10 +185,10 @@ std::vector<uint8_t> ECKCDSA_Signature_Operation::raw_sign(std::span<const uint8
 */
 class ECKCDSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, std::string_view padding) :
+      ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, const PK_Signature_Options& options) :
             m_group(eckcdsa.domain()),
             m_gy_mul(eckcdsa._public_ec_point()),
-            m_hash(eckcdsa_signature_hash(padding)),
+            m_hash(eckcdsa_signature_hash(options)),
             m_prefix(eckcdsa_prefix(eckcdsa._public_ec_point(), m_hash->hash_block_size())),
             m_prefix_used(false) {}
 
@@ -269,12 +266,12 @@ std::unique_ptr<Private_Key> ECKCDSA_PublicKey::generate_another(RandomNumberGen
    return std::make_unique<ECKCDSA_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                                std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECKCDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECKCDSA_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_x509_verification_op(
@@ -286,13 +283,14 @@ std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_x509_verificatio
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECKCDSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECKCDSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> ECKCDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   if(!options.using_provider()) {
+      return std::make_unique<ECKCDSA_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -40,23 +40,13 @@ bool ECKCDSA_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) cons
 
 namespace {
 
-std::unique_ptr<HashFunction> eckcdsa_signature_hash(std::string_view padding) {
-   if(auto hash = HashFunction::create(padding)) {
-      return hash;
-   }
+std::unique_ptr<HashFunction> eckcdsa_signature_hash(const PK_Signature_Options& options) {
+   // Prehashing could be supported, but it's not standard
 
-   const SCAN_Name req(padding);
-
-   if(req.algo_name() == "EMSA1" && req.arg_count() == 1) {
-      if(auto hash = HashFunction::create(req.arg(0))) {
-         return hash;
-      }
-   }
-
-   // intentionally not supporting Raw for ECKCDSA, we need to know
+   // intentionally not supporting Raw for ECKCDSA, since we need to know
    // the length in advance which complicates the logic for Raw
 
-   throw Algorithm_Not_Found(padding);
+   return HashFunction::create_or_throw(options.hash_function_name());
 }
 
 std::unique_ptr<HashFunction> eckcdsa_signature_hash(const AlgorithmIdentifier& alg_id) {
@@ -119,10 +109,10 @@ void truncate_hash_if_needed(std::vector<uint8_t>& digest, size_t group_order_by
 */
 class ECKCDSA_Signature_Operation final : public PK_Ops::Signature {
    public:
-      ECKCDSA_Signature_Operation(const ECKCDSA_PrivateKey& eckcdsa, std::string_view padding) :
+      ECKCDSA_Signature_Operation(const ECKCDSA_PrivateKey& eckcdsa, const PK_Signature_Options& options) :
             m_group(eckcdsa.domain()),
             m_x(eckcdsa._private_key()),
-            m_hash(eckcdsa_signature_hash(padding)),
+            m_hash(eckcdsa_signature_hash(options)),
             m_prefix(eckcdsa_prefix(eckcdsa._public_ec_point(), m_hash->hash_block_size())),
             m_prefix_used(false) {}
 
@@ -190,10 +180,10 @@ std::vector<uint8_t> ECKCDSA_Signature_Operation::raw_sign(std::span<const uint8
 */
 class ECKCDSA_Verification_Operation final : public PK_Ops::Verification {
    public:
-      ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, std::string_view padding) :
+      ECKCDSA_Verification_Operation(const ECKCDSA_PublicKey& eckcdsa, const PK_Signature_Options& options) :
             m_group(eckcdsa.domain()),
             m_gy_mul(eckcdsa._public_ec_point()),
-            m_hash(eckcdsa_signature_hash(padding)),
+            m_hash(eckcdsa_signature_hash(options)),
             m_prefix(eckcdsa_prefix(eckcdsa._public_ec_point(), m_hash->hash_block_size())),
             m_prefix_used(false) {}
 
@@ -271,12 +261,12 @@ std::unique_ptr<Private_Key> ECKCDSA_PublicKey::generate_another(RandomNumberGen
    return std::make_unique<ECKCDSA_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_verification_op(std::string_view params,
-                                                                                std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECKCDSA_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<ECKCDSA_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_x509_verification_op(
@@ -288,13 +278,14 @@ std::unique_ptr<PK_Ops::Verification> ECKCDSA_PublicKey::create_x509_verificatio
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> ECKCDSA_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<ECKCDSA_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> ECKCDSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   if(!options.using_provider()) {
+      return std::make_unique<ECKCDSA_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -52,8 +52,7 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PublicKey : public virtual EC_PublicKey {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -108,9 +107,8 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey
 
       std::unique_ptr<Public_Key> public_key() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -50,8 +50,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
 
       Ed25519_PublicKey(const uint8_t pub_key[], size_t len);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -123,9 +122,8 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PrivateKey final : public Ed25519_PublicKey
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& option) const override;
 
    private:
       secure_vector<uint8_t> m_private;

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -53,8 +53,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
 
       Ed25519_PublicKey(const uint8_t pub_key[], size_t len);
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -124,9 +123,8 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PrivateKey final : public Ed25519_PublicKey
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& option) const override;
 
    private:
       std::shared_ptr<const Ed25519_PrivateKey_Data> m_private;

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -168,10 +168,12 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 /**
 * Ed25519 verifying operation with pre-hash
 */
-class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_Hash {
+class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
    public:
       Ed25519_Hashed_Verify_Operation(const Ed25519_PublicKey& key, std::string_view hash, bool rfc8032) :
-            PK_Ops::Verification_with_Hash(hash), m_key(key.get_public_key()) {
+            m_key(key.get_public_key()) {
+         m_hash = HashFunction::create_or_throw(hash);
+
          if(rfc8032) {
             m_domain_sep = {0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                             0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -179,17 +181,25 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_H
          }
       }
 
-      bool verify(std::span<const uint8_t> ph, std::span<const uint8_t> sig) override {
+      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
+
+      bool is_valid_signature(std::span<const uint8_t> sig) override {
+         std::vector<uint8_t> msg_hash(m_hash->output_length());
+         m_hash->final(msg_hash.data());
+
          if(sig.size() != 64) {
             return false;
          }
 
          BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
          return ed25519_verify(
-            ph.data(), ph.size(), sig.data(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+            msg_hash.data(), msg_hash.size(), sig.data(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
       }
 
+      std::string hash_function() const override { return m_hash->name(); }
+
    private:
+      std::unique_ptr<HashFunction> m_hash;
       std::vector<uint8_t> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
@@ -228,10 +238,12 @@ AlgorithmIdentifier Ed25519_Pure_Sign_Operation::algorithm_identifier() const {
 /**
 * Ed25519 signing operation with pre-hash
 */
-class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
+class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature {
    public:
       Ed25519_Hashed_Sign_Operation(const Ed25519_PrivateKey& key, std::string_view hash, bool rfc8032) :
-            PK_Ops::Signature_with_Hash(hash), m_key(key.raw_private_key_bits()) {
+            m_key(key.raw_private_key_bits()) {
+         m_hash = HashFunction::create_or_throw(hash);
+
          if(rfc8032) {
             m_domain_sep = std::vector<uint8_t>{0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                                                 0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -241,31 +253,47 @@ class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
 
       size_t signature_length() const override { return 64; }
 
-      std::vector<uint8_t> raw_sign(std::span<const uint8_t> ph, RandomNumberGenerator& /*rng*/) override {
+      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
+
+      std::vector<uint8_t> sign(RandomNumberGenerator& /*rng*/) override {
          std::vector<uint8_t> sig(64);
-         ed25519_sign(sig.data(), ph.data(), ph.size(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+         std::vector<uint8_t> msg_hash(m_hash->output_length());
+         m_hash->final(msg_hash.data());
+         ed25519_sign(
+            sig.data(), msg_hash.data(), msg_hash.size(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
          return sig;
       }
 
+      std::string hash_function() const override { return m_hash->name(); }
+
    private:
+      std::unique_ptr<HashFunction> m_hash;
       secure_vector<uint8_t> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_verification_op(std::string_view params,
-                                                                                std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Verify_Operation>(*this);
-      } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, "SHA-512", true);
+std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   BOTAN_ARG_CHECK(!options.using_padding(), "Ed25519 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_hash(), "Ed25519 does not support specifying a hash function");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "Ed25519 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "Ed25519 does not support a padding trailer field");
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         if(options.prehash_function().has_value()) {
+            return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, options.prehash_function().value(), false);
+         } else {
+            return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, "SHA-512", true);
+         }
       } else {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, params, false);
+         return std::make_unique<Ed25519_Pure_Verify_Operation>(*this);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
@@ -280,19 +308,28 @@ std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_x509_verificatio
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> Ed25519_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Sign_Operation>(*this);
-      } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, "SHA-512", true);
+std::unique_ptr<PK_Ops::Signature> Ed25519_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   BOTAN_ARG_CHECK(!options.using_padding(), "Ed25519 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_hash(), "Ed25519 does not support specifying a hash function");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "Ed25519 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "Ed25519 does not support a padding trailer field");
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         if(options.prehash_function().has_value()) {
+            return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, options.prehash_function().value(), false);
+         } else {
+            return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, "SHA-512", true);
+         }
       } else {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, params, false);
+         return std::make_unique<Ed25519_Pure_Sign_Operation>(*this);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -15,6 +15,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ed25519_internal.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -246,12 +247,12 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 /**
 * Ed25519 verifying operation with pre-hash
 */
-class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_Hash {
+class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification {
    public:
       Ed25519_Hashed_Verify_Operation(std::shared_ptr<const Ed25519_PublicKey_Data> key,
                                       std::string_view hash,
                                       bool rfc8032) :
-            PK_Ops::Verification_with_Hash(hash), m_key(std::move(key)) {
+            m_hash(HashFunction::create_or_throw(hash)), m_key(std::move(key)) {
          if(rfc8032) {
             m_domain_sep = {0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                             0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -259,17 +260,26 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_H
          }
       }
 
-      bool verify(std::span<const uint8_t> ph, std::span<const uint8_t> sig) override {
+      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
+
+      bool is_valid_signature(std::span<const uint8_t> sig) override {
+         std::vector<uint8_t> msg_hash(m_hash->output_length());
+         m_hash->final(msg_hash.data());
+
          if(sig.size() != 64) {
             return false;
          }
 
          const auto& key = m_key->key();
          BOTAN_ASSERT_EQUAL(key.size(), 32, "Expected size");
-         return ed25519_verify(ph.data(), ph.size(), sig.data(), key.data(), m_domain_sep.data(), m_domain_sep.size());
+         return ed25519_verify(
+            msg_hash.data(), msg_hash.size(), sig.data(), key.data(), m_domain_sep.data(), m_domain_sep.size());
       }
 
+      std::string hash_function() const override { return m_hash->name(); }
+
    private:
+      std::unique_ptr<HashFunction> m_hash;
       std::shared_ptr<const Ed25519_PublicKey_Data> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
@@ -310,12 +320,12 @@ AlgorithmIdentifier Ed25519_Pure_Sign_Operation::algorithm_identifier() const {
 /**
 * Ed25519 signing operation with pre-hash
 */
-class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
+class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature {
    public:
       Ed25519_Hashed_Sign_Operation(std::shared_ptr<const Ed25519_PrivateKey_Data> key,
                                     std::string_view hash,
                                     bool rfc8032) :
-            PK_Ops::Signature_with_Hash(hash), m_key(std::move(key)) {
+            m_hash(HashFunction::create_or_throw(hash)), m_key(std::move(key)) {
          if(rfc8032) {
             m_domain_sep = std::vector<uint8_t>{0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                                                 0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -325,32 +335,44 @@ class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
 
       size_t signature_length() const override { return 64; }
 
-      std::vector<uint8_t> raw_sign(std::span<const uint8_t> ph, RandomNumberGenerator& /*rng*/) override {
+      void update(std::span<const uint8_t> msg) override { m_hash->update(msg); }
+
+      std::vector<uint8_t> sign(RandomNumberGenerator& /*rng*/) override {
          std::vector<uint8_t> sig(64);
+         std::vector<uint8_t> msg_hash(m_hash->output_length());
+         m_hash->final(msg_hash.data());
          const auto& key = m_key->key();
-         ed25519_sign(sig.data(), ph.data(), ph.size(), key.data(), m_domain_sep.data(), m_domain_sep.size());
+         ed25519_sign(
+            sig.data(), msg_hash.data(), msg_hash.size(), key.data(), m_domain_sep.data(), m_domain_sep.size());
          return sig;
       }
 
+      std::string hash_function() const override { return m_hash->name(); }
+
    private:
+      std::unique_ptr<HashFunction> m_hash;
       std::shared_ptr<const Ed25519_PrivateKey_Data> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_verification_op(std::string_view params,
-                                                                                std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Verify_Operation>(m_public);
-      } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(m_public, "SHA-512", true);
+std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         if(options.prehash_function().has_value()) {
+            return std::make_unique<Ed25519_Hashed_Verify_Operation>(
+               m_public, options.prehash_function().value(), false);
+         } else {
+            return std::make_unique<Ed25519_Hashed_Verify_Operation>(m_public, "SHA-512", true);
+         }
       } else {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(m_public, params, false);
+         return std::make_unique<Ed25519_Pure_Verify_Operation>(m_public);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,
@@ -365,19 +387,26 @@ std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_x509_verificatio
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> Ed25519_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Sign_Operation>(m_private);
-      } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(m_private, "SHA-512", true);
+std::unique_ptr<PK_Ops::Signature> Ed25519_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   acknowledge_always_deterministic(options);
+
+   if(!options.using_provider()) {
+      if(options.using_prehash()) {
+         if(options.prehash_function().has_value()) {
+            return std::make_unique<Ed25519_Hashed_Sign_Operation>(
+               m_private, options.prehash_function().value(), false);
+         } else {
+            return std::make_unique<Ed25519_Hashed_Sign_Operation>(m_private, "SHA-512", true);
+         }
       } else {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(m_private, params, false);
+         return std::make_unique<Ed25519_Pure_Sign_Operation>(m_private);
       }
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/gost_3410.h>
 
+#include <botan/assert.h>
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
 #include <botan/internal/ec_key_data.h>
@@ -128,8 +129,11 @@ EC_Scalar gost_msg_to_scalar(const EC_Group& group, std::span<const uint8_t> msg
 */
 class GOST_3410_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      GOST_3410_Signature_Operation(const GOST_3410_PrivateKey& gost_3410, std::string_view hash_fn) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_group(gost_3410.domain()), m_x(gost_3410._private_key()) {}
+      GOST_3410_Signature_Operation(const GOST_3410_PrivateKey& gost_3410, const PK_Signature_Options& options) :
+            PK_Ops::Signature_with_Hash(options), m_group(gost_3410.domain()), m_x(gost_3410._private_key()) {
+         BOTAN_ARG_CHECK(!options.using_deterministic_signature(),
+                         "GOST-34.10 does not support deterministic signatures");
+      }
 
       size_t signature_length() const override { return 2 * m_group.get_order_bytes(); }
 
@@ -179,23 +183,23 @@ std::vector<uint8_t> GOST_3410_Signature_Operation::raw_sign(std::span<const uin
    return EC_Scalar::serialize_pair(s, r);
 }
 
-std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
+PK_Signature_Options gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
    if(!alg_id.parameters_are_empty()) {
       throw Decoding_Error("Unexpected non-empty AlgorithmIdentifier parameters for GOST 34.10 signature");
    }
 
    const std::string oid_str = alg_id.oid().to_formatted_string();
    if(oid_str == "GOST-34.10/GOST-R-34.11-94") {
-      return "GOST-R-34.11-94";
+      return PK_Signature_Options("GOST-R-34.11-94");
    }
    if(oid_str == "GOST-34.10-2012-256/Streebog-256") {
-      return "Streebog-256";
+      return PK_Signature_Options("Streebog-256");
    }
    if(oid_str == "GOST-34.10-2012-512/Streebog-512") {
-      return "Streebog-512";
+      return PK_Signature_Options("Streebog-512");
    }
    if(oid_str == "GOST-34.10-2012-256/SHA-256") {
-      return "SHA-256";
+      return PK_Signature_Options("SHA-256");
    }
 
    throw Decoding_Error(fmt("Unknown OID ({}) for GOST 34.10 signatures", alg_id.oid()));
@@ -206,8 +210,8 @@ std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
 */
 class GOST_3410_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(gost.domain()), m_gy_mul(gost._public_ec_point()) {}
+      GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(gost.domain()), m_gy_mul(gost._public_ec_point()) {}
 
       GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(gost_hash_from_algid(alg_id)),
@@ -244,12 +248,12 @@ std::unique_ptr<Private_Key> GOST_3410_PublicKey::generate_another(RandomNumberG
    return std::make_unique<GOST_3410_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_verification_op(std::string_view params,
-                                                                                  std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<GOST_3410_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<GOST_3410_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_x509_verification_op(
@@ -261,13 +265,14 @@ std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_x509_verificat
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> GOST_3410_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                             std::string_view params,
-                                                                             std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<GOST_3410_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> GOST_3410_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   if(!options.using_provider()) {
+      return std::make_unique<GOST_3410_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/gost_3410.h>
 
+#include <botan/assert.h>
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
 #include <botan/internal/ec_key_data.h>
@@ -209,8 +210,8 @@ EC_Scalar gost_msg_to_scalar(const EC_Group& group, std::span<const uint8_t> msg
 */
 class GOST_3410_Signature_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      GOST_3410_Signature_Operation(const GOST_3410_PrivateKey& gost_3410, std::string_view hash_fn) :
-            PK_Ops::Signature_with_Hash(hash_fn), m_group(gost_3410.domain()), m_x(gost_3410._private_key()) {}
+      GOST_3410_Signature_Operation(const GOST_3410_PrivateKey& gost_3410, const PK_Signature_Options& options) :
+            PK_Ops::Signature_with_Hash(options), m_group(gost_3410.domain()), m_x(gost_3410._private_key()) {}
 
       size_t signature_length() const override { return 2 * m_group.get_order_bytes(); }
 
@@ -260,20 +261,20 @@ std::vector<uint8_t> GOST_3410_Signature_Operation::raw_sign(std::span<const uin
    return EC_Scalar::serialize_pair(s, r);
 }
 
-std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
+PK_Signature_Options gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
    if(!alg_id.parameters_are_empty()) {
       throw Decoding_Error("Unexpected non-empty AlgorithmIdentifier parameters for GOST 34.10 signature");
    }
 
    if(const auto name = alg_id.oid().registered_name()) {
       if(*name == "GOST-34.10/GOST-R-34.11-94") {
-         return "GOST-R-34.11-94";
+         return PK_Signature_Options().with_hash("GOST-R-34.11-94");
       } else if(*name == "GOST-34.10-2012-256/Streebog-256") {
-         return "Streebog-256";
+         return PK_Signature_Options().with_hash("Streebog-256");
       } else if(*name == "GOST-34.10-2012-512/Streebog-512") {
-         return "Streebog-512";
+         return PK_Signature_Options().with_hash("Streebog-512");
       } else if(*name == "GOST-34.10-2012-256/SHA-256") {
-         return "SHA-256";
+         return PK_Signature_Options().with_hash("SHA-256");
       } else {
          throw Decoding_Error(fmt("Unknown OID ({}, {}) for GOST 34.10 signatures", alg_id.oid(), *name));
       }
@@ -287,8 +288,8 @@ std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
 */
 class GOST_3410_Verification_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, std::string_view padding) :
-            PK_Ops::Verification_with_Hash(padding), m_group(gost.domain()), m_gy_mul(gost._public_ec_point()) {}
+      GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, const PK_Signature_Options& options) :
+            PK_Ops::Verification_with_Hash(options), m_group(gost.domain()), m_gy_mul(gost._public_ec_point()) {}
 
       GOST_3410_Verification_Operation(const GOST_3410_PublicKey& gost, const AlgorithmIdentifier& alg_id) :
             PK_Ops::Verification_with_Hash(gost_hash_from_algid(alg_id)),
@@ -325,12 +326,12 @@ std::unique_ptr<Private_Key> GOST_3410_PublicKey::generate_another(RandomNumberG
    return std::make_unique<GOST_3410_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_verification_op(std::string_view params,
-                                                                                  std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<GOST_3410_Verification_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<GOST_3410_Verification_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_x509_verification_op(
@@ -342,13 +343,14 @@ std::unique_ptr<PK_Ops::Verification> GOST_3410_PublicKey::create_x509_verificat
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> GOST_3410_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                             std::string_view params,
-                                                                             std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<GOST_3410_Signature_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Signature> GOST_3410_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   if(!options.using_provider()) {
+      return std::make_unique<GOST_3410_Signature_Operation>(*this, options);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -62,8 +62,7 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PublicKey : public virtual EC_PublicKey {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -119,9 +118,8 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PrivateKey final : public GOST_3410_Publi
          return EC_PublicKey::algorithm_identifier();  // NOLINT(bugprone-parent-virtual-call)
       }
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -62,8 +62,7 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PublicKey : public virtual EC_PublicKey {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -118,9 +117,8 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PrivateKey final : public GOST_3410_Publi
          return GOST_3410_PublicKey::algorithm_identifier();
       }
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/hss_lms/hss_lms.cpp
+++ b/src/lib/pubkey/hss_lms/hss_lms.cpp
@@ -11,6 +11,7 @@
 #include <botan/rng.h>
 #include <botan/internal/hss.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -89,12 +90,15 @@ class HSS_LMS_Verification_Operation final : public PK_Ops::Verification {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                                std::string_view provider) const {
-   if(provider.empty() || provider == "base") {
+std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_for_hash_based_signature(options, "HSS-LMS", "");
+   BOTAN_ARG_CHECK(!options.using_hash(), "Unexpected parameters for verifying with HSS-LMS");
+
+   if(!options.using_provider()) {
       return std::make_unique<HSS_LMS_Verification_Operation>(m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::create_x509_verification_op(
@@ -203,16 +207,18 @@ class HSS_LMS_Signature_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> HSS_LMS_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> HSS_LMS_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
-   BOTAN_ARG_CHECK(params.empty(), "Unexpected parameters for signing with HSS-LMS");
 
-   if(provider.empty() || provider == "base") {
+   validate_for_hash_based_signature(options, "HSS-LMS", "");
+
+   BOTAN_ARG_CHECK(!options.using_hash(), "Unexpected parameters for signing with HSS-LMS");
+
+   if(!options.using_provider()) {
       return std::make_unique<HSS_LMS_Signature_Operation>(m_private, m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/hss_lms/hss_lms.cpp
+++ b/src/lib/pubkey/hss_lms/hss_lms.cpp
@@ -11,6 +11,7 @@
 #include <botan/rng.h>
 #include <botan/internal/hss.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -100,12 +101,14 @@ class HSS_LMS_Verification_Operation final : public PK_Ops::Verification {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                                std::string_view provider) const {
-   if(provider.empty() || provider == "base") {
+std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_for_hash_based_signature(options, "HSS-LMS", m_public->lms_pub_key().lms_params().hash_name());
+
+   if(!options.using_provider()) {
       return std::make_unique<HSS_LMS_Verification_Operation>(m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> HSS_LMS_PublicKey::create_x509_verification_op(
@@ -223,16 +226,17 @@ class HSS_LMS_Signature_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> HSS_LMS_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                           std::string_view params,
-                                                                           std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> HSS_LMS_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                            const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
-   BOTAN_ARG_CHECK(params.empty(), "Unexpected parameters for signing with HSS-LMS");
 
-   if(provider.empty() || provider == "base") {
+   validate_for_hash_based_signature(options, "HSS-LMS", m_public->lms_pub_key().lms_params().hash_name());
+   acknowledge_always_deterministic(options);
+
+   if(!options.using_provider()) {
       return std::make_unique<HSS_LMS_Signature_Operation>(m_private, m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/hss_lms/hss_lms.h
+++ b/src/lib/pubkey/hss_lms/hss_lms.h
@@ -55,8 +55,7 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PublicKey : public virtual Public_Key {
       std::vector<uint8_t> raw_public_key_bits() const override;
       std::vector<uint8_t> public_key_bits() const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -154,9 +153,8 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PrivateKey final : public virtual HSS_LMS_P
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       explicit HSS_LMS_PrivateKey(std::shared_ptr<HSS_LMS_PrivateKeyInternal> sk);

--- a/src/lib/pubkey/hss_lms/hss_lms.h
+++ b/src/lib/pubkey/hss_lms/hss_lms.h
@@ -61,8 +61,7 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PublicKey : public virtual Public_Key {
       std::vector<uint8_t> raw_public_key_bits() const override;
       std::vector<uint8_t> public_key_bits() const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -166,9 +165,8 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PrivateKey final : public virtual HSS_LMS_P
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       explicit HSS_LMS_PrivateKey(std::shared_ptr<HSS_LMS_PrivateKeyInternal> sk);

--- a/src/lib/pubkey/info.txt
+++ b/src/lib/pubkey/info.txt
@@ -1,5 +1,5 @@
 <defines>
-PUBLIC_KEY_CRYPTO -> 20131128
+PUBLIC_KEY_CRYPTO -> 20240817
 </defines>
 
 <module_info>
@@ -9,6 +9,7 @@ brief -> "Implementations of public key schemes"
 
 <header:public>
 pk_algs.h
+pk_options.h
 pk_keys.h
 pk_ops_fwd.h
 pk_ops.h
@@ -19,6 +20,7 @@ x509_key.h
 
 <header:internal>
 pk_ops_impl.h
+pk_options_impl.h
 workfactor.h
 </header:internal>
 

--- a/src/lib/pubkey/info.txt
+++ b/src/lib/pubkey/info.txt
@@ -1,5 +1,5 @@
 <defines>
-PUBLIC_KEY_CRYPTO -> 20131128
+PUBLIC_KEY_CRYPTO -> 20260815
 </defines>
 
 <module_info>
@@ -9,6 +9,7 @@ brief -> "Implementations of public key schemes"
 
 <header:public>
 pk_algs.h
+pk_options.h
 pk_keys.h
 pk_ops_fwd.h
 pk_ops.h
@@ -19,6 +20,7 @@ x509_key.h
 
 <header:internal>
 pk_ops_impl.h
+pk_options_impl.h
 workfactor.h
 </header:internal>
 

--- a/src/lib/pubkey/pk_keys.cpp
+++ b/src/lib/pubkey/pk_keys.cpp
@@ -7,11 +7,13 @@
 
 #include <botan/pk_keys.h>
 
+#include <botan/assert.h>
 #include <botan/der_enc.h>
 #include <botan/hash.h>
 #include <botan/hex.h>
 #include <botan/pk_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -113,8 +115,8 @@ std::unique_ptr<PK_Ops::KEM_Encryption> Public_Key::create_kem_encryption_op(std
    throw Lookup_Error(fmt("{} does not support KEM encryption", algo_name()));
 }
 
-std::unique_ptr<PK_Ops::Verification> Public_Key::create_verification_op(std::string_view /*params*/,
-                                                                         std::string_view /*provider*/) const {
+std::unique_ptr<PK_Ops::Verification> Public_Key::_create_verification_op(const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(options);
    throw Lookup_Error(fmt("{} does not support verification", algo_name()));
 }
 
@@ -135,9 +137,9 @@ std::unique_ptr<PK_Ops::KEM_Decryption> Private_Key::create_kem_decryption_op(Ra
    throw Lookup_Error(fmt("{} does not support KEM decryption", algo_name()));
 }
 
-std::unique_ptr<PK_Ops::Signature> Private_Key::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                    std::string_view /*params*/,
-                                                                    std::string_view /*provider*/) const {
+std::unique_ptr<PK_Ops::Signature> Private_Key::_create_signature_op(RandomNumberGenerator& rng,
+                                                                     const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng, options);
    throw Lookup_Error(fmt("{} does not support signatures", algo_name()));
 }
 
@@ -145,6 +147,19 @@ std::unique_ptr<PK_Ops::Key_Agreement> Private_Key::create_key_agreement_op(Rand
                                                                             std::string_view /*params*/,
                                                                             std::string_view /*provider*/) const {
    throw Lookup_Error(fmt("{} does not support key agreement", algo_name()));
+}
+
+// Forwarding functions for compat
+
+std::unique_ptr<PK_Ops::Verification> Public_Key::create_verification_op(std::string_view params,
+                                                                         std::string_view provider) const {
+   return this->_create_verification_op(parse_legacy_sig_options(*this, params).with_provider(provider));
+}
+
+std::unique_ptr<PK_Ops::Signature> Private_Key::create_signature_op(RandomNumberGenerator& rng,
+                                                                    std::string_view params,
+                                                                    std::string_view provider) const {
+   return this->_create_signature_op(rng, parse_legacy_sig_options(*this, params).with_provider(provider));
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -22,6 +22,7 @@ namespace Botan {
 
 class BigInt;
 class RandomNumberGenerator;
+class PK_Signature_Options;
 
 /**
 * Enumeration specifying the signature format.
@@ -106,6 +107,23 @@ class BOTAN_PUBLIC_API(3, 0) Asymmetric_Key /* NOLINT(*special-member-functions)
       * of operation.
       */
       virtual bool supports_operation(PublicKeyOperation op) const = 0;
+
+      /**
+      * Return true if this key supports contextual inputs during processing
+      *
+      * This is typically some protocol or user specific binding information
+      * which is included during cryptographic computations.
+      *
+      * This is only supported by a few algorithm types, so default
+      * implementation returns false.
+      *
+      * Note that support for contextual data may depend on both the algorithm
+      * and the library version. For example Ed25519 can support contextual
+      * data, using RFC 8032's Ed25519ctx construction, but this is not
+      * currently supported. In a future release, if Ed25519ctx was supported,
+      * then this function would start returning true for Ed25519 keys.
+      */
+      virtual bool supports_context_data() const;
 
       /**
        * Generate another (cryptographically independent) key pair using the
@@ -266,11 +284,24 @@ class BOTAN_PUBLIC_API(2, 0) Public_Key : public virtual Asymmetric_Key {
       * In all cases applications should use wrappers in pubkey.h
       *
       * Return a verification operation for this key/params or throw
+      *
+      * @param options which specify parameters of the signature beyond those
+      * implicit to the public key itself
+      */
+      virtual std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const;
+
+      /**
+      * This is an internal library function exposed on key types.
+      * In all cases applications should use wrappers in pubkey.h
+      *
+      * Return a verification operation for this key/params or throw
+      *
       * @param params additional parameters
       * @param provider the provider to use
       */
-      virtual std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                           std::string_view provider) const;
+      BOTAN_DEPRECATED("Use PK_Verifier")
+      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
+                                                                   std::string_view provider) const;
 
       /**
       * This is an internal library function exposed on key types.
@@ -388,12 +419,29 @@ class BOTAN_PUBLIC_API(2, 0) Private_Key : public virtual Public_Key {
       * @param rng a random number generator. The PK_Op may maintain a
       * reference to the RNG and use it many times. The rng must outlive
       * any operations which reference it.
+      *
+      * @param options allow controlling behavior
+      */
+      virtual std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                                      const PK_Signature_Options& options) const;
+
+      /**
+      * This is an internal library function exposed on key types.
+      * In all cases applications should use wrappers in pubkey.h
+      *
+      * Return a signature operation for this key/params or throw
+      *
+      * @param rng a random number generator. The PK_Op may maintain a
+      * reference to the RNG and use it many times. The rng must outlive
+      * any operations which reference it.
+      *
       * @param params additional parameters
       * @param provider the provider to use
       */
-      virtual std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                                     std::string_view params,
-                                                                     std::string_view provider) const;
+      BOTAN_DEPRECATED("Use PK_Signer")
+      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
+                                                             std::string_view params,
+                                                             std::string_view provider) const;
 
       /**
       * This is an internal library function exposed on key types.

--- a/src/lib/pubkey/pk_keys.h
+++ b/src/lib/pubkey/pk_keys.h
@@ -22,6 +22,7 @@ namespace Botan {
 
 class BigInt;
 class RandomNumberGenerator;
+class PK_Signature_Options;
 
 /**
 * Enumeration specifying the signature format.
@@ -277,11 +278,24 @@ class BOTAN_PUBLIC_API(2, 0) Public_Key : public virtual Asymmetric_Key {
       * In all cases applications should use wrappers in pubkey.h
       *
       * Return a verification operation for this key/params or throw
+      *
+      * @param options which specify parameters of the signature beyond those
+      * implicit to the public key itself
+      */
+      virtual std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const;
+
+      /**
+      * This is an internal library function exposed on key types.
+      * In all cases applications should use wrappers in pubkey.h
+      *
+      * Return a verification operation for this key/params or throw
+      *
       * @param params additional parameters
       * @param provider the provider to use
       */
-      virtual std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                           std::string_view provider) const;
+      BOTAN_DEPRECATED("Use PK_Verifier")
+      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
+                                                                   std::string_view provider) const;
 
       /**
       * This is an internal library function exposed on key types.
@@ -404,12 +418,29 @@ class BOTAN_PUBLIC_API(2, 0) Private_Key : public virtual Public_Key {
       * @param rng a random number generator. The PK_Op may maintain a
       * reference to the RNG and use it many times. The rng must outlive
       * any operations which reference it.
+      *
+      * @param options allow controlling behavior
+      */
+      virtual std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                                      const PK_Signature_Options& options) const;
+
+      /**
+      * This is an internal library function exposed on key types.
+      * In all cases applications should use wrappers in pubkey.h
+      *
+      * Return a signature operation for this key/params or throw
+      *
+      * @param rng a random number generator. The PK_Op may maintain a
+      * reference to the RNG and use it many times. The rng must outlive
+      * any operations which reference it.
+      *
       * @param params additional parameters
       * @param provider the provider to use
       */
-      virtual std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                                     std::string_view params,
-                                                                     std::string_view provider) const;
+      BOTAN_DEPRECATED("Use PK_Signer")
+      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
+                                                             std::string_view params,
+                                                             std::string_view provider) const;
 
       /**
       * This is an internal library function exposed on key types.

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -98,25 +98,31 @@ secure_vector<uint8_t> PK_Ops::Key_Agreement_with_KDF::agree(size_t key_len,
 
 namespace {
 
-std::unique_ptr<HashFunction> create_signature_hash(std::string_view padding) {
-   if(auto hash = HashFunction::create(padding)) {
-      return hash;
-   }
+std::unique_ptr<HashFunction> validate_options_returning_hash(const PK_Signature_Options& options) {
+   BOTAN_ARG_CHECK(!options.hash_function_name().empty(), "This algorithm requires a hash function for signing");
+   BOTAN_ARG_CHECK(!options.using_padding(), "This algorithm does not support padding modes");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "This algorithm does not support a salt");
 
-   const SCAN_Name req(padding);
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "This algorithm does not support a padding trailer field");
 
-   if(req.algo_name() == "EMSA1" && req.arg_count() == 1) {
-      if(auto hash = HashFunction::create(req.arg(0))) {
-         return hash;
+   /*
+   * In a sense ECDSA/DSA are *always* in prehashing mode, so we accept the case
+   * where prehashing is requested as long as the prehash hash matches the signature hash.
+   */
+   if(options.using_prehash()) {
+      if(!options.prehash_function().has_value() ||
+         options.prehash_function().value() != options.hash_function_name()) {
+         throw Invalid_Argument("This algorithm does not support prehashing with a different hash");
       }
    }
 
 #if defined(BOTAN_HAS_RAW_HASH_FN)
-   if(req.algo_name() == "Raw") {
-      if(req.arg_count() == 0) {
+   if(options.hash_function_name().starts_with("Raw")) {
+      if(options.hash_function_name() == "Raw") {
          return std::make_unique<RawHashFunction>("Raw", 0);
       }
 
+      SCAN_Name req(options.hash_function_name());
       if(req.arg_count() == 1) {
          if(auto hash = HashFunction::create(req.arg(0))) {
             return std::make_unique<RawHashFunction>(std::move(hash));
@@ -125,13 +131,13 @@ std::unique_ptr<HashFunction> create_signature_hash(std::string_view padding) {
    }
 #endif
 
-   throw Algorithm_Not_Found(padding);
+   return HashFunction::create_or_throw(options.hash_function_name());
 }
 
 }  // namespace
 
-PK_Ops::Signature_with_Hash::Signature_with_Hash(std::string_view hash) :
-      Signature(), m_hash(create_signature_hash(hash)) {}
+PK_Ops::Signature_with_Hash::Signature_with_Hash(const PK_Signature_Options& options) :
+      Signature(), m_hash(validate_options_returning_hash(options)) {}
 
 PK_Ops::Signature_with_Hash::~Signature_with_Hash() = default;
 
@@ -158,8 +164,8 @@ std::vector<uint8_t> PK_Ops::Signature_with_Hash::sign(RandomNumberGenerator& rn
    return raw_sign(msg, rng);
 }
 
-PK_Ops::Verification_with_Hash::Verification_with_Hash(std::string_view padding) :
-      Verification(), m_hash(create_signature_hash(padding)) {}
+PK_Ops::Verification_with_Hash::Verification_with_Hash(const PK_Signature_Options& options) :
+      Verification(), m_hash(validate_options_returning_hash(options)) {}
 
 PK_Ops::Verification_with_Hash::~Verification_with_Hash() = default;
 

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -15,7 +15,7 @@
 #include <botan/internal/enc_padding.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/parsing.h>
-#include <botan/internal/scan_name.h>
+#include <botan/internal/pk_options_impl.h>
 
 #if defined(BOTAN_HAS_RAW_HASH_FN)
    #include <botan/internal/raw_hash.h>
@@ -98,40 +98,39 @@ secure_vector<uint8_t> PK_Ops::Key_Agreement_with_KDF::agree(size_t key_len,
 
 namespace {
 
-std::unique_ptr<HashFunction> create_signature_hash(std::string_view padding) {
-   if(auto hash = HashFunction::create(padding)) {
-      return hash;
-   }
-
-   const SCAN_Name req(padding);
-
-   if(req.algo_name() == "EMSA1" && req.arg_count() == 1) {
-      if(auto hash = HashFunction::create(req.arg(0))) {
-         return hash;
-      }
-   }
-
+std::unique_ptr<HashFunction> validate_options_returning_hash(const PK_Signature_Options& options) {
+   // The caller provides the digest; if they named the hash, its length is checked
+   if(options.using_externally_computed_prehash()) {
 #if defined(BOTAN_HAS_RAW_HASH_FN)
-   if(req.algo_name() == "Raw") {
-      if(req.arg_count() == 0) {
-         return std::make_unique<RawHashFunction>("Raw", 0);
+      if(auto prehash = externally_computed_prehash_name(options)) {
+         return std::make_unique<RawHashFunction>(HashFunction::create_or_throw(*prehash));
       }
+      return std::make_unique<RawHashFunction>("Raw", 0);
+#else
+      throw Lookup_Error("Signing an externally computed prehash requires the raw_hash module");
+#endif
+   }
 
-      if(req.arg_count() == 1) {
-         if(auto hash = HashFunction::create(req.arg(0))) {
-            return std::make_unique<RawHashFunction>(std::move(hash));
-         }
+   BOTAN_ARG_CHECK(!options.hash_function_name().empty(), "This algorithm requires a hash function for signing");
+
+   /*
+   * In a sense ECDSA/DSA are *always* in prehashing mode, so we accept the case
+   * where prehashing is requested as long as the prehash hash matches the signature hash.
+   */
+   if(options.using_prehash()) {
+      if(!options.prehash_function().has_value() ||
+         options.prehash_function().value() != options.hash_function_name()) {
+         throw Invalid_Argument("This algorithm does not support prehashing with a different hash");
       }
    }
-#endif
 
-   throw Algorithm_Not_Found(padding);
+   return HashFunction::create_or_throw(options.hash_function_name());
 }
 
 }  // namespace
 
-PK_Ops::Signature_with_Hash::Signature_with_Hash(std::string_view hash) :
-      Signature(), m_hash(create_signature_hash(hash)) {}
+PK_Ops::Signature_with_Hash::Signature_with_Hash(const PK_Signature_Options& options) :
+      Signature(), m_hash(validate_options_returning_hash(options)) {}
 
 PK_Ops::Signature_with_Hash::~Signature_with_Hash() = default;
 
@@ -158,8 +157,8 @@ std::vector<uint8_t> PK_Ops::Signature_with_Hash::sign(RandomNumberGenerator& rn
    return raw_sign(msg, rng);
 }
 
-PK_Ops::Verification_with_Hash::Verification_with_Hash(std::string_view padding) :
-      Verification(), m_hash(create_signature_hash(padding)) {}
+PK_Ops::Verification_with_Hash::Verification_with_Hash(const PK_Signature_Options& options) :
+      Verification(), m_hash(validate_options_returning_hash(options)) {}
 
 PK_Ops::Verification_with_Hash::~Verification_with_Hash() = default;
 

--- a/src/lib/pubkey/pk_ops_impl.h
+++ b/src/lib/pubkey/pk_ops_impl.h
@@ -10,6 +10,8 @@
 
 #include <botan/pk_ops.h>
 
+#include <botan/pk_options.h>
+
 namespace Botan {
 
 class HashFunction;
@@ -64,7 +66,7 @@ class Verification_with_Hash : public Verification {
       std::string hash_function() const final;
 
    protected:
-      explicit Verification_with_Hash(std::string_view hash);
+      explicit Verification_with_Hash(const PK_Signature_Options& options);
 
       explicit Verification_with_Hash(const AlgorithmIdentifier& alg_id,
                                       std::string_view pk_algo,
@@ -91,7 +93,7 @@ class Signature_with_Hash : public Signature {
       ~Signature_with_Hash() override;
 
    protected:
-      explicit Signature_with_Hash(std::string_view hash);
+      explicit Signature_with_Hash(const PK_Signature_Options& options);
 
       std::string hash_function() const final;
 

--- a/src/lib/pubkey/pk_options.cpp
+++ b/src/lib/pubkey/pk_options.cpp
@@ -1,0 +1,145 @@
+/*
+* (C) 2024,2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/pk_options.h>
+
+#include <botan/assert.h>
+#include <botan/hash.h>
+#include <botan/hex.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/mem_utils.h>
+#include <sstream>
+
+namespace Botan {
+
+PK_Signature_Options::~PK_Signature_Options() = default;
+
+PK_Signature_Options PK_Signature_Options::with_hash(std::string_view hash) {
+   BOTAN_STATE_CHECK_MSG(!using_hash(), "PK_Signature_Options::with_hash cannot specify hash twice");
+   auto next = (*this);
+   if(!hash.empty()) {
+      next.m_hash_fn = hash;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_padding(std::string_view padding) {
+   BOTAN_STATE_CHECK_MSG(!using_padding(), "PK_Signature_Options::with_padding cannot specify padding twice");
+   auto next = (*this);
+   if(!padding.empty()) {
+      next.m_padding = padding;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_prehash(std::optional<std::string> prehash_function) {
+   BOTAN_STATE_CHECK_MSG(!using_prehash(), "PK_Signature_Options::with_prehash cannot specify prehash twice");
+   auto next = (*this);
+
+   // Calling this with a std::nullopt enables prehashing with an algorithm-
+   // specific hash function that is not user-defined. Hence the bool flag.
+   next.m_using_prehash = true;
+   next.m_prehash = std::move(prehash_function);
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_provider(std::string_view provider) {
+   BOTAN_STATE_CHECK_MSG(provider.empty() || !using_provider(),
+                         "PK_Signature_Options::with_provider cannot specify provider twice");
+   auto next = (*this);
+   if(!provider.empty()) {
+      next.m_provider = provider;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_context(std::span<const uint8_t> context) {
+   BOTAN_STATE_CHECK_MSG(!using_context(), "PK_Signature_Options::with_context cannot specify context twice");
+   auto next = (*this);
+   next.m_context = std::vector<uint8_t>(context.begin(), context.end());
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_context(std::string_view context) {
+   BOTAN_STATE_CHECK_MSG(!using_context(), "PK_Signature_Options::with_context cannot specify context twice");
+   auto next = (*this);
+   auto contextb = as_span_of_bytes(context);
+   next.m_context = std::vector<uint8_t>(contextb.begin(), contextb.end());
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_salt_size(size_t salt_size) {
+   BOTAN_STATE_CHECK_MSG(!using_salt_size(), "PK_Signature_Options::with_salt_size cannot specify salt size twice");
+   auto next = (*this);
+   next.m_salt_size = salt_size;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_deterministic_signature(bool deterministic) {
+   auto next = (*this);
+   next.m_deterministic_sig = deterministic;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_der_encoded_signature(bool der) {
+   auto next = (*this);
+   next.m_use_der = der;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_explicit_trailer_field(bool trailer) {
+   auto next = (*this);
+   next.m_explicit_trailer_field = trailer;
+   return next;
+}
+
+bool PK_Signature_Options::using_provider() const {
+   if(auto prov = provider()) {
+      return !prov->empty() && *prov != "base";
+   }
+   return false;
+}
+
+std::string PK_Signature_Options::hash_function_name() const {
+   if(m_hash_fn.has_value()) {
+      return m_hash_fn.value();
+   }
+
+   throw Invalid_State("This signature scheme requires specifying a hash function");
+}
+
+std::string PK_Signature_Options::to_string() const {
+   std::ostringstream out;
+
+   auto print_str = [&](std::string_view name, std::optional<std::string> val) {
+      if(val.has_value()) {
+         out << name << "='" << val.value() << "' ";
+      }
+   };
+
+   print_str("Hash", this->hash_function());
+   print_str("Padding", this->padding());
+   print_str("Prehash", this->prehash_function());
+   print_str("Provider", this->provider());
+
+   if(auto context = this->context()) {
+      out << "Context=" << hex_encode(*context) << " ";
+   }
+
+   if(auto salt = this->salt_size()) {
+      out << "SaltLen=" << *salt << " ";
+   }
+   if(this->using_der_encoded_signature()) {
+      out << "DerSignature ";
+   }
+   if(this->using_deterministic_signature()) {
+      out << "Deterministic ";
+   }
+
+   return out.str();
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/pk_options.cpp
+++ b/src/lib/pubkey/pk_options.cpp
@@ -1,0 +1,248 @@
+/*
+* (C) 2024,2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/pk_options.h>
+
+#include <botan/assert.h>
+#include <botan/hash.h>
+#include <botan/hex.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/mem_utils.h>
+#include <sstream>
+
+namespace Botan {
+
+PK_Signature_Options::~PK_Signature_Options() = default;
+
+PK_Signature_Options PK_Signature_Options::with_hash(std::string_view hash) {
+   BOTAN_STATE_CHECK_MSG(!m_hash_fn.has_value(), "PK_Signature_Options::with_hash cannot specify hash twice");
+   auto next = (*this);
+   if(!hash.empty()) {
+      next.m_hash_fn = hash;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_padding(std::string_view padding) {
+   BOTAN_STATE_CHECK_MSG(!m_padding.has_value(), "PK_Signature_Options::with_padding cannot specify padding twice");
+   auto next = (*this);
+   if(!padding.empty()) {
+      next.m_padding = padding;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_prehash(std::optional<std::string> prehash_function) {
+   BOTAN_STATE_CHECK_MSG(!m_using_prehash, "PK_Signature_Options::with_prehash cannot specify prehash twice");
+   BOTAN_STATE_CHECK_MSG(!m_using_external_prehash,
+                         "PK_Signature_Options::with_prehash cannot be combined with an externally computed prehash");
+   auto next = (*this);
+
+   // Calling this with a std::nullopt enables prehashing with an algorithm-
+   // specific hash function that is not user-defined. Hence the bool flag.
+   next.m_using_prehash = true;
+   next.m_prehash = std::move(prehash_function);
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_externally_computed_prehash(std::optional<std::string> hash) {
+   BOTAN_STATE_CHECK_MSG(
+      !m_using_external_prehash,
+      "PK_Signature_Options::with_externally_computed_prehash cannot specify external prehash twice");
+   BOTAN_STATE_CHECK_MSG(!m_using_prehash,
+                         "PK_Signature_Options::with_externally_computed_prehash cannot be combined with a prehash");
+   auto next = (*this);
+
+   // As with with_prehash, a nullopt hash is meaningful (the input is an
+   // unidentified digest) so a flag tracks that the option was requested
+   next.m_using_external_prehash = true;
+   next.m_external_prehash = std::move(hash);
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_provider(std::string_view provider) {
+   BOTAN_STATE_CHECK_MSG(provider.empty() || !m_provider.has_value(),
+                         "PK_Signature_Options::with_provider cannot specify provider twice");
+   auto next = (*this);
+   if(!provider.empty()) {
+      next.m_provider = provider;
+   }
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_context(std::span<const uint8_t> context) {
+   BOTAN_STATE_CHECK_MSG(!m_context.has_value(), "PK_Signature_Options::with_context cannot specify context twice");
+   auto next = (*this);
+   next.m_context = std::vector<uint8_t>(context.begin(), context.end());
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_context(std::string_view context) {
+   BOTAN_STATE_CHECK_MSG(!m_context.has_value(), "PK_Signature_Options::with_context cannot specify context twice");
+   auto next = (*this);
+   auto contextb = as_span_of_bytes(context);
+   next.m_context = std::vector<uint8_t>(contextb.begin(), contextb.end());
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_salt_size(size_t salt_size) {
+   BOTAN_STATE_CHECK_MSG(!m_salt_size.has_value(),
+                         "PK_Signature_Options::with_salt_size cannot specify salt size twice");
+   BOTAN_ARG_CHECK(salt_size <= 1024, "Unreasonable salt size");
+   auto next = (*this);
+   next.m_salt_size = salt_size;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_deterministic_signature(bool deterministic) {
+   BOTAN_STATE_CHECK_MSG(
+      !m_deterministic_sig,
+      "PK_Signature_Options::with_deterministic_signature cannot specify deterministic signature twice");
+   auto next = (*this);
+   next.m_deterministic_sig = deterministic;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_der_encoded_signature(bool der) {
+   BOTAN_STATE_CHECK_MSG(!m_use_der,
+                         "PK_Signature_Options::with_der_encoded_signature cannot specify DER encoding twice");
+   auto next = (*this);
+   next.m_use_der = der;
+   return next;
+}
+
+PK_Signature_Options PK_Signature_Options::with_explicit_trailer_field(bool trailer) {
+   BOTAN_STATE_CHECK_MSG(
+      !m_explicit_trailer_field,
+      "PK_Signature_Options::with_explicit_trailer_field cannot specify explicit trailer field twice");
+   auto next = (*this);
+   next.m_explicit_trailer_field = trailer;
+   return next;
+}
+
+namespace {
+
+bool provider_is_in_use(const std::optional<std::string>& provider) {
+   return provider.has_value() && !provider->empty() && *provider != "base";
+}
+
+}  // namespace
+
+bool PK_Signature_Options::using_provider() const {
+   note_examined(Option::Provider);
+   return provider_is_in_use(m_provider);
+}
+
+std::string PK_Signature_Options::hash_function_name() const {
+   note_examined(Option::Hash);
+
+   if(m_hash_fn.has_value()) {
+      return m_hash_fn.value();
+   }
+
+   throw Invalid_State("This signature scheme requires specifying a hash function");
+}
+
+uint32_t PK_Signature_Options::options_in_use() const {
+   uint32_t in_use = 0;
+
+   auto set_if = [&](bool cond, Option option) {
+      if(cond) {
+         in_use |= static_cast<uint32_t>(option);
+      }
+   };
+
+   set_if(m_hash_fn.has_value(), Option::Hash);
+   set_if(m_using_prehash, Option::Prehash);
+   set_if(m_using_external_prehash, Option::ExternalPrehash);
+   set_if(m_padding.has_value(), Option::Padding);
+   set_if(m_context.has_value(), Option::Context);
+   set_if(provider_is_in_use(m_provider), Option::Provider);
+   set_if(m_salt_size.has_value(), Option::SaltSize);
+   set_if(m_use_der, Option::DerEncoded);
+   set_if(m_deterministic_sig, Option::Deterministic);
+   set_if(m_explicit_trailer_field, Option::ExplicitTrailer);
+
+   return in_use;
+}
+
+void PK_Signature_Options::throw_if_unexamined(std::string_view algo_name) const {
+   const uint32_t unexamined = options_in_use() & ~m_examined;
+
+   if(unexamined == 0) {
+      return;
+   }
+
+   const std::vector<std::pair<Option, std::string_view>> option_names = {
+      {Option::Hash, "hash"},
+      {Option::Prehash, "prehash"},
+      {Option::Padding, "padding"},
+      {Option::Context, "context"},
+      {Option::Provider, "provider"},
+      {Option::SaltSize, "salt size"},
+      {Option::DerEncoded, "DER encoding"},
+      {Option::Deterministic, "deterministic"},
+      {Option::ExplicitTrailer, "explicit trailer field"},
+      {Option::ExternalPrehash, "externally computed prehash"},
+   };
+
+   std::string names;
+   for(const auto& [option, name] : option_names) {
+      if((unexamined & static_cast<uint32_t>(option)) != 0) {
+         if(!names.empty()) {
+            names += ", ";
+         }
+         names += name;
+      }
+   }
+
+   throw Invalid_Argument(fmt("{} does not support the signature option(s): {}", algo_name, names));
+}
+
+std::string PK_Signature_Options::to_string() const {
+   std::ostringstream out;
+
+   auto print_str = [&](std::string_view name, std::optional<std::string> val) {
+      if(val.has_value()) {
+         out << name << "='" << val.value() << "' ";
+      }
+   };
+
+   // This reads the members directly since formatting the options does not
+   // count as the signature scheme having examined them
+
+   print_str("Hash", m_hash_fn);
+   print_str("Padding", m_padding);
+   print_str("Provider", m_provider);
+
+   if(m_using_prehash) {
+      out << "Prehash=" << m_prehash.value_or("default") << " ";
+   }
+   if(m_using_external_prehash) {
+      out << "ExternalPrehash=" << m_external_prehash.value_or("unspecified") << " ";
+   }
+
+   if(m_context) {
+      out << "Context=" << hex_encode(*m_context) << " ";
+   }
+
+   if(m_salt_size) {
+      out << "SaltLen=" << *m_salt_size << " ";
+   }
+   if(m_use_der) {
+      out << "DerSignature ";
+   }
+   if(m_deterministic_sig) {
+      out << "Deterministic ";
+   }
+   if(m_explicit_trailer_field) {
+      out << "ExplicitTrailer ";
+   }
+
+   return out.str();
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/pk_options.h
+++ b/src/lib/pubkey/pk_options.h
@@ -1,0 +1,197 @@
+/*
+* (C) 2024,2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_PK_OPTIONS_H_
+#define BOTAN_PK_OPTIONS_H_
+
+#include <botan/pk_keys.h>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Botan {
+
+/**
+* Signature generation/verification options
+*
+* The normal usage of this is in a builder style, eg
+*
+* PK_Signature_Options()
+*   .with_hash("SHA-256")
+*   .with_der_encoded_signature()
+*   .with_context("Foo")
+*/
+class BOTAN_PUBLIC_API(3, 6) PK_Signature_Options {
+   public:
+      /// Create an empty PK_Signature_Options
+      ///
+      /// This can be further parameterized by calling with_xxx functions
+      PK_Signature_Options() = default;
+
+      PK_Signature_Options(PK_Signature_Options&& other) = default;
+      PK_Signature_Options& operator=(PK_Signature_Options&& other) = default;
+
+      PK_Signature_Options(const PK_Signature_Options&) = default;
+      PK_Signature_Options& operator=(const PK_Signature_Options& other) = default;
+      ~PK_Signature_Options();
+
+      /// Format this PK_Signature_Options as a string
+      ///
+      /// This is primarily intended for debugging and error messages;
+      /// the format is not fixed
+      std::string to_string() const;
+
+      /// Create a PK_Signature_Options specifying the hash to use
+      ///
+      /// Most but not all signture schemes require specifying the hash
+      ///
+      /// This can be further parameterized by calling with_xxx functions
+      explicit PK_Signature_Options(std::string_view hash_fn) : m_hash_fn(hash_fn) {}
+
+      /// Specify the hash function to use for signing/verification
+      ///
+      /// Most, but not all, schemes require specifying a hash function.
+      PK_Signature_Options with_hash(std::string_view hash);
+
+      /// Specify a padding scheme
+      ///
+      /// This is mostly/only used for RSA
+      ///
+      /// If the scheme does not support a padding option, it will throw an
+      /// exception when presented with such an option.
+      PK_Signature_Options with_padding(std::string_view padding);
+
+      /// Specify the signature is prehashed
+      ///
+      /// Some signature schemes, such as Ed25519, normally sign the
+      /// entire message along with some context data. However such
+      /// schemes also sometimes offer a prehashing variant where the
+      /// message is hashed on its own, then the hash is signed.
+      ///
+      /// If given this specifies what hash function to use for prehashing.
+      /// If prehash is nullopt, this requests prehashing using an algorithm
+      /// specific default function
+      ///
+      /// If the scheme does not support prehashing, it will throw an
+      /// exception when presented with such an option.
+      PK_Signature_Options with_prehash(std::optional<std::string> prehash = std::nullopt);
+
+      /// Specify a context
+      ///
+      /// Some signature schemes allow specifying a context with the signature.
+      /// This is typically a fixed string that identifies a protocol or peer.
+      ///
+      /// For SM2 this context is the user identifier
+      ///
+      /// If the scheme does not support contextual identifiers, then an exception
+      /// will be thrown.
+      PK_Signature_Options with_context(std::span<const uint8_t> context);
+
+      /// Specify a context as a string
+      ///
+      /// Equivalent to the version taking a span above; just uses the bytes
+      /// of the string instead.
+      PK_Signature_Options with_context(std::string_view context);
+
+      /// Specify the size of salt to be used
+      ///
+      /// A small number of padding schemes (most importantly RSA-PSS) use a randomized
+      /// salt. This allows controlling the size of the salt that is used.
+      PK_Signature_Options with_salt_size(size_t salt_size);
+
+      /// Request producing a deterministic signature
+      ///
+      /// Some signature schemes are always deterministic, or always randomized.
+      /// Others support both randomized or deterministic options. This allows
+      /// requesting this. For signatures which are always deterministic or
+      /// always randomized, this option has no effect.
+      ///
+      /// This option is ignored for verification
+      PK_Signature_Options with_deterministic_signature(bool deterministic = true);
+
+      /// Specify producing or expecting a DER encoded signature
+      ///
+      /// This is mostly used with ECDSA
+      ///
+      /// For schemes that do not support such formatting (such as RSA
+      /// or post-quantum schemes), an exception will be thrown when the
+      /// PK_Signer or PK_Verifier is created.
+      PK_Signature_Options with_der_encoded_signature(bool der = true);
+
+      /// Specify producing or expecting an explicit trailer field
+      ///
+      /// Certain RSA padding schemes, such as PSS and ISO-9796, support two
+      /// different trailer fields. One is an "implicit" trailer, which does not
+      /// directly identify the hash. The other is an "explicit" trailer, which
+      /// does.
+      ///
+      /// Note that currently this option is only supported by ISO-9796. While
+      /// some standards allow PSS to use a trailer field, others (such as RFC
+      /// 4055) prohibit using explicit trailers for PSS, and it is not
+      /// currently supported.
+      ///
+      PK_Signature_Options with_explicit_trailer_field(bool trailer = true);
+
+      /// Specify a provider that should be used
+      ///
+      /// This is rarely relevant
+      PK_Signature_Options with_provider(std::string_view provider);
+
+      /// Return the name of the hash function to use
+      ///
+      /// This will throw an exception if no hash function was configured
+      std::string hash_function_name() const;
+
+      // Getters; these are mostly for internal use
+
+      const std::optional<std::string>& hash_function() const { return m_hash_fn; }
+
+      const std::optional<std::string>& prehash_function() const { return m_prehash; }
+
+      const std::optional<std::string>& padding() const { return m_padding; }
+
+      const std::optional<std::vector<uint8_t>>& context() const { return m_context; }
+
+      const std::optional<std::string>& provider() const { return m_provider; }
+
+      const std::optional<size_t>& salt_size() const { return m_salt_size; }
+
+      bool using_der_encoded_signature() const { return m_use_der; }
+
+      bool using_deterministic_signature() const { return m_deterministic_sig; }
+
+      bool using_explicit_trailer_field() const { return m_explicit_trailer_field; }
+
+      bool using_hash() const { return hash_function().has_value(); }
+
+      bool using_context() const { return context().has_value(); }
+
+      bool using_prehash() const { return m_using_prehash; }
+
+      bool using_padding() const { return padding().has_value(); }
+
+      bool using_salt_size() const { return salt_size().has_value(); }
+
+      bool using_provider() const;
+
+   private:
+      std::optional<std::string> m_hash_fn;
+      std::optional<std::string> m_prehash;
+      std::optional<std::string> m_padding;
+      std::optional<std::vector<uint8_t>> m_context;
+      std::optional<std::string> m_provider;
+      std::optional<size_t> m_salt_size;
+      bool m_using_prehash = false;
+      bool m_use_der = false;
+      bool m_deterministic_sig = false;
+      bool m_explicit_trailer_field = false;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pk_options.h
+++ b/src/lib/pubkey/pk_options.h
@@ -1,0 +1,308 @@
+/*
+* (C) 2024,2025 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_PK_OPTIONS_H_
+#define BOTAN_PK_OPTIONS_H_
+
+#include <botan/pk_keys.h>
+#include <optional>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Botan {
+
+class PK_Signer;
+class PK_Verifier;
+
+/**
+* Signature generation/verification options
+*
+* The normal usage of this is in a builder style, eg
+*
+* PK_Signature_Options()
+*   .with_hash("SHA-256")
+*   .with_der_encoded_signature()
+*   .with_context("Foo")
+*
+* Every option that is set must be understood by the signature scheme in use.
+* If a scheme does not support an option (for example a context for RSA, or a
+* salt for Ed25519) then constructing the PK_Signer or PK_Verifier throws an
+* exception; an option is never silently ignored.
+*/
+class BOTAN_PUBLIC_API(3, 14) PK_Signature_Options final {
+   public:
+      /// Create an empty PK_Signature_Options
+      ///
+      /// This can be further parameterized by calling with_xxx functions
+      PK_Signature_Options() = default;
+
+      PK_Signature_Options(PK_Signature_Options&& other) = default;
+      PK_Signature_Options& operator=(PK_Signature_Options&& other) = default;
+
+      PK_Signature_Options(const PK_Signature_Options&) = default;
+      PK_Signature_Options& operator=(const PK_Signature_Options& other) = default;
+      ~PK_Signature_Options();
+
+      /// Format this PK_Signature_Options as a string
+      ///
+      /// This is primarily intended for debugging and error messages;
+      /// the format is not fixed
+      std::string to_string() const;
+
+      /// Specify the hash function to use for signing/verification
+      ///
+      /// Most, but not all, schemes require specifying a hash function.
+      PK_Signature_Options with_hash(std::string_view hash);
+
+      /// Specify a padding scheme
+      ///
+      /// This is mostly/only used for RSA
+      ///
+      /// If the scheme does not support a padding option, it will throw an
+      /// exception when presented with such an option.
+      PK_Signature_Options with_padding(std::string_view padding);
+
+      /// Request that the library prehash the message
+      ///
+      /// Some signature schemes, such as Ed25519, normally sign the
+      /// entire message along with some context data. However such
+      /// schemes also sometimes offer a prehashing variant where the
+      /// message is hashed on its own, then the hash is signed.
+      ///
+      /// With this option the library computes the prehash itself; the
+      /// caller still provides the full message. If given this specifies
+      /// what hash function to use for prehashing. If prehash is nullopt,
+      /// this requests prehashing using an algorithm specific default
+      /// function.
+      ///
+      /// If the scheme does not support prehashing, it will throw an
+      /// exception when presented with such an option.
+      ///
+      /// This cannot be combined with with_externally_computed_prehash
+      PK_Signature_Options with_prehash(std::optional<std::string> prehash = std::nullopt);
+
+      /// Specify that the caller has already hashed the message
+      ///
+      /// With this option the data passed to the signature operation is
+      /// not the message but a hash of it, which the caller computed. The
+      /// library signs (or verifies) the provided digest directly, without
+      /// hashing it again.
+      ///
+      /// The hash function that was used can be named either here or via
+      /// with_hash (if both are given they must agree). Naming it allows
+      /// the scheme to check the digest length and to identify the hash in
+      /// the signature where the format requires it (for example the
+      /// PKCS #1 v1.5 DigestInfo). If no hash is named the input is signed
+      /// as an opaque byte string.
+      ///
+      /// @warning Signing externally computed hashes is easy to get wrong
+      /// and many ways of doing it are insecure. Don't use this unless you
+      /// know what you are doing.
+      ///
+      /// If the scheme does not support signing an externally computed hash,
+      /// it will throw an exception when presented with such an option.
+      ///
+      /// This cannot be combined with with_prehash
+      PK_Signature_Options with_externally_computed_prehash(std::optional<std::string> hash = std::nullopt);
+
+      /// Specify a context
+      ///
+      /// Some signature schemes allow specifying a context with the signature.
+      /// This is typically a fixed string that identifies a protocol or peer.
+      ///
+      /// For SM2 this context is the user identifier
+      ///
+      /// If the scheme does not support contextual identifiers, then an exception
+      /// will be thrown.
+      PK_Signature_Options with_context(std::span<const uint8_t> context);
+
+      /// Specify a context as a string
+      ///
+      /// Equivalent to the version taking a span above; just uses the bytes
+      /// of the string instead.
+      PK_Signature_Options with_context(std::string_view context);
+
+      /// Specify the size of salt to be used
+      ///
+      /// A small number of padding schemes (most importantly RSA-PSS) use a randomized
+      /// salt. This allows controlling the size of the salt that is used.
+      PK_Signature_Options with_salt_size(size_t salt_size);
+
+      /// Request producing a deterministic signature
+      ///
+      /// Some signature schemes are always deterministic, or always randomized.
+      /// Others support both randomized or deterministic options. This allows
+      /// requesting this. For signatures which are always deterministic this
+      /// option has no effect. Schemes which can only produce randomized
+      /// signatures reject this option.
+      ///
+      /// This option is ignored for verification
+      PK_Signature_Options with_deterministic_signature(bool deterministic = true);
+
+      /// Specify producing or expecting a DER encoded signature
+      ///
+      /// This is mostly used with ECDSA
+      ///
+      /// For schemes that do not support such formatting (such as RSA
+      /// or post-quantum schemes), an exception will be thrown when the
+      /// PK_Signer or PK_Verifier is created.
+      PK_Signature_Options with_der_encoded_signature(bool der = true);
+
+      /// Specify producing or expecting an explicit trailer field
+      ///
+      /// Certain RSA padding schemes, such as PSS and ISO-9796, support two
+      /// different trailer fields. One is an "implicit" trailer, which does not
+      /// directly identify the hash. The other is an "explicit" trailer, which
+      /// does.
+      ///
+      /// Note that currently this option is only supported by ISO-9796. While
+      /// some standards allow PSS to use a trailer field, others (such as RFC
+      /// 4055) prohibit using explicit trailers for PSS, and it is not
+      /// currently supported.
+      ///
+      PK_Signature_Options with_explicit_trailer_field(bool trailer = true);
+
+      /// Specify a provider that should be used
+      ///
+      /// This is rarely relevant
+      PK_Signature_Options with_provider(std::string_view provider);
+
+      /// Return the name of the hash function to use
+      ///
+      /// This will throw an exception if no hash function was configured
+      std::string hash_function_name() const;
+
+      /*
+      * Getters; these are mostly for internal use
+      *
+      * Calling any of these records that the respective option was examined by
+      * the signature scheme (see PK_Signature_Options::Option below), so a scheme
+      * should only read an option that it will actually act on.
+      */
+
+      const std::optional<std::string>& hash_function() const {
+         note_examined(Option::Hash);
+         return m_hash_fn;
+      }
+
+      const std::optional<std::string>& prehash_function() const {
+         note_examined(Option::Prehash);
+         return m_prehash;
+      }
+
+      const std::optional<std::string>& externally_computed_prehash_function() const {
+         note_examined(Option::ExternalPrehash);
+         return m_external_prehash;
+      }
+
+      const std::optional<std::string>& padding() const {
+         note_examined(Option::Padding);
+         return m_padding;
+      }
+
+      const std::optional<std::vector<uint8_t>>& context() const {
+         note_examined(Option::Context);
+         return m_context;
+      }
+
+      const std::optional<std::string>& provider() const {
+         note_examined(Option::Provider);
+         return m_provider;
+      }
+
+      const std::optional<size_t>& salt_size() const {
+         note_examined(Option::SaltSize);
+         return m_salt_size;
+      }
+
+      bool using_der_encoded_signature() const {
+         note_examined(Option::DerEncoded);
+         return m_use_der;
+      }
+
+      bool using_deterministic_signature() const {
+         note_examined(Option::Deterministic);
+         return m_deterministic_sig;
+      }
+
+      bool using_explicit_trailer_field() const {
+         note_examined(Option::ExplicitTrailer);
+         return m_explicit_trailer_field;
+      }
+
+      bool using_hash() const { return hash_function().has_value(); }
+
+      bool using_context() const { return context().has_value(); }
+
+      bool using_prehash() const {
+         note_examined(Option::Prehash);
+         return m_using_prehash;
+      }
+
+      bool using_externally_computed_prehash() const {
+         note_examined(Option::ExternalPrehash);
+         return m_using_external_prehash;
+      }
+
+      bool using_padding() const { return padding().has_value(); }
+
+      bool using_salt_size() const { return salt_size().has_value(); }
+
+      bool using_provider() const;
+
+   private:
+      friend class PK_Signer;
+      friend class PK_Verifier;
+
+      /*
+      * Each option a caller sets must be examined by whatever creates the
+      * signature operation, otherwise the option would be silently ignored.
+      * The getters above record which options were examined; PK_Signer and
+      * PK_Verifier then reject any option that was set but never examined.
+      */
+      enum class Option : uint32_t /* NOLINT(*-enum-size) */ {
+         Hash = (1 << 0),
+         Prehash = (1 << 1),
+         Padding = (1 << 2),
+         Context = (1 << 3),
+         Provider = (1 << 4),
+         SaltSize = (1 << 5),
+         DerEncoded = (1 << 6),
+         Deterministic = (1 << 7),
+         ExplicitTrailer = (1 << 8),
+         ExternalPrehash = (1 << 9),
+      };
+
+      void note_examined(Option option) const { m_examined |= static_cast<uint32_t>(option); }
+
+      /// Return the bitmask of options which were set to a non-default value
+      uint32_t options_in_use() const;
+
+      void reset_examined() const { m_examined = 0; }
+
+      /// Throw Invalid_Argument if any option in use has not been examined
+      void throw_if_unexamined(std::string_view algo_name) const;
+
+      std::optional<std::string> m_hash_fn;
+      std::optional<std::string> m_prehash;
+      std::optional<std::string> m_external_prehash;
+      std::optional<std::string> m_padding;
+      std::optional<std::vector<uint8_t>> m_context;
+      std::optional<std::string> m_provider;
+      std::optional<size_t> m_salt_size;
+      bool m_using_prehash = false;
+      bool m_using_external_prehash = false;
+      bool m_use_der = false;
+      bool m_deterministic_sig = false;
+      bool m_explicit_trailer_field = false;
+      mutable uint32_t m_examined = 0;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pk_options_impl.cpp
+++ b/src/lib/pubkey/pk_options_impl.cpp
@@ -1,0 +1,222 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/pk_options_impl.h>
+
+#include <botan/exceptn.h>
+#include <botan/pk_options.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/scan_name.h>
+
+namespace Botan {
+
+PK_Signature_Options parse_legacy_sig_options(const Public_Key& key, std::string_view params) {
+   /*
+   * This is a convoluted mess because we must handle dispatch for every algorithm
+   * specific detail of how padding strings were formatted in versions prior to 3.6.
+   *
+   * This will all go away once the deprecated constructors of PK_Signer and PK_Verifier
+   * are removed in Botan4.
+   */
+
+   const std::string algo = key.algo_name();
+
+   if(algo.starts_with("Dilithium") || algo.starts_with("ML-DSA") || algo == "SLH-DSA" || algo == "SPHINCS+") {
+      if(!params.empty() && params != "Randomized" && params != "Deterministic" && params != "Pure") {
+         throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+      }
+
+      if(params == "Deterministic" || params == "Pure") {
+         return PK_Signature_Options().with_deterministic_signature();
+      } else {
+         return PK_Signature_Options();
+      }
+   }
+
+   if(algo == "SM2") {
+      /*
+      * SM2 parameters have the following possible formats:
+      * Ident [since 2.2.0]
+      * Ident,Hash [since 2.3.0]
+      */
+      if(params.empty()) {
+         return PK_Signature_Options().with_hash("SM3");
+      } else {
+         std::string userid;
+         std::string hash = "SM3";
+         auto comma = params.find(',');
+         if(comma == std::string::npos) {
+            userid = params;
+         } else {
+            userid = params.substr(0, comma);
+            hash = params.substr(comma + 1, std::string::npos);
+         }
+         return PK_Signature_Options(hash).with_context(userid);
+      }
+   }
+
+   if(algo == "Ed25519") {
+      if(params.empty() || params == "Identity" || params == "Pure") {
+         return PK_Signature_Options();
+      } else if(params == "Ed25519ph") {
+         return PK_Signature_Options().with_prehash();
+      } else {
+         return PK_Signature_Options().with_prehash(std::string(params));
+      }
+   }
+
+   if(algo == "Ed448") {
+      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
+         return PK_Signature_Options();
+      } else if(params == "Ed448ph") {
+         return PK_Signature_Options().with_prehash();
+      } else {
+         return PK_Signature_Options().with_prehash(std::string(params));
+      }
+   }
+
+   if(algo == "RSA") {
+      SCAN_Name req(params);
+
+      // handling various deprecated aliases that have accumulated over the years ...
+      auto padding = [](std::string_view alg) -> std::string_view {
+         // TODO(Botan4) Remove all but "PKCSv15"
+         if(alg == "EMSA_PKCS1" || alg == "EMSA-PKCS1-v1_5" || alg == "EMSA3") {
+            return "PKCS1v15";
+         }
+
+         // TODO(Botan4) Remove this alias
+         if(alg == "PSSR_Raw") {
+            return "PSS_Raw";
+         }
+
+         // TODO(Botan4) Remove all but "PSS"
+         if(alg == "PSSR" || alg == "EMSA-PSS" || alg == "PSS-MGF1" || alg == "EMSA4") {
+            return "PSS";
+         }
+
+         // TODO(Botan4) Remove all but "X9.31"
+         if(alg == "EMSA_X931" || alg == "EMSA2" || alg == "X9.31") {
+            return "X9.31";
+         }
+
+         return alg;
+      }(req.algo_name());
+
+      if(padding == "Raw") {
+         if(req.arg_count() == 0) {
+            return PK_Signature_Options().with_padding(padding);
+         } else if(req.arg_count() == 1) {
+            return PK_Signature_Options().with_padding(padding).with_prehash(req.arg(0));
+         }
+      }
+
+      if(padding == "PKCS1v15") {
+         if(req.arg_count() == 2 && req.arg(0) == "Raw") {
+            return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0)).with_prehash(req.arg(1));
+         } else if(req.arg_count() == 1) {
+            return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+         }
+      }
+
+      if(padding == "PSS_Raw" || padding == "PSS") {
+         if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
+            auto pss_opt = PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+
+            if(req.arg_count() == 3) {
+               return std::move(pss_opt).with_salt_size(req.arg_as_integer(2));
+            } else {
+               return pss_opt;
+            }
+         }
+      }
+
+      if(padding == "ISO_9796_DS2") {
+         if(req.arg_count_between(1, 3)) {
+            // FIXME
+            const bool implicit = req.arg(1, "exp") == "imp";
+
+            auto opt = PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+
+            if(req.arg_count() == 3) {
+               if(implicit) {
+                  return std::move(opt).with_salt_size(req.arg_as_integer(2));
+               } else {
+                  return std::move(opt).with_salt_size(req.arg_as_integer(2)).with_explicit_trailer_field();
+               }
+            } else {
+               if(implicit) {
+                  return opt;
+               } else {
+                  return std::move(opt).with_explicit_trailer_field();
+               }
+            }
+         }
+      }
+
+      //ISO-9796-2 DS 3 is deterministic and DS2 without a salt
+      if(padding == "ISO_9796_DS3") {
+         if(req.arg_count_between(1, 2)) {
+            if(req.arg(1, "exp") == "imp") {
+               return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+            } else {
+               return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0)).with_explicit_trailer_field();
+            }
+         }
+      }
+
+      if(padding == "X9.31" && req.arg_count() == 1) {
+         return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+      }
+   }  // RSA block
+
+   if(params.empty()) {
+      return PK_Signature_Options();
+   }
+
+   // ECDSA/DSA/ECKCDSA/etc
+   auto hash = [&]() {
+      if(params.starts_with("EMSA1")) {
+         SCAN_Name req(params);
+         return req.arg(0);
+      } else {
+         return std::string(params);
+      }
+   }();
+
+   return PK_Signature_Options().with_hash(hash);
+}
+
+void validate_for_hash_based_signature(const PK_Signature_Options& options,
+                                       std::string_view algo_name,
+                                       std::string_view hash_fn) {
+   if(options.using_hash()) {
+      if(hash_fn.empty()) {
+         throw Invalid_Argument(fmt("This {} key does not support explicit hash function choice", algo_name));
+      } else if(options.hash_function_name() != hash_fn) {
+         throw Invalid_Argument(
+            fmt("This {} key can only be used with {}, not {}", algo_name, hash_fn, options.hash_function_name()));
+      }
+   }
+
+   if(options.using_padding()) {
+      throw Invalid_Argument(fmt("{} does not support padding modes", algo_name));
+   }
+
+   if(options.using_prehash()) {
+      throw Invalid_Argument(fmt("{} does not support prehashing", algo_name));
+   }
+
+   if(options.using_salt_size()) {
+      throw Invalid_Argument(fmt("{} does not support a salt", algo_name));
+   }
+
+   if(options.using_explicit_trailer_field()) {
+      throw Invalid_Argument(fmt("{} does not support a padding trailer field", algo_name));
+   }
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/pk_options_impl.cpp
+++ b/src/lib/pubkey/pk_options_impl.cpp
@@ -1,0 +1,273 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/pk_options_impl.h>
+
+#include <botan/assert.h>
+#include <botan/exceptn.h>
+#include <botan/pk_options.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/scan_name.h>
+
+namespace Botan {
+
+PK_Signature_Options parse_legacy_sig_options(const Public_Key& key, std::string_view params) {
+   /*
+   * This is a convoluted mess because we must handle dispatch for every algorithm
+   * specific detail of how padding strings were formatted in versions prior to the
+   * introduction of PK_Signature_Options.
+   *
+   * This will all go away once the deprecated constructors of PK_Signer and PK_Verifier
+   * are removed in Botan4.
+   */
+
+   const std::string algo = key.algo_name();
+
+   if(algo.starts_with("Dilithium") || algo.starts_with("ML-DSA") || algo == "SLH-DSA" || algo == "SPHINCS+") {
+      if(!params.empty() && params != "Randomized" && params != "Deterministic" && params != "Pure") {
+         throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+      }
+
+      if(params == "Deterministic" || params == "Pure") {
+         return PK_Signature_Options().with_deterministic_signature();
+      } else {
+         return PK_Signature_Options();
+      }
+   }
+
+   if(algo == "SM2") {
+      /*
+      * SM2 parameters have the following possible formats:
+      * Ident [since 2.2.0]
+      * Ident,Hash [since 2.3.0]
+      *
+      * Historically a completely empty parameter string was treated as
+      * if the identity was empty. This probably should have instead been
+      * treated as if it was the "default userid" ("1234567812345678") but
+      * there was a bug and it wasn't.
+      *
+      * TODO(Botan4) evaluate if this should be changed
+      */
+      std::string userid;
+      std::string hash = "SM3";
+      auto comma = params.find(',');
+      if(comma == std::string::npos) {
+         userid = params;
+      } else {
+         userid = params.substr(0, comma);
+         hash = params.substr(comma + 1, std::string::npos);
+      }
+
+      // With a "Raw" hash there is no ZA computation, and the identity was always ignored
+      if(hash == "Raw") {
+         return PK_Signature_Options().with_externally_computed_prehash();
+      }
+
+      return PK_Signature_Options().with_hash(hash).with_context(userid);
+   }
+
+   if(algo == "Ed25519") {
+      if(params.empty() || params == "Identity" || params == "Pure") {
+         return PK_Signature_Options();
+      } else if(params == "Ed25519ph") {
+         return PK_Signature_Options().with_prehash();
+      } else {
+         return PK_Signature_Options().with_prehash(std::string(params));
+      }
+   }
+
+   if(algo == "Ed448") {
+      if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
+         return PK_Signature_Options();
+      } else if(params == "Ed448ph") {
+         return PK_Signature_Options().with_prehash();
+      } else {
+         return PK_Signature_Options().with_prehash(std::string(params));
+      }
+   }
+
+   if(algo == "RSA") {
+      const SCAN_Name req(params);
+
+      // handling various deprecated aliases that have accumulated over the years ...
+      auto padding = [](std::string_view alg) -> std::string_view {
+         // TODO(Botan4) Remove all but "PKCSv15"
+         if(alg == "EMSA_PKCS1" || alg == "EMSA-PKCS1-v1_5" || alg == "EMSA3") {
+            return "PKCS1v15";
+         }
+
+         // TODO(Botan4) Remove this alias
+         if(alg == "PSSR_Raw") {
+            return "PSS_Raw";
+         }
+
+         // TODO(Botan4) Remove all but "PSS"
+         if(alg == "PSSR" || alg == "EMSA-PSS" || alg == "PSS-MGF1" || alg == "EMSA4") {
+            return "PSS";
+         }
+
+         // TODO(Botan4) Remove all but "X9.31"
+         if(alg == "EMSA_X931" || alg == "EMSA2" || alg == "X9.31") {
+            return "X9.31";
+         }
+
+         return alg;
+      }(req.algo_name());
+
+      if(padding == "Raw") {
+         if(req.arg_count() == 0) {
+            return PK_Signature_Options().with_padding(padding);
+         } else if(req.arg_count() == 1) {
+            return PK_Signature_Options().with_padding(padding).with_externally_computed_prehash(req.arg(0));
+         }
+      }
+
+      if(padding == "PKCS1v15") {
+         if(req.arg_count() == 2 && req.arg(0) == "Raw") {
+            return PK_Signature_Options().with_padding(padding).with_externally_computed_prehash(req.arg(1));
+         } else if(req.arg_count() == 1 && req.arg(0) == "Raw") {
+            return PK_Signature_Options().with_padding(padding).with_externally_computed_prehash();
+         } else if(req.arg_count() == 1) {
+            return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+         }
+      }
+
+      // Only supported by PKCS#11 (CKM_RSA_9796)
+      if(padding == "ISO9796" && req.arg_count() == 0) {
+         return PK_Signature_Options().with_padding(padding);
+      }
+
+      if(padding == "PSS" && req.arg_count() == 1 && req.arg(0) == "Raw") {
+         return PK_Signature_Options().with_padding(padding).with_externally_computed_prehash();
+      }
+
+      if(padding == "PSS_Raw" || padding == "PSS") {
+         if(req.arg_count_between(1, 3) && req.arg(1, "MGF1") == "MGF1") {
+            auto pss_opt = PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+
+            if(req.arg_count() == 3) {
+               return std::move(pss_opt).with_salt_size(req.arg_as_integer(2));
+            } else {
+               return pss_opt;
+            }
+         }
+      }
+
+      if(padding == "ISO_9796_DS2") {
+         if(req.arg_count_between(1, 3)) {
+            const std::string trailer = req.arg(1, "exp");
+            if(trailer != "imp" && trailer != "exp") {
+               throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+            }
+
+            auto opt = PK_Signature_Options()
+                          .with_padding(padding)
+                          .with_hash(req.arg(0))
+                          .with_explicit_trailer_field(trailer == "exp");
+
+            if(req.arg_count() == 3) {
+               return std::move(opt).with_salt_size(req.arg_as_integer(2));
+            } else {
+               return opt;
+            }
+         }
+      }
+
+      //ISO-9796-2 DS 3 is deterministic and DS2 without a salt
+      if(padding == "ISO_9796_DS3") {
+         if(req.arg_count_between(1, 2)) {
+            const std::string trailer = req.arg(1, "exp");
+            if(trailer != "imp" && trailer != "exp") {
+               throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+            }
+
+            return PK_Signature_Options()
+               .with_padding(padding)
+               .with_hash(req.arg(0))
+               .with_explicit_trailer_field(trailer == "exp");
+         }
+      }
+
+      if(padding == "X9.31" && req.arg_count() == 1) {
+         if(req.arg(0) == "Raw") {
+            return PK_Signature_Options().with_padding(padding).with_externally_computed_prehash();
+         }
+         return PK_Signature_Options().with_padding(padding).with_hash(req.arg(0));
+      }
+   }  // RSA block
+
+   if(params.empty()) {
+      return PK_Signature_Options();
+   }
+
+   // ECDSA/DSA/ECKCDSA/etc
+
+   /*
+   * Stopgap until PK_Signature_Options is exposed through the FFI: a
+   * trailing ",Deterministic" (eg "SHA-256,Deterministic") requests a
+   * deterministic signature, so that RFC 6979 ECDSA remains reachable
+   * through the string based interfaces.
+   */
+   const std::string_view det_suffix = ",Deterministic";
+   const bool deterministic = params.ends_with(det_suffix);
+   const std::string_view hash_params = deterministic ? params.substr(0, params.size() - det_suffix.size()) : params;
+
+   // "Raw" or "Raw(hash)" means the caller provides the digest
+   if(hash_params.starts_with("Raw")) {
+      const SCAN_Name req(hash_params);
+      if(req.algo_name() != "Raw" || req.arg_count() > 1) {
+         throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+      }
+      auto raw_opt = PK_Signature_Options().with_deterministic_signature(deterministic);
+      if(req.arg_count() == 1) {
+         return std::move(raw_opt).with_externally_computed_prehash(req.arg(0));
+      }
+      return std::move(raw_opt).with_externally_computed_prehash();
+   }
+
+   auto hash = [&]() -> std::string {
+      if(hash_params.starts_with("EMSA1")) {
+         const SCAN_Name req(hash_params);
+         if(req.algo_name() != "EMSA1" || req.arg_count() != 1) {
+            throw Invalid_Argument(fmt("Unexpected parameters '{}' for signing with {}", params, algo));
+         }
+         return req.arg(0);
+      } else {
+         return std::string(hash_params);
+      }
+   }();
+
+   return PK_Signature_Options().with_hash(hash).with_deterministic_signature(deterministic);
+}
+
+void validate_for_hash_based_signature(const PK_Signature_Options& options,
+                                       std::string_view algo_name,
+                                       std::string_view hash_fn) {
+   if(options.using_hash() && options.hash_function_name() != hash_fn) {
+      throw Invalid_Argument(
+         fmt("This {} key can only be used with {}, not {}", algo_name, hash_fn, options.hash_function_name()));
+   }
+}
+
+std::optional<std::string> externally_computed_prehash_name(const PK_Signature_Options& options) {
+   BOTAN_STATE_CHECK(options.using_externally_computed_prehash());
+
+   const auto& prehash = options.externally_computed_prehash_function();
+   const auto& hash = options.hash_function();
+
+   if(prehash.has_value() && hash.has_value() && *prehash != *hash) {
+      throw Invalid_Argument(
+         fmt("Externally computed prehash was named as {} but the hash option specified {}", *prehash, *hash));
+   }
+
+   return prehash.has_value() ? prehash : hash;
+}
+
+void acknowledge_always_deterministic(const PK_Signature_Options& options) {
+   BOTAN_UNUSED(options.using_deterministic_signature());
+}
+
+}  // namespace Botan

--- a/src/lib/pubkey/pk_options_impl.h
+++ b/src/lib/pubkey/pk_options_impl.h
@@ -1,0 +1,25 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_PK_OPTIONS_IMPL_H_
+#define BOTAN_PK_OPTIONS_IMPL_H_
+
+#include <botan/pk_options.h>
+#include <string_view>
+
+namespace Botan {
+
+class Public_Key;
+
+PK_Signature_Options parse_legacy_sig_options(const Public_Key& key, std::string_view params);
+
+void validate_for_hash_based_signature(const PK_Signature_Options& options,
+                                       std::string_view algo_name,
+                                       std::string_view hash_fn = "");
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pk_options_impl.h
+++ b/src/lib/pubkey/pk_options_impl.h
@@ -1,0 +1,51 @@
+/*
+* (C) 2024 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_PK_OPTIONS_IMPL_H_
+#define BOTAN_PK_OPTIONS_IMPL_H_
+
+#include <botan/pk_options.h>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace Botan {
+
+class Public_Key;
+
+PK_Signature_Options parse_legacy_sig_options(const Public_Key& key, std::string_view params);
+
+/**
+* For schemes where the hash function is fixed by the key (XMSS, SLH-DSA, ...)
+*
+* Accepts the hash option only if it names the hash the key already uses.
+*/
+void validate_for_hash_based_signature(const PK_Signature_Options& options,
+                                       std::string_view algo_name,
+                                       std::string_view hash_fn);
+
+/**
+* For schemes which can sign an externally computed prehash
+*
+* Returns the name of the hash function the caller used, if it was named
+* (either in the prehash option or via with_hash; if both were given they
+* must agree), or nullopt if the input is an unidentified digest.
+*
+* Must only be called if using_externally_computed_prehash() is true.
+*/
+std::optional<std::string> externally_computed_prehash_name(const PK_Signature_Options& options);
+
+/**
+* For schemes whose signatures are always deterministic
+*
+* Any request for a deterministic signature is trivially satisfied, so this
+* just examines (and thereby acknowledges) the option.
+*/
+void acknowledge_always_deterministic(const PK_Signature_Options& options);
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 1999-2010,2015,2018 Jack Lloyd
+* (C) 1999-2010,2015,2018,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -10,11 +10,13 @@
 #include <botan/bigint.h>
 #include <botan/der_enc.h>
 #include <botan/pk_ops.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/mem_utils.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -253,14 +255,27 @@ PK_Signer::PK_Signer(const Private_Key& key,
                      std::string_view padding,
                      Signature_Format format,
                      std::string_view provider) :
-      m_sig_format(format), m_sig_element_size(key._signature_element_size_for_DER_encoding()) {
-   if(m_sig_format == Signature_Format::DerSequence) {
-      BOTAN_ARG_CHECK(m_sig_element_size.has_value(), "This key does not support DER signatures");
+      PK_Signer(key,
+                rng,
+                parse_legacy_sig_options(key, padding)
+                   .with_der_encoded_signature(format == Signature_Format::DerSequence)
+                   .with_provider(provider)) {}
+
+PK_Signer::PK_Signer(const Private_Key& key, RandomNumberGenerator& rng, const PK_Signature_Options& options) {
+   if(options.using_context() && !key.supports_context_data()) {
+      throw Invalid_Argument(fmt("Key type {} does not support context information", key.algo_name()));
    }
 
-   m_op = key.create_signature_op(rng, padding, provider);
+   m_op = key._create_signature_op(rng, options);
+
    if(!m_op) {
       throw Invalid_Argument(fmt("Key type {} does not support signature generation", key.algo_name()));
+   }
+   m_sig_format = options.using_der_encoded_signature() ? Signature_Format::DerSequence : Signature_Format::Standard;
+   m_sig_element_size = key._signature_element_size_for_DER_encoding();
+
+   if(m_sig_format == Signature_Format::DerSequence && !m_sig_element_size.has_value()) {
+      throw Invalid_Argument(fmt("Key type {} does not support DER encoded signatures", key.algo_name()));
    }
 }
 
@@ -363,20 +378,31 @@ std::vector<uint8_t> PK_Signer::signature(RandomNumberGenerator& rng) {
    }
 }
 
-PK_Verifier::PK_Verifier(const Public_Key& key,
+PK_Verifier::PK_Verifier(const Public_Key& pub_key,
                          std::string_view padding,
                          Signature_Format format,
-                         std::string_view provider) {
-   m_op = key.create_verification_op(padding, provider);
+                         std::string_view provider) :
+      PK_Verifier(pub_key,
+                  parse_legacy_sig_options(pub_key, padding)
+                     .with_der_encoded_signature(format == Signature_Format::DerSequence)
+                     .with_provider(provider)) {}
+
+PK_Verifier::PK_Verifier(const Public_Key& key, const PK_Signature_Options& options) {
+   if(options.using_context() && !key.supports_context_data()) {
+      throw Invalid_Argument(fmt("Key type {} does not support context information", key.algo_name()));
+   }
+
+   m_op = key._create_verification_op(options);
+
    if(!m_op) {
       throw Invalid_Argument(fmt("Key type {} does not support signature verification", key.algo_name()));
    }
 
-   m_sig_format = format;
    m_sig_element_size = key._signature_element_size_for_DER_encoding();
+   m_sig_format = options.using_der_encoded_signature() ? Signature_Format::DerSequence : Signature_Format::Standard;
 
-   if(m_sig_format == Signature_Format::DerSequence) {
-      BOTAN_ARG_CHECK(m_sig_element_size.has_value(), "This key does not support DER signatures");
+   if(m_sig_format == Signature_Format::DerSequence && !m_sig_element_size.has_value()) {
+      throw Invalid_Argument(fmt("Key type {} does not support DER encoded signatures", key.algo_name()));
    }
 }
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 1999-2010,2015,2018 Jack Lloyd
+* (C) 1999-2010,2015,2018,2024 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -10,11 +10,13 @@
 #include <botan/bigint.h>
 #include <botan/der_enc.h>
 #include <botan/pk_ops.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/mem_utils.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -257,15 +259,30 @@ PK_Signer::PK_Signer(const Private_Key& key,
                      std::string_view padding,
                      Signature_Format format,
                      std::string_view provider) :
-      m_sig_format(format), m_sig_element_size(key._signature_element_size_for_DER_encoding()) {
-   if(m_sig_format == Signature_Format::DerSequence) {
-      BOTAN_ARG_CHECK(m_sig_element_size.has_value(), "This key does not support DER signatures");
-   }
+      PK_Signer(key,
+                rng,
+                parse_legacy_sig_options(key, padding)
+                   .with_der_encoded_signature(format == Signature_Format::DerSequence)
+                   .with_provider(provider)) {}
 
-   m_op = key.create_signature_op(rng, padding, provider);
+PK_Signer::PK_Signer(const Private_Key& key, RandomNumberGenerator& rng, const PK_Signature_Options& user_options) {
+   // Track option usage on a private copy, so the caller's object is never modified
+   const PK_Signature_Options options(user_options);  // NOLINT(*-unnecessary-copy-initialization) clang-tidy bug
+   options.reset_examined();
+
+   m_op = key._create_signature_op(rng, options);
+
    if(!m_op) {
       throw Invalid_Argument(fmt("Key type {} does not support signature generation", key.algo_name()));
    }
+   m_sig_format = options.using_der_encoded_signature() ? Signature_Format::DerSequence : Signature_Format::Standard;
+   m_sig_element_size = key._signature_element_size_for_DER_encoding();
+
+   if(m_sig_format == Signature_Format::DerSequence && !m_sig_element_size.has_value()) {
+      throw Invalid_Argument(fmt("Key type {} does not support DER encoded signatures", key.algo_name()));
+   }
+
+   options.throw_if_unexamined(key.algo_name());
 }
 
 AlgorithmIdentifier PK_Signer::algorithm_identifier() const {
@@ -367,21 +384,39 @@ std::vector<uint8_t> PK_Signer::signature(RandomNumberGenerator& rng) {
    }
 }
 
-PK_Verifier::PK_Verifier(const Public_Key& key,
+PK_Verifier::PK_Verifier(const Public_Key& pub_key,
                          std::string_view padding,
                          Signature_Format format,
-                         std::string_view provider) {
-   m_op = key.create_verification_op(padding, provider);
+                         std::string_view provider) :
+      PK_Verifier(pub_key,
+                  parse_legacy_sig_options(pub_key, padding)
+                     .with_der_encoded_signature(format == Signature_Format::DerSequence)
+                     .with_provider(provider)) {}
+
+PK_Verifier::PK_Verifier(const Public_Key& key, const PK_Signature_Options& user_options) {
+   // Track option usage on a private copy, so the caller's object is never modified
+   PK_Signature_Options options(user_options);
+
+   // The deterministic option only affects signature generation, so remove it
+   // here rather than have every verification operation know to ignore it
+   options.m_deterministic_sig = false;
+
+   options.reset_examined();
+
+   m_op = key._create_verification_op(options);
+
    if(!m_op) {
       throw Invalid_Argument(fmt("Key type {} does not support signature verification", key.algo_name()));
    }
 
-   m_sig_format = format;
    m_sig_element_size = key._signature_element_size_for_DER_encoding();
+   m_sig_format = options.using_der_encoded_signature() ? Signature_Format::DerSequence : Signature_Format::Standard;
 
-   if(m_sig_format == Signature_Format::DerSequence) {
-      BOTAN_ARG_CHECK(m_sig_element_size.has_value(), "This key does not support DER signatures");
+   if(m_sig_format == Signature_Format::DerSequence && !m_sig_element_size.has_value()) {
+      throw Invalid_Argument(fmt("Key type {} does not support DER encoded signatures", key.algo_name()));
    }
+
+   options.throw_if_unexamined(key.algo_name());
 }
 
 PK_Verifier::PK_Verifier(const Public_Key& key,

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -154,6 +154,18 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor {
 class BOTAN_PUBLIC_API(2, 0) PK_Signer final {
    public:
       /**
+      * Construct a PK signer
+      *
+      * @param key the key to use to generate signatures
+      * @param rng the random generator to use
+      * @param options controls the behavior of the signature generation, eg which hash function to use
+      *
+      * Note that most common algorithms (eg RSA or ECDSA) require an options
+      * parameter to specify at least which hash function to use.
+      */
+      PK_Signer(const Private_Key& key, RandomNumberGenerator& rng, const PK_Signature_Options& options);
+
+      /**
       * Construct a PK Signer.
       * @param key the key to use inside this signer
       * @param rng the random generator to use
@@ -273,7 +285,14 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       /**
       * Construct a PK Verifier.
       * @param pub_key the public key to verify against
-      * @param padding the padding/hash to use (eg "SHA-512" or "PSS(SHA-256)")
+      * @param options relating to the signature
+      */
+      PK_Verifier(const Public_Key& pub_key, const PK_Signature_Options& options);
+
+      /**
+      * Construct a PK Verifier.
+      * @param pub_key the public key to verify against
+      * @param padding the padding/hash to use (eg "EMSA_PKCS1(SHA-256)")
       * @param format the signature format to use
       * @param provider the provider to use
       */

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -10,6 +10,7 @@
 
 #include <botan/pk_keys.h>
 #include <botan/pk_ops_fwd.h>
+#include <botan/pk_options.h>
 #include <botan/symkey.h>
 #include <span>
 #include <string>
@@ -160,6 +161,21 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor {
 class BOTAN_PUBLIC_API(2, 0) PK_Signer final {
    public:
       /**
+      * Construct a PK signer
+      *
+      * @param key the key to use to generate signatures
+      * @param rng the random generator to use
+      * @param options controls the behavior of the signature generation, eg which hash function to use
+      *
+      * Note that most common algorithms (eg RSA or ECDSA) require an options
+      * parameter to specify at least which hash function to use. Schemes without
+      * any parameters (eg Ed25519, ML-DSA, XMSS) can be used with the default.
+      */
+      PK_Signer(const Private_Key& key,
+                RandomNumberGenerator& rng,
+                const PK_Signature_Options& options = PK_Signature_Options());
+
+      /**
       * Construct a PK Signer.
       * @param key the key to use inside this signer
       * @param rng the random generator to use
@@ -279,7 +295,15 @@ class BOTAN_PUBLIC_API(2, 0) PK_Verifier final {
       /**
       * Construct a PK Verifier.
       * @param pub_key the public key to verify against
-      * @param padding the padding/hash to use (eg "SHA-512" or "PSS(SHA-256)")
+      * @param options relating to the signature; schemes without any parameters
+      * (eg Ed25519, ML-DSA, XMSS) can be used with the default.
+      */
+      explicit PK_Verifier(const Public_Key& pub_key, const PK_Signature_Options& options = PK_Signature_Options());
+
+      /**
+      * Construct a PK Verifier.
+      * @param pub_key the public key to verify against
+      * @param padding the padding/hash to use (eg "EMSA_PKCS1(SHA-256)")
       * @param format the signature format to use
       * @param provider the provider to use
       */

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -22,6 +22,7 @@
 #include <botan/internal/mp_core.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/scan_name.h>
 #include <botan/internal/sig_padding.h>
 #include <botan/internal/target_info.h>
 #include <botan/internal/workfactor.h>
@@ -632,10 +633,15 @@ class RSA_Signature_Operation final : public PK_Ops::Signature,
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::string hash_function() const override { return m_padding->hash_function(); }
+      std::string hash_function() const override {
+         BOTAN_ASSERT_NONNULL(m_padding);
+         return m_padding->hash_function();
+      }
 
-      RSA_Signature_Operation(const RSA_PrivateKey& rsa, std::string_view padding, RandomNumberGenerator& rng) :
-            RSA_Private_Operation(rsa, rng), m_padding(SignaturePaddingScheme::create_or_throw(padding)) {}
+      RSA_Signature_Operation(const RSA_PrivateKey& rsa,
+                              const PK_Signature_Options& options,
+                              RandomNumberGenerator& rng) :
+            RSA_Private_Operation(rsa, rng), m_padding(SignaturePaddingScheme::create_or_throw(options)) {}
 
    private:
       std::unique_ptr<SignaturePaddingScheme> m_padding;
@@ -741,8 +747,8 @@ class RSA_Verify_Operation final : public PK_Ops::Verification,
          return m_padding->verify(message_repr, msg, public_modulus_bits() - 1);
       }
 
-      RSA_Verify_Operation(const RSA_PublicKey& rsa, std::string_view padding) :
-            RSA_Public_Operation(rsa), m_padding(SignaturePaddingScheme::create_or_throw(padding)) {}
+      RSA_Verify_Operation(const RSA_PublicKey& rsa, const PK_Signature_Options& options) :
+            RSA_Public_Operation(rsa), m_padding(SignaturePaddingScheme::create_or_throw(options)) {}
 
       std::string hash_function() const override { return m_padding->hash_function(); }
 
@@ -799,25 +805,24 @@ std::unique_ptr<PK_Ops::KEM_Encryption> RSA_PublicKey::create_kem_encryption_op(
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<RSA_Verify_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<RSA_Verify_Operation>(*this, options);
    }
-
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 namespace {
 
-std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
+PK_Signature_Options parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
    const auto sig_info = split_on(alg_id.oid().to_formatted_string(), '/');
 
    if(sig_info.empty() || sig_info.size() != 2 || sig_info[0] != "RSA") {
       throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
    }
 
-   std::string padding = sig_info[1];
+   const std::string& padding = sig_info[1];
 
    if(padding == "PSS") {
       // "MUST contain RSASSA-PSS-params"
@@ -850,10 +855,16 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
          throw Decoding_Error("Unacceptable trailer field for PSS signatures");
       }
 
-      padding += fmt("({},MGF1,{})", hash_algo, pss_params.salt_length());
-   }
+      return PK_Signature_Options().with_padding("PSS").with_hash(hash_algo).with_salt_size(pss_params.salt_length());
+   } else {
+      SCAN_Name scan(padding);
 
-   return padding;
+      if(scan.algo_name() != "PKCS1v15") {
+         throw Decoding_Error("Unexpected OID for RSA signatures");
+      }
+
+      return PK_Signature_Options().with_padding("PKCS1v15").with_hash(scan.arg(0));
+   }
 }
 
 }  // namespace
@@ -887,14 +898,13 @@ std::unique_ptr<PK_Ops::KEM_Decryption> RSA_PrivateKey::create_kem_decryption_op
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<RSA_Signature_Operation>(*this, params, rng);
+std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<RSA_Signature_Operation>(*this, options, rng);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -22,6 +22,7 @@
 #include <botan/internal/mp_core.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/scan_name.h>
 #include <botan/internal/sig_padding.h>
 #include <botan/internal/target_info.h>
 #include <botan/internal/workfactor.h>
@@ -667,10 +668,15 @@ class RSA_Signature_Operation final : public PK_Ops::Signature,
 
       AlgorithmIdentifier algorithm_identifier() const override;
 
-      std::string hash_function() const override { return m_padding->hash_function(); }
+      std::string hash_function() const override {
+         BOTAN_ASSERT_NONNULL(m_padding);
+         return m_padding->hash_function();
+      }
 
-      RSA_Signature_Operation(const RSA_PrivateKey& rsa, std::string_view padding, RandomNumberGenerator& rng) :
-            RSA_Private_Operation(rsa, rng), m_padding(SignaturePaddingScheme::create_or_throw(padding)) {}
+      RSA_Signature_Operation(const RSA_PrivateKey& rsa,
+                              const PK_Signature_Options& options,
+                              RandomNumberGenerator& rng) :
+            RSA_Private_Operation(rsa, rng), m_padding(SignaturePaddingScheme::create_or_throw(options)) {}
 
    private:
       std::unique_ptr<SignaturePaddingScheme> m_padding;
@@ -800,8 +806,8 @@ class RSA_Verify_Operation final : public PK_Ops::Verification,
          return m_padding->verify(message_repr, msg, public_modulus_bits() - 1);
       }
 
-      RSA_Verify_Operation(const RSA_PublicKey& rsa, std::string_view padding) :
-            RSA_Public_Operation(rsa), m_padding(SignaturePaddingScheme::create_or_throw(padding)) {}
+      RSA_Verify_Operation(const RSA_PublicKey& rsa, const PK_Signature_Options& options) :
+            RSA_Public_Operation(rsa), m_padding(SignaturePaddingScheme::create_or_throw(options)) {}
 
       std::string hash_function() const override { return m_padding->hash_function(); }
 
@@ -862,18 +868,17 @@ std::unique_ptr<PK_Ops::KEM_Encryption> RSA_PublicKey::create_kem_encryption_op(
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<RSA_Verify_Operation>(*this, params);
+std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<RSA_Verify_Operation>(*this, options);
    }
-
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 namespace {
 
-std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
+PK_Signature_Options parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
    const auto oid_name = alg_id.oid().registered_name();
    if(!oid_name) {
       throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
@@ -885,7 +890,7 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
       throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
    }
 
-   std::string padding = sig_info[1];
+   const std::string& padding = sig_info[1];
 
    if(padding != "PSS") {
       if(!alg_id.parameters_are_null_or_empty()) {
@@ -924,10 +929,16 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
          throw Decoding_Error("Unacceptable trailer field for PSS signatures");
       }
 
-      padding += fmt("({},MGF1,{})", *hash_algo, pss_params.salt_length());
-   }
+      return PK_Signature_Options().with_padding("PSS").with_hash(*hash_algo).with_salt_size(pss_params.salt_length());
+   } else {
+      const SCAN_Name scan(padding);
 
-   return padding;
+      if(scan.algo_name() != "PKCS1v15") {
+         throw Decoding_Error("Unexpected OID for RSA signatures");
+      }
+
+      return PK_Signature_Options().with_padding("PKCS1v15").with_hash(scan.arg(0));
+   }
 }
 
 }  // namespace
@@ -961,14 +972,13 @@ std::unique_ptr<PK_Ops::KEM_Decryption> RSA_PrivateKey::create_kem_decryption_op
    throw Provider_Not_Found(algo_name(), provider);
 }
 
-std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      return std::make_unique<RSA_Signature_Operation>(*this, params, rng);
+std::unique_ptr<PK_Ops::Signature> RSA_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<RSA_Signature_Operation>(*this, options, rng);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/rsa/rsa.h
+++ b/src/lib/pubkey/rsa/rsa.h
@@ -77,8 +77,7 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PublicKey : public virtual Public_Key {
       std::unique_ptr<PK_Ops::KEM_Encryption> create_kem_encryption_op(std::string_view params,
                                                                        std::string_view provider) const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& alg_id,
                                                                         std::string_view provider) const override;
@@ -174,9 +173,8 @@ class BOTAN_PUBLIC_API(2, 0) RSA_PrivateKey final : public virtual Private_Key,
                                                                        std::string_view params,
                                                                        std::string_view provider) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       void init(BigInt&& d, BigInt&& p, BigInt&& q, BigInt&& d1, BigInt&& d2, BigInt&& c);

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -12,6 +12,8 @@
 #include <botan/hash.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/mem_utils.h>
+#include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
 
 namespace Botan {
@@ -79,8 +81,10 @@ std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
 }
 #endif
 
+namespace {
+
 std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
-                                    std::string_view user_id,
+                                    std::span<const uint8_t> user_id,
                                     const EC_Group& group,
                                     const EC_AffinePoint& pubkey) {
    if(user_id.size() >= 8192) {
@@ -104,21 +108,41 @@ std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
    return hash.final<std::vector<uint8_t>>();
 }
 
+}  // namespace
+
+std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
+                                    std::string_view user_id,
+                                    const EC_Group& group,
+                                    const EC_AffinePoint& pubkey) {
+   return sm2_compute_za(hash, as_span_of_bytes(user_id), group, pubkey);
+}
+
 namespace {
+
+// GM/T 0009-2012 specifies this as the default userid
+// "1234567812345678";
+const std::vector<uint8_t> sm2_default_userid = {
+   // clang-format off
+   0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+   0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+   // clang-format on
+};
 
 /**
 * SM2 signature operation
 */
 class SM2_Signature_Operation final : public PK_Ops::Signature {
    public:
-      SM2_Signature_Operation(const SM2_PrivateKey& sm2, std::string_view ident, std::string_view hash) :
+      SM2_Signature_Operation(const SM2_PrivateKey& sm2, const PK_Signature_Options& options) :
             m_group(sm2.domain()), m_x(sm2._private_key()), m_da_inv(sm2._get_da_inv()) {
-         if(hash == "Raw") {
+         if(options.hash_function_name() == "Raw") {
             // m_hash is null, m_za is empty
          } else {
-            m_hash = HashFunction::create_or_throw(hash);
+            auto context = options.context().value_or(sm2_default_userid);
+
+            m_hash = HashFunction::create_or_throw(options.hash_function_name());
             // ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
-            m_za = sm2_compute_za(*m_hash, ident, m_group, sm2._public_ec_point());
+            m_za = sm2_compute_za(*m_hash, context, m_group, sm2._public_ec_point());
             m_hash->update(m_za);
          }
       }
@@ -174,14 +198,16 @@ std::vector<uint8_t> SM2_Signature_Operation::sign(RandomNumberGenerator& rng) {
 */
 class SM2_Verification_Operation final : public PK_Ops::Verification {
    public:
-      SM2_Verification_Operation(const SM2_PublicKey& sm2, std::string_view ident, std::string_view hash) :
+      SM2_Verification_Operation(const SM2_PublicKey& sm2, const PK_Signature_Options& options) :
             m_group(sm2.domain()), m_gy_mul(sm2._public_ec_point()) {
-         if(hash == "Raw") {
+         if(options.hash_function_name() == "Raw") {
             // m_hash is null, m_za is empty
          } else {
-            m_hash = HashFunction::create_or_throw(hash);
+            auto context = options.context().value_or(sm2_default_userid);
+
+            m_hash = HashFunction::create_or_throw(options.hash_function_name());
             // ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
-            m_za = sm2_compute_za(*m_hash, ident, m_group, sm2._public_ec_point());
+            m_za = sm2_compute_za(*m_hash, context, m_group, sm2._public_ec_point());
             m_hash->update(m_za);
          }
       }
@@ -234,58 +260,39 @@ bool SM2_Verification_Operation::is_valid_signature(std::span<const uint8_t> sig
    return false;
 }
 
-void parse_sm2_param_string(std::string_view params, std::string& userid, std::string& hash) {
-   // GM/T 0009-2012 specifies this as the default userid
-   const std::string default_userid = "1234567812345678";
-
-   // defaults:
-   userid = default_userid;
-   hash = "SM3";
-
-   /*
-   * SM2 parameters have the following possible formats:
-   * Ident [since 2.2.0]
-   * Ident,Hash [since 2.3.0]
-   */
-
-   auto comma = params.find(',');
-   if(comma == std::string::npos) {
-      userid = params;
-   } else {
-      userid = params.substr(0, comma);
-      hash = params.substr(comma + 1, std::string::npos);
-   }
-}
-
 }  // namespace
 
 std::unique_ptr<Private_Key> SM2_PublicKey::generate_another(RandomNumberGenerator& rng) const {
    return std::make_unique<SM2_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> SM2_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      std::string userid;
-      std::string hash;
-      parse_sm2_param_string(params, userid, hash);
-      return std::make_unique<SM2_Verification_Operation>(*this, userid, hash);
-   }
+std::unique_ptr<PK_Ops::Verification> SM2_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   BOTAN_ARG_CHECK(!options.using_padding(), "SM2 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_prehash(), "SM2 does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "SM2 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "SM2 does not support a padding trailer field");
 
-   throw Provider_Not_Found(algo_name(), provider);
+   if(!options.using_provider()) {
+      return std::make_unique<SM2_Verification_Operation>(*this, options);
+   }
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
-std::unique_ptr<PK_Ops::Signature> SM2_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      std::string userid;
-      std::string hash;
-      parse_sm2_param_string(params, userid, hash);
-      return std::make_unique<SM2_Signature_Operation>(*this, userid, hash);
-   }
+std::unique_ptr<PK_Ops::Signature> SM2_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
 
-   throw Provider_Not_Found(algo_name(), provider);
+   BOTAN_ARG_CHECK(!options.using_padding(), "SM2 does not support padding");
+   BOTAN_ARG_CHECK(!options.using_prehash(), "SM2 does not support prehashing");
+   BOTAN_ARG_CHECK(!options.using_salt_size(), "SM2 does not support a salt");
+   BOTAN_ARG_CHECK(!options.using_explicit_trailer_field(), "SM2 does not support a padding trailer field");
+   BOTAN_ARG_CHECK(!options.using_deterministic_signature(), "SM2 does not support deterministic signatures");
+
+   if(!options.using_provider()) {
+      return std::make_unique<SM2_Signature_Operation>(*this, options);
+   }
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -13,7 +13,10 @@
 #include <botan/internal/fmt.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/mem_utils.h>
+#include <botan/internal/parsing.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 
 namespace Botan {
 
@@ -121,8 +124,10 @@ std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
 }
 #endif
 
+namespace {
+
 std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
-                                    std::string_view user_id,
+                                    std::span<const uint8_t> user_id,
                                     const EC_Group& group,
                                     const EC_AffinePoint& pubkey) {
    if(user_id.size() >= 8192) {
@@ -146,28 +151,58 @@ std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
    return hash.final<std::vector<uint8_t>>();
 }
 
+}  // namespace
+
+std::vector<uint8_t> sm2_compute_za(HashFunction& hash,
+                                    std::string_view user_id,
+                                    const EC_Group& group,
+                                    const EC_AffinePoint& pubkey) {
+   return sm2_compute_za(hash, as_span_of_bytes(user_id), group, pubkey);
+}
+
 namespace {
 
-/**
-* SM2 signature operation
+// GM/T 0009-2012 specifies this as the default userid
+// "1234567812345678";
+std::vector<uint8_t> sm2_default_userid() {
+   return {
+      // clang-format off
+      0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+      0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+      // clang-format on
+   };
+}
+
+// SM3 is the only hash specified for use with SM2, so it is the default
+std::string sm2_hash_function(const PK_Signature_Options& options) {
+   return options.hash_function().value_or("SM3");
+}
+
+/*
+* The input to the signature equation: normally e = H(ZA || M), but if the
+* caller provides the digest directly then no ZA is computed and the context
+* is not used.
 */
-class SM2_Signature_Operation final : public PK_Ops::Signature {
+class SM2_Signature_Input final {
    public:
-      SM2_Signature_Operation(const SM2_PrivateKey& sm2, std::string_view ident, std::string_view hash) :
-            m_group(sm2.domain()), m_x(sm2._private_key()), m_da_inv(sm2._get_da_inv()) {
-         if(hash == "Raw") {
-            // m_hash is null, m_za is empty
+      SM2_Signature_Input(const PK_Signature_Options& options, const EC_Group& group, const EC_AffinePoint& pubkey) :
+            m_group(group) {
+         if(options.using_externally_computed_prehash()) {
+            if(auto prehash = externally_computed_prehash_name(options)) {
+               m_prehash_name = *prehash;
+               m_expected_digest_len = HashFunction::create_or_throw(*prehash)->output_length();
+            }
          } else {
-            m_hash = HashFunction::create_or_throw(hash);
+            auto context = options.context().value_or(sm2_default_userid());
+
+            m_hash = HashFunction::create_or_throw(sm2_hash_function(options));
             // ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
-            m_za = sm2_compute_za(*m_hash, ident, m_group, sm2._public_ec_point());
+            m_za = sm2_compute_za(*m_hash, context, m_group, pubkey);
             m_hash->update(m_za);
          }
       }
 
-      size_t signature_length() const override { return 2 * m_group.get_order_bytes(); }
-
-      void update(std::span<const uint8_t> input) override {
+      void update(std::span<const uint8_t> input) {
          if(m_hash) {
             m_hash->update(input);
          } else {
@@ -175,33 +210,71 @@ class SM2_Signature_Operation final : public PK_Ops::Signature {
          }
       }
 
+      EC_Scalar final_e() {
+         if(m_hash) {
+            auto e = EC_Scalar::from_bytes_mod_order(m_group, m_hash->final());
+            // prepend ZA for next signature if any
+            m_hash->update(m_za);
+            return e;
+         }
+
+         secure_vector<uint8_t> digest;
+         std::swap(digest, m_digest);
+
+         if(m_expected_digest_len > 0 && digest.size() != m_expected_digest_len) {
+            throw Invalid_Argument(fmt("SM2 was configured to use a {} byte {} prehash but was given {} bytes",
+                                       m_expected_digest_len,
+                                       m_prehash_name,
+                                       digest.size()));
+         }
+
+         return EC_Scalar::from_bytes_mod_order(m_group, digest);
+      }
+
+      std::string hash_function() const {
+         if(m_hash) {
+            return m_hash->name();
+         }
+         return m_prehash_name.empty() ? "Raw" : m_prehash_name;
+      }
+
+   private:
+      const EC_Group m_group;
+      std::vector<uint8_t> m_za;
+      std::unique_ptr<HashFunction> m_hash;
+      secure_vector<uint8_t> m_digest;
+      std::string m_prehash_name;
+      size_t m_expected_digest_len = 0;
+};
+
+/**
+* SM2 signature operation
+*/
+class SM2_Signature_Operation final : public PK_Ops::Signature {
+   public:
+      SM2_Signature_Operation(const SM2_PrivateKey& sm2, const PK_Signature_Options& options) :
+            m_group(sm2.domain()),
+            m_x(sm2._private_key()),
+            m_da_inv(sm2._get_da_inv()),
+            m_input(options, m_group, sm2._public_ec_point()) {}
+
+      size_t signature_length() const override { return 2 * m_group.get_order_bytes(); }
+
+      void update(std::span<const uint8_t> input) override { m_input.update(input); }
+
       std::vector<uint8_t> sign(RandomNumberGenerator& rng) override;
 
-      std::string hash_function() const override { return m_hash ? m_hash->name() : "Raw"; }
+      std::string hash_function() const override { return m_input.hash_function(); }
 
    private:
       const EC_Group m_group;
       const EC_Scalar m_x;
       const EC_Scalar m_da_inv;
-
-      std::vector<uint8_t> m_za;
-      secure_vector<uint8_t> m_digest;
-      std::unique_ptr<HashFunction> m_hash;
+      SM2_Signature_Input m_input;
 };
 
 std::vector<uint8_t> SM2_Signature_Operation::sign(RandomNumberGenerator& rng) {
-   const auto e = [&]() {
-      if(m_hash) {
-         auto ie = EC_Scalar::from_bytes_mod_order(m_group, m_hash->final());
-         // prepend ZA for next signature if any
-         m_hash->update(m_za);
-         return ie;
-      } else {
-         auto ie = EC_Scalar::from_bytes_mod_order(m_group, m_digest);
-         m_digest.clear();
-         return ie;
-      }
-   }();
+   const auto e = m_input.final_e();
 
    const auto k = EC_Scalar::random(m_group, rng);
 
@@ -223,51 +296,25 @@ std::vector<uint8_t> SM2_Signature_Operation::sign(RandomNumberGenerator& rng) {
 */
 class SM2_Verification_Operation final : public PK_Ops::Verification {
    public:
-      SM2_Verification_Operation(const SM2_PublicKey& sm2, std::string_view ident, std::string_view hash) :
-            m_group(sm2.domain()), m_gy_mul(sm2._public_ec_point()) {
-         if(hash == "Raw") {
-            // m_hash is null, m_za is empty
-         } else {
-            m_hash = HashFunction::create_or_throw(hash);
-            // ZA=H256(ENTLA || IDA || a || b || xG || yG || xA || yA)
-            m_za = sm2_compute_za(*m_hash, ident, m_group, sm2._public_ec_point());
-            m_hash->update(m_za);
-         }
-      }
+      SM2_Verification_Operation(const SM2_PublicKey& sm2, const PK_Signature_Options& options) :
+            m_group(sm2.domain()),
+            m_gy_mul(sm2._public_ec_point()),
+            m_input(options, m_group, sm2._public_ec_point()) {}
 
-      void update(std::span<const uint8_t> input) override {
-         if(m_hash) {
-            m_hash->update(input);
-         } else {
-            m_digest.insert(m_digest.end(), input.begin(), input.end());
-         }
-      }
+      void update(std::span<const uint8_t> input) override { m_input.update(input); }
 
       bool is_valid_signature(std::span<const uint8_t> sig) override;
 
-      std::string hash_function() const override { return m_hash ? m_hash->name() : "Raw"; }
+      std::string hash_function() const override { return m_input.hash_function(); }
 
    private:
       const EC_Group m_group;
       const EC_Group::Mul2Table m_gy_mul;
-      secure_vector<uint8_t> m_digest;
-      std::vector<uint8_t> m_za;
-      std::unique_ptr<HashFunction> m_hash;
+      SM2_Signature_Input m_input;
 };
 
 bool SM2_Verification_Operation::is_valid_signature(std::span<const uint8_t> sig) {
-   const auto e = [&]() {
-      if(m_hash) {
-         auto ie = EC_Scalar::from_bytes_mod_order(m_group, m_hash->final());
-         // prepend ZA for next signature if any
-         m_hash->update(m_za);
-         return ie;
-      } else {
-         auto ie = EC_Scalar::from_bytes_mod_order(m_group, m_digest);
-         m_digest.clear();
-         return ie;
-      }
-   }();
+   const auto e = m_input.final_e();
 
    if(auto rs = EC_Scalar::deserialize_pair(m_group, sig)) {
       const auto& [r, s] = rs.value();
@@ -283,60 +330,28 @@ bool SM2_Verification_Operation::is_valid_signature(std::span<const uint8_t> sig
    return false;
 }
 
-std::pair<std::string, std::string> parse_sm2_param_string(std::string_view params) {
-   const std::string default_hash = "SM3";
-
-   /*
-   * SM2 parameters have the following possible formats:
-   * Ident [since 2.2.0]
-   * Ident,Hash [since 2.3.0]
-   *
-   * Historically a completely empty parameter string was treated as
-   * if the identity was empty. This probably should have instead been
-   * treated as if it was the "default userid" ("1234567812345678") but
-   * there was a bug and it wasn't.
-   *
-   * TODO(Botan4) evaluate if this should be changed
-   */
-   if(params.empty()) {
-      return std::make_pair(std::string(), default_hash);
-   }
-
-   auto comma = params.find(',');
-   if(comma == std::string::npos) {
-      return std::make_pair(std::string(params), default_hash);
-   } else {
-      const auto userid = params.substr(0, comma);
-      const auto hash = params.substr(comma + 1, std::string::npos);
-      return std::make_pair(std::string(userid), std::string(hash));
-   }
-}
-
 }  // namespace
 
 std::unique_ptr<Private_Key> SM2_PublicKey::generate_another(RandomNumberGenerator& rng) const {
    return std::make_unique<SM2_PrivateKey>(rng, domain());
 }
 
-std::unique_ptr<PK_Ops::Verification> SM2_PublicKey::create_verification_op(std::string_view params,
-                                                                            std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      const auto [userid, hash] = parse_sm2_param_string(params);
-      return std::make_unique<SM2_Verification_Operation>(*this, userid, hash);
+std::unique_ptr<PK_Ops::Verification> SM2_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      return std::make_unique<SM2_Verification_Operation>(*this, options);
    }
-
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
-std::unique_ptr<PK_Ops::Signature> SM2_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                       std::string_view params,
-                                                                       std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
-      const auto [userid, hash] = parse_sm2_param_string(params);
-      return std::make_unique<SM2_Signature_Operation>(*this, userid, hash);
-   }
+std::unique_ptr<PK_Ops::Signature> SM2_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                        const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
 
-   throw Provider_Not_Found(algo_name(), provider);
+   if(!options.using_provider()) {
+      return std::make_unique<SM2_Signature_Operation>(*this, options);
+   }
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -57,8 +57,9 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PublicKey : public virtual EC_PublicKey {
 
       std::optional<size_t> _signature_element_size_for_DER_encoding() const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      bool supports_context_data() const override { return true; }
+
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Encryption> create_encryption_op(RandomNumberGenerator& rng,
                                                                std::string_view params,
@@ -112,9 +113,8 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
 
       std::unique_ptr<Public_Key> public_key() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Decryption> create_decryption_op(RandomNumberGenerator& rng,
                                                                std::string_view params,

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -56,8 +56,7 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PublicKey : public virtual EC_PublicKey {
 
       std::optional<size_t> _signature_element_size_for_DER_encoding() const override;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Encryption> create_encryption_op(RandomNumberGenerator& rng,
                                                                std::string_view params,
@@ -111,9 +110,8 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PrivateKey final : public SM2_PublicKey,
 
       std::unique_ptr<Public_Key> public_key() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Decryption> create_decryption_op(RandomNumberGenerator& rng,
                                                                std::string_view params,

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/concat_util.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/sp_fors.h>
 #include <botan/internal/sp_hash.h>
 #include <botan/internal/sp_hypertree.h>
@@ -247,12 +248,15 @@ class SphincsPlus_Verification_Operation final : public PK_Ops::Verification {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                                    std::string_view provider) const {
-   if(provider.empty() || provider == "base") {
+std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_for_hash_based_signature(options, "SPHINCS+", m_public->parameters().hash_name());
+
+   if(!options.using_provider()) {
       return std::make_unique<SphincsPlus_Verification_Operation>(m_public);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::create_x509_verification_op(
@@ -437,21 +441,20 @@ class SphincsPlus_Signature_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> SphincsPlus_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                               std::string_view params,
-                                                                               std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> SphincsPlus_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
-   BOTAN_ARG_CHECK(params.empty() || params == "Deterministic" || params == "Randomized",
-                   "Unexpected parameters for signing with SLH-DSA (or SPHINCS+)");
+
+   validate_for_hash_based_signature(options, "SPHINCS+", m_public->parameters().hash_name());
 
    // FIPS 205, Section 9.2
    //   The hedged variant is the default and should be used on platforms where
    //   side-channel attacks are a concern.
-   const bool randomized = (params.empty() || params == "Randomized");
-   if(provider.empty() || provider == "base") {
+   const bool randomized = !options.using_deterministic_signature();
+   if(!options.using_provider()) {
       return std::make_unique<SphincsPlus_Signature_Operation>(m_private, m_public, randomized);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/concat_util.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/pk_ops_impl.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/sp_fors.h>
 #include <botan/internal/sp_hash.h>
 #include <botan/internal/sp_hypertree.h>
@@ -252,12 +253,16 @@ class SphincsPlus_Verification_Operation final : public PK_Ops::Verification {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                                    std::string_view provider) const {
-   if(provider.empty() || provider == "base") {
-      return std::make_unique<SphincsPlus_Verification_Operation>(m_public);
+std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   if(!options.using_provider()) {
+      auto op = std::make_unique<SphincsPlus_Verification_Operation>(m_public);
+      // The message hash depends on the parameter set, so check against what the operation reports
+      validate_for_hash_based_signature(options, "SPHINCS+", op->hash_function());
+      return op;
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> SphincsPlus_PublicKey::create_x509_verification_op(
@@ -462,21 +467,21 @@ class SphincsPlus_Signature_Operation final : public PK_Ops::Signature {
 
 }  // namespace
 
-std::unique_ptr<PK_Ops::Signature> SphincsPlus_PrivateKey::create_signature_op(RandomNumberGenerator& rng,
-                                                                               std::string_view params,
-                                                                               std::string_view provider) const {
+std::unique_ptr<PK_Ops::Signature> SphincsPlus_PrivateKey::_create_signature_op(
+   RandomNumberGenerator& rng, const PK_Signature_Options& options) const {
    BOTAN_UNUSED(rng);
-   BOTAN_ARG_CHECK(params.empty() || params == "Deterministic" || params == "Randomized",
-                   "Unexpected parameters for signing with SLH-DSA (or SPHINCS+)");
 
    // FIPS 205, Section 9.2
    //   The hedged variant is the default and should be used on platforms where
    //   side-channel attacks are a concern.
-   const bool randomized = (params.empty() || params == "Randomized");
-   if(provider.empty() || provider == "base") {
-      return std::make_unique<SphincsPlus_Signature_Operation>(m_private, m_public, randomized);
+   const bool randomized = !options.using_deterministic_signature();
+   if(!options.using_provider()) {
+      auto op = std::make_unique<SphincsPlus_Signature_Operation>(m_private, m_public, randomized);
+      // The message hash depends on the parameter set, so check against what the operation reports
+      validate_for_hash_based_signature(options, "SPHINCS+", op->hash_function());
+      return op;
    }
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
@@ -54,8 +54,7 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PublicKey : public virtual Public_Key {
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -112,9 +111,8 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PrivateKey final : public virtual Sphin
       secure_vector<uint8_t> raw_private_key_bits() const override;
       std::unique_ptr<Public_Key> public_key() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       std::shared_ptr<SphincsPlus_PrivateKeyInternal> m_private;

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
@@ -54,8 +54,7 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PublicKey : public virtual Public_Key {
 
       std::unique_ptr<Private_Key> generate_another(RandomNumberGenerator& rng) const final;
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& signature_algorithm,
                                                                         std::string_view provider) const override;
@@ -114,9 +113,8 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PrivateKey final : public virtual Sphin
 
       bool check_key(RandomNumberGenerator& rng, bool strong) const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
    private:
       std::shared_ptr<const SphincsPlus_PrivateKeyInternal> m_private;

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -102,8 +102,7 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& alg_id,
                                                                         std::string_view provider) const override;
@@ -230,9 +229,8 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
 
       std::optional<uint64_t> remaining_operations() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
       secure_vector<uint8_t> private_key_bits() const override;
 

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -113,8 +113,7 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      std::unique_ptr<PK_Ops::Verification> create_verification_op(std::string_view params,
-                                                                   std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Verification> _create_verification_op(const PK_Signature_Options& options) const override;
 
       std::unique_ptr<PK_Ops::Verification> create_x509_verification_op(const AlgorithmIdentifier& alg_id,
                                                                         std::string_view provider) const override;
@@ -246,9 +245,8 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
 
       std::optional<uint64_t> remaining_operations() const override;
 
-      std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,
-                                                             std::string_view params,
-                                                             std::string_view provider) const override;
+      std::unique_ptr<PK_Ops::Signature> _create_signature_op(RandomNumberGenerator& rng,
+                                                              const PK_Signature_Options& options) const override;
 
       secure_vector<uint8_t> private_key_bits() const override;
 

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -20,11 +20,13 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/stateful_key_index_registry.h>
 #include <botan/internal/xmss_common_ops.h>
 #include <botan/internal/xmss_hash.h>
@@ -143,6 +145,8 @@ class XMSS_PrivateKey_Internal {
       const secure_vector<uint8_t>& prf_value() const { return m_prf; }
 
       const secure_vector<uint8_t>& private_seed() { return m_private_seed; }
+
+      const XMSS_Parameters& parameters() const { return m_xmss_params; }
 
       const XMSS_WOTS_Parameters& wots_parameters() { return m_wots_params; }
 
@@ -417,14 +421,17 @@ std::unique_ptr<Public_Key> XMSS_PrivateKey::public_key() const {
    return std::make_unique<XMSS_PublicKey>(xmss_parameters().oid(), root(), public_seed());
 }
 
-std::unique_ptr<PK_Ops::Signature> XMSS_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                        std::string_view /*params*/,
-                                                                        std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
+std::unique_ptr<PK_Ops::Signature> XMSS_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                         const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   validate_for_hash_based_signature(options, "XMSS", this->m_private->parameters().hash_function_name());
+
+   if(!options.using_provider()) {
       return std::make_unique<XMSS_Signature_Operation>(*this);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -20,11 +20,13 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/stateful_key_index_registry.h>
 #include <botan/internal/xmss_common_ops.h>
 #include <botan/internal/xmss_hash.h>
@@ -520,14 +522,18 @@ std::unique_ptr<Public_Key> XMSS_PrivateKey::public_key() const {
    return std::make_unique<XMSS_PublicKey>(xmss_parameters().oid(), root(), public_seed());
 }
 
-std::unique_ptr<PK_Ops::Signature> XMSS_PrivateKey::create_signature_op(RandomNumberGenerator& /*rng*/,
-                                                                        std::string_view /*params*/,
-                                                                        std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
+std::unique_ptr<PK_Ops::Signature> XMSS_PrivateKey::_create_signature_op(RandomNumberGenerator& rng,
+                                                                         const PK_Signature_Options& options) const {
+   BOTAN_UNUSED(rng);
+
+   validate_for_hash_based_signature(options, "XMSS", xmss_parameters().hash_function_name());
+   acknowledge_always_deterministic(options);
+
+   if(!options.using_provider()) {
       return std::make_unique<XMSS_Signature_Operation>(*this);
    }
 
-   throw Provider_Not_Found(algo_name(), provider);
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -18,10 +18,12 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/xmss_verification_operation.h>
 
 namespace Botan {
@@ -99,12 +101,15 @@ XMSS_PublicKey::XMSS_PublicKey(XMSS_Parameters::xmss_algorithm_t xmss_oid,
    BOTAN_ARG_CHECK(m_public_seed.size() == m_xmss_params.element_size(), "XMSS: unexpected byte length of public seed");
 }
 
-std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                             std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
+std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_for_hash_based_signature(options, "XMSS", this->m_xmss_params.hash_function_name());
+
+   if(!options.using_provider()) {
       return std::make_unique<XMSS_Verification_Operation>(*this);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -18,10 +18,12 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/pk_options.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/concat_util.h>
 #include <botan/internal/loadstor.h>
+#include <botan/internal/pk_options_impl.h>
 #include <botan/internal/xmss_verification_operation.h>
 
 namespace Botan {
@@ -164,12 +166,15 @@ bool XMSS_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) 
    return true;
 }
 
-std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::create_verification_op(std::string_view /*params*/,
-                                                                             std::string_view provider) const {
-   if(provider == "base" || provider.empty()) {
+std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::_create_verification_op(
+   const PK_Signature_Options& options) const {
+   validate_for_hash_based_signature(options, "XMSS", xmss_parameters().hash_function_name());
+
+   if(!options.using_provider()) {
       return std::make_unique<XMSS_Verification_Operation>(*this);
    }
-   throw Provider_Not_Found(algo_name(), provider);
+
+   throw Provider_Not_Found(algo_name(), options.provider().value());
 }
 
 std::unique_ptr<PK_Ops::Verification> XMSS_PublicKey::create_x509_verification_op(const AlgorithmIdentifier& alg_id,

--- a/src/lib/utils/assert.h
+++ b/src/lib/utils/assert.h
@@ -56,6 +56,13 @@ namespace Botan {
       }                                                         \
    } while(0)
 
+#define BOTAN_STATE_CHECK_MSG(expr, msg)                      \
+   /* NOLINTNEXTLINE(*-avoid-do-while) */                     \
+   do {                                                       \
+      if(!(expr))                                             \
+         Botan::throw_invalid_state(msg, __func__, __FILE__); \
+   } while(0)
+
 /**
 * Make an assertion
 */

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -111,7 +111,7 @@ std::pair<Certificate_Status_Code, std::string> X509_Object::verify_signature(co
       }
    } catch(Decoding_Error&) {
       return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-   } catch(Algorithm_Not_Found&) {
+   } catch(Lookup_Error&) {
       return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_UNKNOWN, "");
    } catch(...) {
       // This shouldn't happen, fallback to generic signature error

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -142,7 +142,7 @@ std::pair<Certificate_Status_Code, std::string> X509_Object::verify_signature(co
       }
    } catch(Decoding_Error&) {
       return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_BAD_PARAMS, "");
-   } catch(Algorithm_Not_Found&) {
+   } catch(Lookup_Error&) {
       return std::make_pair(Certificate_Status_Code::SIGNATURE_ALGO_UNKNOWN, "");
    } catch(...) {
       // This shouldn't happen, fallback to generic signature error

--- a/src/scripts/acvp_tests.py
+++ b/src/scripts/acvp_tests.py
@@ -1474,6 +1474,10 @@ def _ecdsa_siggen_aft(group: dict, test: dict, *, deterministic: bool) -> None:
     else:
         padding = _map_hash(group["hashAlg"])
 
+    # ECDSA signatures are randomized unless RFC 6979 is explicitly requested
+    if deterministic:
+        padding += ",Deterministic"
+
     priv = _group_state(group, "priv")
     if priv is None:
         rng = botan.RandomNumberGenerator("system")

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -598,9 +598,10 @@ mlLtJ5JvZ0/p6zP3x+Y9yPIrAR8L/acG5ItSrAKXzzuqQQZMv4aN
              "83:FC:67:87:30:C7:0C:9C:54:9A:E7:A1:FA:25:83:4C:77:A4:43:16:33:6D:47:3C:CE:4B:91:62:30:97:62:D4",
              open(pub_key, 'rb').read().decode())
 
+    # RFC 6979 deterministic signature, so it does not depend on the RNG
     valid_sig = "nI4mI1ec14Y7nYUWs2edysAVvkob0TWpmGh5rrYWDA+/W9Fj0ZM21qJw8qa3/avAOIVBO6hoMEVmfJYXlS+ReA=="
 
-    test_cli("sign", "%s %s" % (priv_key, pub_key), valid_sig)
+    test_cli("sign", "--deterministic %s %s" % (priv_key, pub_key), valid_sig)
 
     test_cli("verify", [pub_key, pub_key, '-'],
              "Signature is valid", valid_sig)
@@ -632,6 +633,64 @@ mlLtJ5JvZ0/p6zP3x+Y9yPIrAR8L/acG5ItSrAKXzzuqQQZMv4aN
 
     test_cli("cert_verify", user_cert,
              "Certificate did not validate - Certificate issuer not found")
+
+def cli_pk_sign_tests(tmp_dir):
+    # Ed25519 key from RFC 8032 section 7.1 "TEST 2"
+    ed25519_priv_pem = """-----BEGIN PRIVATE KEY-----
+MC4CAQAwBQYDK2VwBCIEIEzNCJso/5banbbDRuwRTg9bijGfNaumJNqM9u1PuKb7
+-----END PRIVATE KEY-----"""
+
+    ed25519_pub_pem = """-----BEGIN PUBLIC KEY-----
+MCowBQYDK2VwAyEAPUAXw+hDiVqStwqnTRt+vJyYLM8uxJaMwM1V8Sr0Zgw=
+-----END PUBLIC KEY-----"""
+
+    priv_key = os.path.join(tmp_dir, 'ed25519.pem')
+    pub_key = os.path.join(tmp_dir, 'ed25519.pub')
+    msg = os.path.join(tmp_dir, 'msg')
+    sig = os.path.join(tmp_dir, 'sig')
+
+    with open(priv_key, 'w', encoding='utf8') as f:
+        f.write(ed25519_priv_pem)
+    with open(pub_key, 'w', encoding='utf8') as f:
+        f.write(ed25519_pub_pem)
+    with open(msg, 'wb') as f:
+        f.write(b'\x72')
+
+    # The signature from RFC 8032 for this key and message; verifies that the
+    # CLI produces standard (pure) Ed25519 signatures by default
+    rfc8032_sig = "kqAJqfDUyrhyDoILX2QlQKKye1QWUD+Ps3YiI+vbadoIWsHkPhWZbkWPNhPQ8R2MOHsurrQwKu6wDSkWErsMAA=="
+
+    test_cli("sign", [priv_key, msg], rfc8032_sig)
+    test_cli("verify", [pub_key, msg, '-'], "Signature is valid", rfc8032_sig)
+
+    # Ed25519ph is a distinct signature scheme
+    test_cli("sign", ["--prehash=default", priv_key, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", ["--prehash=default", pub_key, msg, sig], "Signature is valid")
+    test_cli("verify", [pub_key, msg, sig], "Signature is invalid")
+
+    # ML-DSA takes no options at all
+    mldsa_priv = os.path.join(tmp_dir, 'mldsa.pem')
+    mldsa_pub = os.path.join(tmp_dir, 'mldsa.pub')
+    test_cli("keygen", ["--algo=ML-DSA", "--params=ML-DSA-4x4", "--output=%s" % (mldsa_priv)], "")
+    test_cli("pkcs8", "--pub-out --output=%s %s" % (mldsa_pub, mldsa_priv), "")
+    test_cli("sign", [mldsa_priv, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", [mldsa_pub, msg, sig], "Signature is valid")
+    test_cli("sign", ["--deterministic", mldsa_priv, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", [mldsa_pub, msg, sig], "Signature is valid")
+
+    # RSA defaults to PSS with SHA-256; other paddings and salt sizes can be selected
+    rsa_priv = os.path.join(tmp_dir, 'rsa.pem')
+    rsa_pub = os.path.join(tmp_dir, 'rsa.pub')
+    test_cli("keygen", ["--algo=RSA", "--params=2048", "--output=%s" % (rsa_priv)], "")
+    test_cli("pkcs8", "--pub-out --output=%s %s" % (rsa_pub, rsa_priv), "")
+    test_cli("sign", [rsa_priv, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", [rsa_pub, msg, sig], "Signature is valid")
+    test_cli("verify", ["--padding=PSS", "--hash=SHA-256", rsa_pub, msg, sig], "Signature is valid")
+    test_cli("verify", ["--padding=PKCS1v15", rsa_pub, msg, sig], "Signature is invalid")
+    test_cli("sign", ["--padding=PKCS1v15", "--hash=SHA-512", rsa_priv, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", ["--padding=PKCS1v15", "--hash=SHA-512", rsa_pub, msg, sig], "Signature is valid")
+    test_cli("sign", ["--padding=PSS", "--salt-size=0", "--deterministic", rsa_priv, msg, "--output=%s" % (sig)], "")
+    test_cli("verify", ["--padding=PSS", "--salt-size=0", rsa_pub, msg, sig], "Signature is valid")
 
 def cli_xmss_sign_tests(tmp_dir):
     if os.linesep != '\n':
@@ -2133,6 +2192,7 @@ def main(args=None):
         cli_ocsp_check_tests,
         cli_pbkdf_tune_tests,
         cli_pk_encrypt_tests,
+        cli_pk_sign_tests,
         cli_pk_workfactor_tests,
         cli_pkcs12_tests,
         cli_psk_db_tests,

--- a/src/tests/data/pubkey/api_sign.vec
+++ b/src/tests/data/pubkey/api_sign.vec
@@ -62,4 +62,4 @@ SigParams =
 [XMSS]
 
 AlgoParams = XMSS-SHA2_10_256
-SigParams = SHA2_10_256
+SigParams = SHA-256

--- a/src/tests/data/pubkey/pk_sig_options.vec
+++ b/src/tests/data/pubkey/pk_sig_options.vec
@@ -1,0 +1,197 @@
+# Tests for PK_Signature_Options validation
+#
+# For each algorithm, a key is generated using KeyParams (if provided).
+# A baseline set of options is created using Hash (if non-empty).
+# The baseline is verified to produce working signatures.
+#
+# Each Supports* flag tests adding that option to the baseline:
+#   true  -> signer and verifier accept it, sign/verify succeeds
+#   false -> signer and verifier both reject it with an exception
+
+[ECDSA]
+KeyParams = secp256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[Ed25519]
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = true
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[Ed448]
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = true
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[ECKCDSA]
+KeyParams = secp256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[SM2]
+KeyParams = sm2p256v1
+Hash = SM3
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = true
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[ECGDSA]
+KeyParams = brainpool256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[GOST-34.10]
+KeyParams = gost_256A
+Hash = Streebog-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+# RSA with different padding schemes - each combination has different
+# valid options, so they are tested as separate sections.
+
+[RSA/PKCS1v15]
+KeyParams = 2048
+Hash = SHA-256
+Padding = PKCS1v15
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[RSA/PSS]
+KeyParams = 2048
+Hash = SHA-256
+Padding = PSS
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[RSA/ISO_9796_DS2]
+KeyParams = 2048
+Hash = SHA-256
+Padding = ISO_9796_DS2
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = false
+SupportsExplicitTrailer = true
+
+[RSA/ISO_9796_DS3]
+KeyParams = 2048
+Hash = SHA-256
+Padding = ISO_9796_DS3
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = true
+
+[RSA/X9.31]
+KeyParams = 2048
+Hash = SHA-256
+Padding = X9.31
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+# Hash-based signature schemes - the hash function is fixed by the key
+# parameters and cannot be changed via options.
+
+[SLH-DSA]
+KeyParams = SLH-DSA-SHA2-128s
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[XMSS]
+KeyParams = XMSS-SHA2_10_256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[HSS-LMS]
+KeyParams = SHA-256,HW(5,1)
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[ML-DSA]
+KeyParams = ML-DSA-6x5
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[DSA]
+KeyParams = dsa/botan/2048
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false

--- a/src/tests/data/pubkey/pk_sig_options.vec
+++ b/src/tests/data/pubkey/pk_sig_options.vec
@@ -1,0 +1,226 @@
+# Tests for PK_Signature_Options validation
+#
+# For each algorithm, a key is generated using KeyParams (if provided).
+# A baseline set of options is created using Hash and Padding (if non-empty).
+# The baseline is verified to produce working signatures.
+#
+# Each Supports* flag tests adding that option to the baseline:
+#   true  -> signer and verifier accept it, sign/verify succeeds, and the
+#            option takes effect (a verifier with conflicting options rejects)
+#   false -> signer and verifier both reject it with an exception
+#
+# For ExternalPrehash the input is the baseline hash of the message (if the
+# baseline names a hash); the signature must then also verify in the baseline
+# configuration over the original message.
+#
+# Every section must have a Supports* entry for each option (except for those
+# used in the baseline); the test fails otherwise.
+
+[ECDSA]
+KeyParams = secp256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[Ed25519]
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = true
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[Ed448]
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = true
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[ECKCDSA]
+KeyParams = secp256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+# SM2 defaults to SM3 if no hash is specified
+[SM2]
+KeyParams = sm2p256v1
+SupportsHash = true
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = true
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[ECGDSA]
+KeyParams = brainpool256r1
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[GOST-34.10]
+KeyParams = gost_256A
+Hash = Streebog-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+# RSA with different padding schemes - each combination has different
+# valid options, so they are tested as separate sections.
+
+[RSA/PKCS1v15]
+KeyParams = 2048
+Hash = SHA-256
+Padding = PKCS1v15
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[RSA/PSS]
+KeyParams = 2048
+Hash = SHA-256
+Padding = PSS
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = false
+SupportsExplicitTrailer = false
+
+[RSA/ISO_9796_DS2]
+KeyParams = 2048
+Hash = SHA-256
+Padding = ISO_9796_DS2
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = false
+SupportsExplicitTrailer = true
+
+[RSA/ISO_9796_DS3]
+KeyParams = 2048
+Hash = SHA-256
+Padding = ISO_9796_DS3
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = true
+
+[RSA/X9.31]
+KeyParams = 2048
+Hash = SHA-256
+Padding = X9.31
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+# Hash-based signature schemes - the hash function is fixed by the key
+# parameters; the hash option is accepted only if it names that same hash.
+
+[SLH-DSA]
+KeyParams = SLH-DSA-SHA2-128s
+SupportsHash = true
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[XMSS]
+KeyParams = XMSS-SHA2_10_256
+SupportsHash = true
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[HSS-LMS]
+KeyParams = SHA-256,HW(5,1)
+SupportsHash = true
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[ML-DSA]
+KeyParams = ML-DSA-6x5
+SupportsHash = false
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = false
+SupportsContext = false
+SupportsDER = false
+SupportsSaltSize = true
+SupportsDeterministic = true
+SupportsExplicitTrailer = false
+
+[DSA]
+KeyParams = dsa/botan/2048
+Hash = SHA-256
+SupportsPadding = false
+SupportsPrehash = false
+SupportsExternalPrehash = true
+SupportsContext = false
+SupportsDER = true
+SupportsSaltSize = false
+SupportsDeterministic = true
+SupportsExplicitTrailer = false

--- a/src/tests/test_dilithium.cpp
+++ b/src/tests/test_dilithium.cpp
@@ -15,6 +15,7 @@
    #include <botan/dilithium.h>
    #include <botan/hash.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
 
    #include "test_pubkey.h"
@@ -65,7 +66,7 @@ class Dilithium_KAT_Tests : public Text_Based_Test {
          }
 
          const Botan::Dilithium_PublicKey pub_key(priv_key.public_key_bits(), DerivedT::mode);
-         auto verifier = Botan::PK_Verifier(pub_key, "");
+         auto verifier = Botan::PK_Verifier(pub_key, Botan::PK_Signature_Options());
          verifier.update(ref_msg.data(), ref_msg.size());
          result.test_is_true("signature verifies", verifier.check_signature(signature.data(), signature.size()));
 
@@ -147,7 +148,7 @@ class DilithiumRoundtripTests final : public Test {
          };
 
          auto verify = [](const auto& public_key, const auto& msg, const auto& signature) {
-            auto verifier = Botan::PK_Verifier(public_key, "");
+            auto verifier = Botan::PK_Verifier(public_key, Botan::PK_Signature_Options());
             verifier.update(msg);
             return verifier.check_signature(signature);
          };

--- a/src/tests/test_dilithium.cpp
+++ b/src/tests/test_dilithium.cpp
@@ -15,6 +15,7 @@
    #include <botan/dilithium.h>
    #include <botan/hash.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
 
    #include "test_pubkey.h"
@@ -65,7 +66,7 @@ class Dilithium_KAT_Tests : public Text_Based_Test {
          }
 
          const Botan::Dilithium_PublicKey pub_key(priv_key.public_key_bits(), DerivedT::mode);
-         auto verifier = Botan::PK_Verifier(pub_key, "");
+         auto verifier = Botan::PK_Verifier(pub_key, Botan::PK_Signature_Options());
          verifier.update(ref_msg.data(), ref_msg.size());
          result.test_is_true("signature verifies", verifier.check_signature(signature.data(), signature.size()));
 
@@ -147,7 +148,7 @@ class DilithiumRoundtripTests final : public Test {
          };
 
          auto verify = [](const auto& public_key, const auto& msg, const auto& signature) {
-            auto verifier = Botan::PK_Verifier(public_key, "");
+            auto verifier = Botan::PK_Verifier(public_key, Botan::PK_Signature_Options());
             verifier.update(msg);
             return verifier.check_signature(signature);
          };
@@ -239,6 +240,63 @@ class DilithiumRoundtripTests final : public Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "dilithium_roundtrips", DilithiumRoundtripTests);
+
+/*
+* The "salt" option names the size of the randomness drawn during hedged
+* signing, which differs between ML-DSA (32 byte rnd) and Dilithium round 3
+* (the full 64 byte rho')
+*/
+class Dilithium_Salt_Size_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("Dilithium salt size option");
+
+         auto check = [&](const std::string& algo, const std::string& mode, size_t expected_salt, size_t wrong_salt) {
+            std::unique_ptr<Botan::Private_Key> key;
+            try {
+               key = Botan::create_private_key(algo, this->rng(), mode);
+            } catch(const Botan::Lookup_Error&) {
+               /*ignore*/
+            } catch(const Botan::Not_Implemented&) {
+               /*ignore*/
+            }
+
+            if(key == nullptr) {
+               result.test_note("Skipping " + mode + " - not available");
+               return;
+            }
+
+            const auto pub = key->public_key();
+            const std::vector<uint8_t> msg = {0x61, 0x62, 0x63};
+
+            result.test_no_throw(mode + " accepts its randomness size as salt", [&] {
+               Botan::PK_Signer signer(*key, this->rng(), Botan::PK_Signature_Options().with_salt_size(expected_salt));
+               Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_salt_size(expected_salt));
+               result.test_is_true(mode + " sign/verify",
+                                   verifier.verify_message(msg, signer.sign_message(msg, this->rng())));
+            });
+
+            result.test_throws(mode + " rejects another salt size", [&] {
+               const Botan::PK_Signer signer(
+                  *key, this->rng(), Botan::PK_Signature_Options().with_salt_size(wrong_salt));
+            });
+
+            result.test_throws(mode + " rejects a salt when deterministic", [&] {
+               const Botan::PK_Signer signer(
+                  *key,
+                  this->rng(),
+                  Botan::PK_Signature_Options().with_salt_size(expected_salt).with_deterministic_signature());
+            });
+         };
+
+         check("ML-DSA", "ML-DSA-4x4", 32, 64);
+         check("Dilithium", "Dilithium-4x4-r3", 64, 32);
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "dilithium_salt_size", Dilithium_Salt_Size_Tests);
 
 class Dilithium_Keygen_Tests final : public PK_Key_Generation_Test {
    public:

--- a/src/tests/test_dsa.cpp
+++ b/src/tests/test_dsa.cpp
@@ -11,6 +11,8 @@
    #include <botan/bigint.h>
    #include <botan/dl_group.h>
    #include <botan/dsa.h>
+   #include <botan/pk_options.h>
+   #include <botan/pubkey.h>
 #endif
 
 namespace Botan_Tests {
@@ -22,16 +24,7 @@ namespace {
 class DSA_KAT_Tests final : public PK_Signature_Generation_Test {
    public:
       DSA_KAT_Tests() :
-            PK_Signature_Generation_Test("DSA",
-   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                         "pubkey/dsa_rfc6979.vec",
-                                         "P,Q,G,X,Hash,Msg,Signature",
-   #else
-                                         "pubkey/dsa_prob.vec",
-                                         "P,Q,G,X,Hash,Msg,Nonce,Signature",
-   #endif
-                                         "") {
-      }
+            PK_Signature_Generation_Test("DSA", "pubkey/dsa_prob.vec", "P,Q,G,X,Hash,Msg,Nonce,Signature", "") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -49,19 +42,49 @@ class DSA_KAT_Tests final : public PK_Signature_Generation_Test {
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
 };
 
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+
+class DSA_RFC6979_KAT_Tests final : public Text_Based_Test {
+   public:
+      DSA_RFC6979_KAT_Tests() : Text_Based_Test("pubkey/dsa_rfc6979.vec", "P,Q,G,X,Hash,Msg,Signature") {}
+
+      bool clear_between_callbacks() const override { return false; }
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         const std::string hash = vars.get_req_str("Hash");
+         const auto msg = vars.get_req_bin("Msg");
+         const auto expected_sig = vars.get_req_bin("Signature");
+
+         const Botan::BigInt p = vars.get_req_bn("P");
+         const Botan::BigInt q = vars.get_req_bn("Q");
+         const Botan::BigInt g = vars.get_req_bn("G");
+         const Botan::BigInt x = vars.get_req_bn("X");
+
+         Test::Result result("DSA RFC6979 " + hash);
+
+         const Botan::DL_Group group(p, q, g);
+         const Botan::DSA_PrivateKey priv_key(group, x);
+
+         Botan::PK_Signer signer(
+            priv_key, this->rng(), Botan::PK_Signature_Options(hash).with_deterministic_signature());
+
+         const auto sig = signer.sign_message(msg, this->rng());
+         result.test_bin_eq("RFC6979 signature matches KAT", sig, expected_sig);
+
+         const auto pub = priv_key.public_key();
+         Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options(hash));
+         result.test_is_true("Signature verifies", verifier.verify_message(msg, sig));
+
+         return result;
+      }
+};
+
+   #endif
+
 class DSA_KAT_Verification_Tests final : public PK_Signature_Verification_Test {
    public:
       DSA_KAT_Verification_Tests() :
-            PK_Signature_Verification_Test("DSA",
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                           "pubkey/dsa_rfc6979.vec",
-                                           "P,Q,G,X,Hash,Msg,Signature",
-   #else
-                                           "pubkey/dsa_prob.vec",
-                                           "P,Q,G,X,Hash,Msg,Nonce,Signature",
-   #endif
-                                           "") {
-      }
+            PK_Signature_Verification_Test("DSA", "pubkey/dsa_rfc6979.vec", "P,Q,G,X,Hash,Msg,Signature", "") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -117,6 +140,9 @@ class DSA_Keygen_Tests final : public PK_Key_Generation_Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "dsa_kat_sign", DSA_KAT_Tests);
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+BOTAN_REGISTER_TEST("pubkey", "dsa_rfc6979_sign", DSA_RFC6979_KAT_Tests);
+   #endif
 BOTAN_REGISTER_TEST("pubkey", "dsa_kat_verify", DSA_KAT_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "dsa_misc_verify", DSA_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "dsa_keygen", DSA_Keygen_Tests);

--- a/src/tests/test_dsa.cpp
+++ b/src/tests/test_dsa.cpp
@@ -11,6 +11,8 @@
    #include <botan/bigint.h>
    #include <botan/dl_group.h>
    #include <botan/dsa.h>
+   #include <botan/pk_options.h>
+   #include <botan/pubkey.h>
 #endif
 
 namespace Botan_Tests {
@@ -22,16 +24,7 @@ namespace {
 class DSA_KAT_Tests final : public PK_Signature_Generation_Test {
    public:
       DSA_KAT_Tests() :
-            PK_Signature_Generation_Test("DSA",
-   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                         "pubkey/dsa_rfc6979.vec",
-                                         "P,Q,G,X,Hash,Msg,Signature",
-   #else
-                                         "pubkey/dsa_prob.vec",
-                                         "P,Q,G,X,Hash,Msg,Nonce,Signature",
-   #endif
-                                         "") {
-      }
+            PK_Signature_Generation_Test("DSA", "pubkey/dsa_prob.vec", "P,Q,G,X,Hash,Msg,Nonce,Signature", "") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -49,19 +42,49 @@ class DSA_KAT_Tests final : public PK_Signature_Generation_Test {
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
 };
 
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+
+class DSA_RFC6979_KAT_Tests final : public Text_Based_Test {
+   public:
+      DSA_RFC6979_KAT_Tests() : Text_Based_Test("pubkey/dsa_rfc6979.vec", "P,Q,G,X,Hash,Msg,Signature") {}
+
+      bool clear_between_callbacks() const override { return false; }
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         const std::string hash = vars.get_req_str("Hash");
+         const auto msg = vars.get_req_bin("Msg");
+         const auto expected_sig = vars.get_req_bin("Signature");
+
+         const Botan::BigInt p = vars.get_req_bn("P");
+         const Botan::BigInt q = vars.get_req_bn("Q");
+         const Botan::BigInt g = vars.get_req_bn("G");
+         const Botan::BigInt x = vars.get_req_bn("X");
+
+         Test::Result result("DSA RFC6979 " + hash);
+
+         const Botan::DL_Group group(p, q, g);
+         const Botan::DSA_PrivateKey priv_key(group, x);
+
+         Botan::PK_Signer signer(
+            priv_key, this->rng(), Botan::PK_Signature_Options().with_hash(hash).with_deterministic_signature());
+
+         const auto sig = signer.sign_message(msg, this->rng());
+         result.test_bin_eq("RFC6979 signature matches KAT", sig, expected_sig);
+
+         const auto pub = priv_key.public_key();
+         Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_hash(hash));
+         result.test_is_true("Signature verifies", verifier.verify_message(msg, sig));
+
+         return result;
+      }
+};
+
+   #endif
+
 class DSA_KAT_Verification_Tests final : public PK_Signature_Verification_Test {
    public:
       DSA_KAT_Verification_Tests() :
-            PK_Signature_Verification_Test("DSA",
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                           "pubkey/dsa_rfc6979.vec",
-                                           "P,Q,G,X,Hash,Msg,Signature",
-   #else
-                                           "pubkey/dsa_prob.vec",
-                                           "P,Q,G,X,Hash,Msg,Nonce,Signature",
-   #endif
-                                           "") {
-      }
+            PK_Signature_Verification_Test("DSA", "pubkey/dsa_rfc6979.vec", "P,Q,G,X,Hash,Msg,Signature", "") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -117,6 +140,9 @@ class DSA_Keygen_Tests final : public PK_Key_Generation_Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "dsa_kat_sign", DSA_KAT_Tests);
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+BOTAN_REGISTER_TEST("pubkey", "dsa_rfc6979_sign", DSA_RFC6979_KAT_Tests);
+   #endif
 BOTAN_REGISTER_TEST("pubkey", "dsa_kat_verify", DSA_KAT_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "dsa_misc_verify", DSA_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "dsa_keygen", DSA_Keygen_Tests);

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -14,6 +14,7 @@
    #include <botan/ecdsa.h>
    #include <botan/hash.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pkcs8.h>
    #include <botan/pubkey.h>
    #include <botan/rng.h>
@@ -84,16 +85,7 @@ class ECDSA_Wycheproof_Verification_Tests final : public PK_Signature_Verificati
 class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
    public:
       ECDSA_Signature_KAT_Tests() :
-            PK_Signature_Generation_Test("ECDSA",
-   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                         "pubkey/ecdsa_rfc6979.vec",
-                                         "Group,X,Hash,Msg,Signature") {
-      }
-   #else
-                                         "pubkey/ecdsa_prob.vec",
-                                         "Group,X,Hash,Msg,Nonce,Signature") {
-      }
-   #endif
+            PK_Signature_Generation_Test("ECDSA", "pubkey/ecdsa_prob.vec", "Group,X,Hash,Msg,Nonce,Signature") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -111,28 +103,57 @@ class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
 
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
          // probabilistic ecdsa signature generation extracts more random than just the nonce,
          // but the nonce is extracted first
          return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
-   #endif
 };
+
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+
+class ECDSA_RFC6979_KAT_Tests final : public Text_Based_Test {
+   public:
+      ECDSA_RFC6979_KAT_Tests() : Text_Based_Test("pubkey/ecdsa_rfc6979.vec", "Group,X,Hash,Msg,Signature") {}
+
+      bool clear_between_callbacks() const override { return false; }
+
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
+         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
+      }
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         const std::string group_id = vars.get_req_str("Group");
+         const std::string hash = vars.get_req_str("Hash");
+         const auto msg = vars.get_req_bin("Msg");
+         const auto expected_sig = vars.get_req_bin("Signature");
+         const BigInt x = vars.get_req_bn("X");
+
+         Test::Result result("ECDSA RFC6979 " + group_id + "/" + hash);
+
+         const auto group = Botan::EC_Group::from_name(group_id);
+         const Botan::ECDSA_PrivateKey priv_key(this->rng(), group, x);
+
+         Botan::PK_Signer signer(
+            priv_key, this->rng(), Botan::PK_Signature_Options(hash).with_deterministic_signature());
+
+         const auto sig = signer.sign_message(msg, this->rng());
+         result.test_bin_eq("RFC6979 signature matches KAT", sig, expected_sig);
+
+         const auto pub = priv_key.public_key();
+         Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options(hash));
+         result.test_is_true("Signature verifies", verifier.verify_message(msg, sig));
+
+         return result;
+      }
+};
+
+   #endif
 
 class ECDSA_KAT_Verification_Tests final : public PK_Signature_Verification_Test {
    public:
       ECDSA_KAT_Verification_Tests() :
-            PK_Signature_Verification_Test("ECDSA",
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                           "pubkey/ecdsa_rfc6979.vec",
-                                           "Group,X,Hash,Msg,Signature") {
-      }
-   #else
-                                           "pubkey/ecdsa_prob.vec",
-                                           "Group,X,Hash,Msg,Nonce,Signature") {
-      }
-   #endif
+            PK_Signature_Verification_Test("ECDSA", "pubkey/ecdsa_rfc6979.vec", "Group,X,Hash,Msg,Signature") {}
 
       bool clear_between_callbacks() const override { return false; }
 
@@ -287,8 +308,8 @@ class ECDSA_AllGroups_Test : public Test {
                }
 
                try {
-                  Botan::PK_Signer signer(priv, rng(), hash);
-                  Botan::PK_Verifier verifier(*pub, hash);
+                  Botan::PK_Signer signer(priv, rng(), Botan::PK_Signature_Options().with_hash(hash));
+                  Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_hash(hash));
 
                   for(size_t i = 0; i != 16; ++i) {
                      auto message = Botan::unlock(rng().random_vec(rng().next_byte()));
@@ -357,6 +378,9 @@ class ECDSA_ExplicitCurveKey_Test : public Text_Based_Test {
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify", ECDSA_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify_wycheproof", ECDSA_Wycheproof_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_sign", ECDSA_Signature_KAT_Tests);
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+BOTAN_REGISTER_TEST("pubkey", "ecdsa_rfc6979_sign", ECDSA_RFC6979_KAT_Tests);
+   #endif
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify_kat", ECDSA_KAT_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_sign_verify_der", ECDSA_Sign_Verify_DER_Test);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_keygen", ECDSA_Keygen_Tests);

--- a/src/tests/test_ecdsa.cpp
+++ b/src/tests/test_ecdsa.cpp
@@ -14,6 +14,7 @@
    #include <botan/ecdsa.h>
    #include <botan/hash.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pkcs8.h>
    #include <botan/pubkey.h>
    #include <botan/rng.h>
@@ -26,6 +27,48 @@ namespace {
 
 #if defined(BOTAN_HAS_ECDSA)
 
+bool skip_ecdsa_test(const VarMap& vars) {
+   const bool missing_group = !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
+
+   const bool missing_hash = [&](std::string_view hash) {
+      if(hash.empty()) {
+         return false;
+      }
+
+   #if !defined(BOTAN_HAS_RAW_HASH_FN)
+      if(hash.starts_with("Raw")) {
+         return true;
+      }
+   #endif
+
+   #if !defined(BOTAN_HAS_SHA1)
+      if(hash == "SHA-1") {
+         return true;
+      }
+   #endif
+
+   #if !defined(BOTAN_HAS_SHA2_32)
+      if(hash == "SHA-224" || hash == "SHA-256") {
+         return true;
+      }
+   #endif
+
+   #if !defined(BOTAN_HAS_SHA2_64)
+      if(hash == "SHA-384" || hash == "SHA-512" || hash == "SHA-512/256") {
+         return true;
+      }
+   #endif
+
+      return false;
+   }(vars.get_opt_str("Hash", ""));
+
+   if(missing_group || missing_hash) {
+      return true;
+   } else {
+      return false;
+   }
+}
+
 class ECDSA_Verification_Tests final : public PK_Signature_Verification_Test {
    public:
       ECDSA_Verification_Tests() :
@@ -33,9 +76,7 @@ class ECDSA_Verification_Tests final : public PK_Signature_Verification_Test {
 
       bool clear_between_callbacks() const override { return false; }
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::string group_id = vars.get_req_str("Group");
@@ -63,9 +104,7 @@ class ECDSA_Wycheproof_Verification_Tests final : public PK_Signature_Verificati
 
       bool test_random_invalid_sigs() const override { return false; }
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::string group_id = vars.get_req_str("Group");
@@ -84,22 +123,11 @@ class ECDSA_Wycheproof_Verification_Tests final : public PK_Signature_Verificati
 class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
    public:
       ECDSA_Signature_KAT_Tests() :
-            PK_Signature_Generation_Test("ECDSA",
-   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                         "pubkey/ecdsa_rfc6979.vec",
-                                         "Group,X,Hash,Msg,Signature") {
-      }
-   #else
-                                         "pubkey/ecdsa_prob.vec",
-                                         "Group,X,Hash,Msg,Nonce,Signature") {
-      }
-   #endif
+            PK_Signature_Generation_Test("ECDSA", "pubkey/ecdsa_prob.vec", "Group,X,Hash,Msg,Nonce,Signature") {}
 
       bool clear_between_callbacks() const override { return false; }
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {
          const std::string group_id = vars.get_req_str("Group");
@@ -111,34 +139,76 @@ class ECDSA_Signature_KAT_Tests final : public PK_Signature_Generation_Test {
 
       std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Hash"); }
 
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
       std::unique_ptr<Botan::RandomNumberGenerator> test_rng(const std::vector<uint8_t>& nonce) const override {
          // probabilistic ecdsa signature generation extracts more random than just the nonce,
          // but the nonce is extracted first
          return std::make_unique<Fixed_Output_Position_RNG>(nonce, 1, this->rng());
       }
-   #endif
 };
+
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+
+/*
+* The test data spells an externally computed prehash as "Raw" or "Raw(hash)"
+*/
+Botan::PK_Signature_Options ecdsa_kat_options(const std::string& hash) {
+   if(hash == "Raw") {
+      return Botan::PK_Signature_Options().with_externally_computed_prehash();
+   }
+   if(hash.starts_with("Raw(") && hash.ends_with(")")) {
+      return Botan::PK_Signature_Options().with_externally_computed_prehash(hash.substr(4, hash.size() - 5));
+   }
+   return Botan::PK_Signature_Options().with_hash(hash);
+}
+
+class ECDSA_RFC6979_KAT_Tests final : public Text_Based_Test {
+   public:
+      ECDSA_RFC6979_KAT_Tests() : Text_Based_Test("pubkey/ecdsa_rfc6979.vec", "Group,X,Hash,Msg,Signature") {}
+
+      bool clear_between_callbacks() const override { return false; }
+
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         const std::string group_id = vars.get_req_str("Group");
+         const std::string hash = vars.get_req_str("Hash");
+         const auto msg = vars.get_req_bin("Msg");
+         const auto expected_sig = vars.get_req_bin("Signature");
+         const BigInt x = vars.get_req_bn("X");
+
+         Test::Result result("ECDSA RFC6979 " + group_id + "/" + hash);
+
+         const auto group = Botan::EC_Group::from_name(group_id);
+         const Botan::ECDSA_PrivateKey priv_key(this->rng(), group, x);
+
+         Botan::PK_Signer signer(priv_key, this->rng(), ecdsa_kat_options(hash).with_deterministic_signature());
+
+         const auto sig = signer.sign_message(msg, this->rng());
+         result.test_bin_eq("RFC6979 signature matches KAT", sig, expected_sig);
+
+         const auto pub = priv_key.public_key();
+         Botan::PK_Verifier verifier(*pub, ecdsa_kat_options(hash));
+         result.test_is_true("Signature verifies", verifier.verify_message(msg, sig));
+
+         // The string based interfaces can request RFC 6979 with a ",Deterministic" suffix
+         Botan::PK_Signer legacy_signer(priv_key, this->rng(), hash + ",Deterministic");
+         result.test_bin_eq(
+            "Legacy string RFC6979 signature matches KAT", legacy_signer.sign_message(msg, this->rng()), expected_sig);
+
+         return result;
+      }
+};
+
+   #endif
 
 class ECDSA_KAT_Verification_Tests final : public PK_Signature_Verification_Test {
    public:
       ECDSA_KAT_Verification_Tests() :
-            PK_Signature_Verification_Test("ECDSA",
-   #if !defined(BOTAN_HAS_RFC6979_GENERATOR)
-                                           "pubkey/ecdsa_rfc6979.vec",
-                                           "Group,X,Hash,Msg,Signature") {
-      }
-   #else
-                                           "pubkey/ecdsa_prob.vec",
-                                           "Group,X,Hash,Msg,Nonce,Signature") {
-      }
-   #endif
+            PK_Signature_Verification_Test("ECDSA", "pubkey/ecdsa_rfc6979.vec", "Group,X,Hash,Msg,Signature") {}
 
       bool clear_between_callbacks() const override { return false; }
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::string group_id = vars.get_req_str("Group");
@@ -191,9 +261,7 @@ class ECDSA_Key_Recovery_Tests final : public Text_Based_Test {
    public:
       ECDSA_Key_Recovery_Tests() : Text_Based_Test("pubkey/ecdsa_key_recovery.vec", "Group,Msg,R,S,V,Pubkey") {}
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("ECDSA key recovery");
@@ -241,9 +309,7 @@ class ECDSA_Invalid_Key_Tests final : public Text_Based_Test {
 
       bool clear_between_callbacks() const override { return false; }
 
-      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override {
-         return !Botan::EC_Group::supports_named_group(vars.get_req_str("Group"));
-      }
+      bool skip_this_test(const std::string& /*header*/, const VarMap& vars) override { return skip_ecdsa_test(vars); }
 
       Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
          Test::Result result("ECDSA invalid keys");
@@ -287,8 +353,8 @@ class ECDSA_AllGroups_Test : public Test {
                }
 
                try {
-                  Botan::PK_Signer signer(priv, rng(), hash);
-                  Botan::PK_Verifier verifier(*pub, hash);
+                  Botan::PK_Signer signer(priv, rng(), Botan::PK_Signature_Options().with_hash(hash));
+                  Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_hash(hash));
 
                   for(size_t i = 0; i != 16; ++i) {
                      auto message = Botan::unlock(rng().random_vec(rng().next_byte()));
@@ -357,6 +423,9 @@ class ECDSA_ExplicitCurveKey_Test : public Text_Based_Test {
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify", ECDSA_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify_wycheproof", ECDSA_Wycheproof_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_sign", ECDSA_Signature_KAT_Tests);
+   #if defined(BOTAN_HAS_RFC6979_GENERATOR)
+BOTAN_REGISTER_TEST("pubkey", "ecdsa_rfc6979_sign", ECDSA_RFC6979_KAT_Tests);
+   #endif
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_verify_kat", ECDSA_KAT_Verification_Tests);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_sign_verify_der", ECDSA_Sign_Verify_DER_Test);
 BOTAN_REGISTER_TEST("pubkey", "ecdsa_keygen", ECDSA_Keygen_Tests);

--- a/src/tests/test_ed25519.cpp
+++ b/src/tests/test_ed25519.cpp
@@ -10,6 +10,7 @@
    #include "test_pubkey.h"
    #include <botan/data_src.h>
    #include <botan/ed25519.h>
+   #include <botan/pk_options.h>
    #include <botan/pkcs8.h>
    #include <botan/pubkey.h>
    #include <botan/x509_key.h>
@@ -89,11 +90,11 @@ class Ed25519_Curdle_Format_Tests final : public Test {
          auto pub_key = Botan::X509::load_key(pub_data);
          result.test_is_true("Public key loaded", pub_key != nullptr);
 
-         Botan::PK_Signer signer(*priv_key, this->rng(), "Pure");
+         Botan::PK_Signer signer(*priv_key, this->rng(), Botan::PK_Signature_Options());
          signer.update("message");
          std::vector<uint8_t> sig = signer.signature(this->rng());
 
-         Botan::PK_Verifier verifier(*pub_key, "Pure");
+         Botan::PK_Verifier verifier(*pub_key, Botan::PK_Signature_Options());
          verifier.update("message");
          result.test_is_true("Signature valid", verifier.check_signature(sig));
 

--- a/src/tests/test_hss_lms.cpp
+++ b/src/tests/test_hss_lms.cpp
@@ -12,6 +12,7 @@
    #include "test_pubkey.h"
    #include <botan/hss_lms.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/hss.h>
@@ -128,8 +129,8 @@ class HSS_LMS_Negative_Tests final : public Test {
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
-         Botan::PK_Signer signer(*sk, Test::rng(), "");
-         Botan::PK_Verifier verifier(*sk, "");
+         Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
+         Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
 
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
 
@@ -155,8 +156,8 @@ class HSS_LMS_Negative_Tests final : public Test {
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
-         Botan::PK_Signer signer(*sk, Test::rng(), "");
-         Botan::PK_Verifier verifier(*sk, "");
+         Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
+         Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
 
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
 
@@ -241,7 +242,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
          Test::Result result("HSS-LMS");
 
          auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8),HW(5,8)");
-         Botan::PK_Signer signer(sk, Test::rng(), "");
+         Botan::PK_Signer signer(sk, Test::rng(), Botan::PK_Signature_Options());
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
          auto sk_bytes_begin = sk.private_key_bits();
 
@@ -276,7 +277,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
          const uint64_t total_sig_count = 32;
          auto sk = create_private_key_with_idx(total_sig_count - 1);
 
-         Botan::PK_Signer signer(sk, Test::rng(), "");
+         Botan::PK_Signer signer(sk, Test::rng(), Botan::PK_Signature_Options());
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
          auto sk_bytes_begin = sk.private_key_bits();
 
@@ -307,14 +308,14 @@ class HSS_LMS_Missing_API_Test final : public Test {
                            3 * sizeof(uint32_t) + Botan::LMS_IDENTIFIER_LEN);
 
          // HSS_LMS_Verification_Operation::hash_function()
-         const Botan::PK_Verifier verifier(*sk, "");
+         Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
          result.test_str_eq("PK_Verifier should report the hash of the key", verifier.hash_function(), "SHA-256");
 
          // HSS_LMS_PrivateKey::raw_private_key_bits()
          result.test_bin_eq("Our BER and raw encoding is the same", sk->raw_private_key_bits(), sk->private_key_bits());
 
          // HSS_LMS_Signature_Operation::algorithm_identifier()
-         const Botan::PK_Signer signer(*sk, Test::rng(), "");
+         Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
          result.test_is_true("signature algorithm", signer.algorithm_identifier() == sk->algorithm_identifier());
 
          // HSS_LMS_Signature_Operation::hash_function()

--- a/src/tests/test_hss_lms.cpp
+++ b/src/tests/test_hss_lms.cpp
@@ -14,6 +14,7 @@
    #include <botan/exceptn.h>
    #include <botan/hss_lms.h>
    #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/hss.h>
@@ -140,8 +141,8 @@ class HSS_LMS_Negative_Tests final : public Test {
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
-         Botan::PK_Signer signer(*sk, Test::rng(), "");
-         Botan::PK_Verifier verifier(*sk, "");
+         Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
+         Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
 
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
 
@@ -167,8 +168,8 @@ class HSS_LMS_Negative_Tests final : public Test {
 
          auto sk = Botan::create_private_key("HSS-LMS", Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
 
-         Botan::PK_Signer signer(*sk, Test::rng(), "");
-         Botan::PK_Verifier verifier(*sk, "");
+         Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
+         Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
 
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
 
@@ -253,7 +254,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
          Test::Result result("HSS-LMS");
 
          auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8),HW(5,8)");
-         Botan::PK_Signer signer(sk, Test::rng(), "");
+         Botan::PK_Signer signer(sk, Test::rng(), Botan::PK_Signature_Options());
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
          auto sk_bytes_begin = sk.private_key_bits();
 
@@ -288,7 +289,7 @@ class HSS_LMS_Statefulness_Test final : public Test {
          const uint64_t total_sig_count = 32;
          auto sk = create_private_key_with_idx(total_sig_count - 1);
 
-         Botan::PK_Signer signer(sk, Test::rng(), "");
+         Botan::PK_Signer signer(sk, Test::rng(), Botan::PK_Signature_Options());
          std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
          auto sk_bytes_begin = sk.private_key_bits();
 
@@ -512,14 +513,14 @@ class HSS_LMS_Missing_API_Test final : public Test {
                            3 * sizeof(uint32_t) + Botan::LMS_IDENTIFIER_LEN);
 
          // HSS_LMS_Verification_Operation::hash_function()
-         const Botan::PK_Verifier verifier(*sk, "");
+         const Botan::PK_Verifier verifier(*sk, Botan::PK_Signature_Options());
          result.test_str_eq("PK_Verifier should report the hash of the key", verifier.hash_function(), "SHA-256");
 
          // HSS_LMS_PrivateKey::raw_private_key_bits()
          result.test_bin_eq("Our BER and raw encoding is the same", sk->raw_private_key_bits(), sk->private_key_bits());
 
          // HSS_LMS_Signature_Operation::algorithm_identifier()
-         const Botan::PK_Signer signer(*sk, Test::rng(), "");
+         const Botan::PK_Signer signer(*sk, Test::rng(), Botan::PK_Signature_Options());
          result.test_is_true("signature algorithm", signer.algorithm_identifier() == sk->algorithm_identifier());
 
          // HSS_LMS_Signature_Operation::hash_function()

--- a/src/tests/test_pk_pad.cpp
+++ b/src/tests/test_pk_pad.cpp
@@ -12,6 +12,7 @@
 #endif
 
 #if defined(BOTAN_HAS_RSA_SIGNATURE_PADDING)
+   #include <botan/pk_options.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/sig_padding.h>
 #endif
@@ -68,87 +69,6 @@ class EME_PKCS1v15_Decoding_Tests final : public Text_Based_Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "eme_pkcs1v15", EME_PKCS1v15_Decoding_Tests);
-#endif
-
-#if defined(BOTAN_HAS_RSA_SIGNATURE_PADDING)
-class SignaturePaddingSchemeNameTests final : public Test {
-   public:
-      std::vector<Test::Result> run() override {
-         Test::Result result("SignaturePaddingScheme::name");
-
-         const std::vector<std::string> pads_need_hash = {
-   #if BOTAN_HAS_EMSA_X931
-            "X9.31",
-   #endif
-   #if BOTAN_HAS_EMSA_PKCS1
-            "PKCS1v15",
-   #endif
-   #if BOTAN_HAS_EMSA_PSSR
-            "PSS",
-            "PSS_Raw",
-   #endif
-   #if BOTAN_HAS_ISO_9796
-            "ISO_9796_DS2",
-            "ISO_9796_DS3",
-   #endif
-         };
-
-         const std::vector<std::string> pads_no_hash = {
-   #if BOTAN_HAS_EMSA_RAW
-            "Raw",
-   #endif
-   #if BOTAN_HAS_EMSA_PKCS1
-            "PKCS1v15(Raw)",
-            "PKCS1v15(Raw,SHA-512)",
-   #endif
-         };
-
-         for(const auto& pad : pads_need_hash) {
-            try {
-               const std::string hash_to_use = "SHA-256";
-               auto padding = Botan::SignaturePaddingScheme::create_or_throw(Botan::fmt("{}({})", pad, hash_to_use));
-               auto padding_copy = Botan::SignaturePaddingScheme::create(padding->name());
-               result.test_str_eq("SignaturePaddingScheme::name for " + pad, padding->name(), padding_copy->name());
-            } catch(Botan::Lookup_Error&) {
-               result.test_note("Skipping test due to missing hash");
-            } catch(const std::exception& e) {
-               result.test_failure("SignaturePaddingScheme::name for " + pad + ": " + e.what());
-            }
-         }
-
-         for(const auto& pad : pads_need_hash) {
-            const std::string algo_name = pad + "(YYZ)";
-            try {
-               auto padding = Botan::SignaturePaddingScheme::create_or_throw(algo_name);
-               result.test_failure("SignaturePaddingScheme::name for " + pad + ": " +
-                                   "Could create SignaturePaddingScheme with fantasy hash YYZ");
-            } catch(Botan::Lookup_Error&) {
-               result.test_note("Skipping test due to missing hash");
-            } catch(const std::exception& e) {
-               result.test_str_eq("SignaturePaddingScheme::name for " + pad,
-                                  e.what(),
-                                  "Could not find any algorithm named \"" + algo_name + "\"");
-            }
-         }
-
-         for(const auto& pad : pads_no_hash) {
-            try {
-               auto padding = Botan::SignaturePaddingScheme::create(pad);
-               auto padding_copy = Botan::SignaturePaddingScheme::create(padding->name());
-               result.test_str_eq("SignaturePaddingScheme::name for " + pad, padding->name(), padding_copy->name());
-            } catch(Botan::Lookup_Error&) {
-               result.test_note("Skipping test due to missing hash");
-            } catch(const std::exception& e) {
-               result.test_failure("SignaturePaddingScheme::name for " + pad + ": " + e.what());
-            }
-         }
-
-         return {result};
-      }
-};
-
-BOTAN_REGISTER_TEST("pubkey", "sig_padding_name", SignaturePaddingSchemeNameTests);
-
 #endif
 
 }  // namespace

--- a/src/tests/test_pk_sig_options.cpp
+++ b/src/tests/test_pk_sig_options.cpp
@@ -1,0 +1,250 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
+
+   #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
+   #include <botan/pubkey.h>
+   #include <sstream>
+
+namespace Botan_Tests {
+
+namespace {
+
+std::string_view strip_ws(std::string_view s) {
+   while(!s.empty() && (s.front() == ' ' || s.front() == '\t')) {
+      s.remove_prefix(1);
+   }
+   while(!s.empty() && (s.back() == ' ' || s.back() == '\t')) {
+      s.remove_suffix(1);
+   }
+   return s;
+}
+
+struct AlgoTestConfig {
+      std::string algo_name;
+      std::string key_params;
+      std::string hash;
+      std::string padding;
+      std::vector<std::pair<std::string, bool>> option_support;
+};
+
+std::vector<AlgoTestConfig> parse_sig_options_vec(const std::string& contents) {
+   std::vector<AlgoTestConfig> configs;
+   AlgoTestConfig* current = nullptr;
+
+   std::istringstream iss(contents);
+   std::string line;
+
+   while(std::getline(iss, line)) {
+      // Strip inline comments
+      if(auto pos = line.find('#'); pos != std::string::npos) {
+         line.erase(pos);
+      }
+
+      const auto sv = strip_ws(line);
+      if(sv.empty()) {
+         continue;
+      }
+
+      if(sv.front() == '[' && sv.back() == ']') {
+         configs.emplace_back();
+         current = &configs.back();
+         current->algo_name = std::string(sv.substr(1, sv.size() - 2));
+         continue;
+      }
+
+      if(current == nullptr) {
+         throw Test_Error("Key-value pair outside of section");
+      }
+
+      const auto eq = sv.find('=');
+      if(eq == std::string_view::npos) {
+         throw Test_Error(std::string("Line missing '=': ") + std::string(sv));
+      }
+
+      const auto key = strip_ws(sv.substr(0, eq));
+      const auto value = strip_ws(sv.substr(eq + 1));
+
+      if(key == "KeyParams") {
+         current->key_params = std::string(value);
+      } else if(key == "Hash") {
+         current->hash = std::string(value);
+      } else if(key == "Padding") {
+         current->padding = std::string(value);
+      } else if(key.starts_with("Supports")) {
+         const auto opt_name = key.substr(8);  // strip "Supports" prefix
+         bool supported = false;
+         if(value == "true") {
+            supported = true;
+         } else if(value == "false") {
+            supported = false;
+         } else {
+            throw Test_Error(std::string("Invalid boolean: '") + std::string(value) + "'");
+         }
+         current->option_support.emplace_back(std::string(opt_name), supported);
+      } else {
+         throw Test_Error(std::string("Unknown key: '") + std::string(key) + "'");
+      }
+   }
+
+   return configs;
+}
+
+Botan::PK_Signature_Options make_baseline(const AlgoTestConfig& config) {
+   Botan::PK_Signature_Options opts;
+   if(!config.hash.empty()) {
+      opts = opts.with_hash(config.hash);
+   }
+   if(!config.padding.empty()) {
+      opts = opts.with_padding(config.padding);
+   }
+   return opts;
+}
+
+Botan::PK_Signature_Options with_added_option(Botan::PK_Signature_Options baseline, std::string_view option) {
+   if(option == "Padding") {
+      return baseline.with_padding("PKCS1v15");
+   }
+   if(option == "Prehash") {
+      return baseline.with_prehash();
+   }
+   if(option == "Context") {
+      return baseline.with_context("test context");
+   }
+   if(option == "DER") {
+      return baseline.with_der_encoded_signature();
+   }
+   if(option == "SaltSize") {
+      return baseline.with_salt_size(32);
+   }
+   if(option == "Deterministic") {
+      return baseline.with_deterministic_signature();
+   }
+   if(option == "ExplicitTrailer") {
+      return baseline.with_explicit_trailer_field();
+   }
+   if(option == "Hash") {
+      return baseline.with_hash("SHA-256");
+   }
+   throw Test_Error(std::string("Unknown option name: '") + std::string(option) + "'");
+}
+
+class PK_Signature_Options_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         const auto file_contents = Test::read_data_file("pubkey/pk_sig_options.vec");
+         const auto configs = parse_sig_options_vec(file_contents);
+
+         std::vector<Test::Result> results;
+
+         for(const auto& config : configs) {
+            Test::Result result("PK_Sig_Options " + config.algo_name);
+            result.start_timer();
+
+            std::unique_ptr<Botan::Private_Key> key;
+            try {
+               // For entries like "RSA/PSS", use just "RSA" for key generation
+               auto key_algo = config.algo_name;
+               if(auto slash = key_algo.find('/'); slash != std::string::npos) {
+                  key_algo = key_algo.substr(0, slash);
+               }
+               key = Botan::create_private_key(key_algo, rng(), config.key_params);
+            } catch(const Botan::Lookup_Error&) {
+               result.test_note("Skipping - algorithm not available");
+               result.end_timer();
+               results.push_back(std::move(result));
+               continue;
+            }
+
+            if(!key) {
+               result.test_failure("Key generation returned null");
+               result.end_timer();
+               results.push_back(std::move(result));
+               continue;
+            }
+
+            const auto pub = key->public_key();
+
+            // Test that the baseline options produce valid signatures
+            test_baseline(result, *key, *pub, config);
+
+            // Test each option individually
+            for(const auto& [opt_name, supported] : config.option_support) {
+               if(supported) {
+                  test_option_accepted(result, *key, *pub, config, opt_name);
+               } else {
+                  test_option_rejected(result, *key, *pub, config, opt_name);
+               }
+            }
+
+            result.end_timer();
+            results.push_back(std::move(result));
+         }
+
+         return results;
+      }
+
+   private:
+      void test_baseline(Test::Result& result,
+                         const Botan::Private_Key& key,
+                         const Botan::Public_Key& pub,
+                         const AlgoTestConfig& config) {
+         result.test_no_throw("Baseline signer creation", [&] {
+            const auto opts = make_baseline(config);
+            Botan::PK_Signer signer(key, rng(), opts);
+            Botan::PK_Verifier verifier(pub, make_baseline(config));
+
+            const std::vector<uint8_t> message = {0x61, 0x62, 0x63, 0x64};
+            auto sig = signer.sign_message(message, rng());
+            result.test_is_true("Baseline sign/verify", verifier.verify_message(message, sig));
+         });
+      }
+
+      void test_option_accepted(Test::Result& result,
+                                const Botan::Private_Key& key,
+                                const Botan::Public_Key& pub,
+                                const AlgoTestConfig& config,
+                                const std::string& opt_name) {
+         result.test_no_throw(opt_name + " accepted", [&] {
+            const auto opts = with_added_option(make_baseline(config), opt_name);
+            Botan::PK_Signer signer(key, rng(), opts);
+            Botan::PK_Verifier verifier(pub, with_added_option(make_baseline(config), opt_name));
+
+            const std::vector<uint8_t> message = {0x61, 0x62, 0x63, 0x64};
+            auto sig = signer.sign_message(message, rng());
+            result.test_is_true(opt_name + " sign/verify", verifier.verify_message(message, sig));
+         });
+      }
+
+      void test_option_rejected(Test::Result& result,
+                                const Botan::Private_Key& key,
+                                const Botan::Public_Key& pub,
+                                const AlgoTestConfig& config,
+                                const std::string& opt_name) {
+         const auto opts = with_added_option(make_baseline(config), opt_name);
+
+         result.test_throws(opt_name + " rejected by signer", [&] { Botan::PK_Signer(key, rng(), opts); });
+
+         // Deterministic is a signing-only option; verifiers don't check it
+         if(opt_name == "Deterministic") {
+            return;
+         }
+
+         result.test_throws(opt_name + " rejected by verifier", [&] { Botan::PK_Verifier(pub, opts); });
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options", PK_Signature_Options_Test);
+
+}  // namespace
+
+}  // namespace Botan_Tests
+
+#endif

--- a/src/tests/test_pk_sig_options.cpp
+++ b/src/tests/test_pk_sig_options.cpp
@@ -1,0 +1,740 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_PUBLIC_KEY_CRYPTO)
+
+   #include <botan/hash.h>
+   #include <botan/pk_algs.h>
+   #include <botan/pk_options.h>
+   #include <botan/pubkey.h>
+   #include <botan/internal/fmt.h>
+   #include <algorithm>
+   #include <optional>
+   #include <sstream>
+
+namespace Botan_Tests {
+
+namespace {
+
+std::string_view strip_ws(std::string_view s) {
+   while(!s.empty() && (s.front() == ' ' || s.front() == '\t')) {
+      s.remove_prefix(1);
+   }
+   while(!s.empty() && (s.back() == ' ' || s.back() == '\t')) {
+      s.remove_suffix(1);
+   }
+   return s;
+}
+
+struct AlgoTestConfig {
+      std::string algo_name;
+      std::string key_params;
+      std::string hash;
+      std::string padding;
+      std::vector<std::pair<std::string, bool>> option_support;
+};
+
+bool has_expectation_for(const AlgoTestConfig& config, std::string_view option) {
+   if(option == "Hash" && !config.hash.empty()) {
+      return true;
+   }
+   if(option == "Padding" && !config.padding.empty()) {
+      return true;
+   }
+   for(const auto& [name, supported] : config.option_support) {
+      if(name == option) {
+         return true;
+      }
+   }
+   return false;
+}
+
+std::vector<AlgoTestConfig> parse_sig_options_vec(const std::string& contents) {
+   /*
+   * Every option which can be set on a PK_Signature_Options
+   *
+   * Each algorithm section in the data file must either use an option in its
+   * baseline (Hash/Padding) or state via Supports<Option> whether it is accepted.
+   * This way adding a new option without deciding its status for every algorithm
+   * fails the test, rather than the option being silently ignored somewhere.
+   */
+   const std::vector<std::string> ALL_OPTIONS = {"Hash",
+                                                 "Padding",
+                                                 "Prehash",
+                                                 "ExternalPrehash",
+                                                 "Context",
+                                                 "DER",
+                                                 "SaltSize",
+                                                 "Deterministic",
+                                                 "ExplicitTrailer"};
+
+   std::vector<AlgoTestConfig> configs;
+   AlgoTestConfig* current = nullptr;
+
+   std::istringstream iss(contents);
+   std::string line;
+
+   while(std::getline(iss, line)) {
+      // Strip inline comments
+      if(auto pos = line.find('#'); pos != std::string::npos) {
+         line.erase(pos);
+      }
+
+      const auto sv = strip_ws(line);
+      if(sv.empty()) {
+         continue;
+      }
+
+      if(sv.front() == '[' && sv.back() == ']') {
+         configs.emplace_back();
+         current = &configs.back();
+         current->algo_name = std::string(sv.substr(1, sv.size() - 2));
+         continue;
+      }
+
+      if(current == nullptr) {
+         throw Test_Error("Key-value pair outside of section");
+      }
+
+      const auto eq = sv.find('=');
+      if(eq == std::string_view::npos) {
+         throw Test_Error(std::string("Line missing '=': ") + std::string(sv));
+      }
+
+      const auto key = strip_ws(sv.substr(0, eq));
+      const auto value = strip_ws(sv.substr(eq + 1));
+
+      if(key == "KeyParams") {
+         current->key_params = std::string(value);
+      } else if(key == "Hash") {
+         current->hash = std::string(value);
+      } else if(key == "Padding") {
+         current->padding = std::string(value);
+      } else if(key.starts_with("Supports")) {
+         const auto opt_name = key.substr(8);  // strip "Supports" prefix
+         if(std::find(ALL_OPTIONS.begin(), ALL_OPTIONS.end(), opt_name) == ALL_OPTIONS.end()) {
+            throw Test_Error(std::string("Unknown option: '") + std::string(opt_name) + "'");
+         }
+         bool supported = false;
+         if(value == "true") {
+            supported = true;
+         } else if(value == "false") {
+            supported = false;
+         } else {
+            throw Test_Error(std::string("Invalid boolean: '") + std::string(value) + "'");
+         }
+         current->option_support.emplace_back(std::string(opt_name), supported);
+      } else {
+         throw Test_Error(std::string("Unknown key: '") + std::string(key) + "'");
+      }
+   }
+
+   for(const auto& config : configs) {
+      for(const auto& option : ALL_OPTIONS) {
+         if(!has_expectation_for(config, option)) {
+            throw Test_Error(Botan::fmt("[{}] does not state if option {} is supported", config.algo_name, option));
+         }
+      }
+   }
+
+   return configs;
+}
+
+Botan::PK_Signature_Options make_baseline(const AlgoTestConfig& config) {
+   Botan::PK_Signature_Options opts;
+   if(!config.hash.empty()) {
+      opts = opts.with_hash(config.hash);
+   }
+   if(!config.padding.empty()) {
+      opts = opts.with_padding(config.padding);
+   }
+   return opts;
+}
+
+Botan::PK_Signature_Options with_added_option(Botan::PK_Signature_Options baseline, std::string_view option) {
+   if(option == "Padding") {
+      return baseline.with_padding("PKCS1v15");
+   }
+   if(option == "Prehash") {
+      return baseline.with_prehash();
+   }
+   if(option == "ExternalPrehash") {
+      return baseline.with_externally_computed_prehash();
+   }
+   if(option == "Context") {
+      return baseline.with_context("test context");
+   }
+   if(option == "DER") {
+      return baseline.with_der_encoded_signature();
+   }
+   if(option == "SaltSize") {
+      return baseline.with_salt_size(32);
+   }
+   if(option == "Deterministic") {
+      return baseline.with_deterministic_signature();
+   }
+   if(option == "ExplicitTrailer") {
+      return baseline.with_explicit_trailer_field();
+   }
+   if(option == "Hash") {
+      return baseline.with_hash("SHA-256");
+   }
+   throw Test_Error(std::string("Unknown option name: '") + std::string(option) + "'");
+}
+
+/*
+* Verifier options which conflict with a signature created using the given
+* option; verifying with these must fail (or the verifier must refuse them),
+* otherwise the option was accepted by the signer but not actually applied.
+*/
+std::optional<Botan::PK_Signature_Options> conflicting_verifier_options(Botan::PK_Signature_Options baseline,
+                                                                        std::string_view option) {
+   if(option == "Context") {
+      return baseline.with_context("a different context");
+   }
+   if(option == "SaltSize") {
+      return baseline.with_salt_size(16);
+   }
+   if(option == "Prehash" || option == "ExternalPrehash" || option == "DER" || option == "ExplicitTrailer") {
+      // The baseline itself does not use the option
+      return baseline;
+   }
+   return std::nullopt;
+}
+
+class PK_Signature_Options_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         const auto file_contents = Test::read_data_file("pubkey/pk_sig_options.vec");
+         const auto configs = parse_sig_options_vec(file_contents);
+
+         std::vector<Test::Result> results;
+
+         for(const auto& config : configs) {
+            Test::Result result("PK_Sig_Options " + config.algo_name);
+            result.start_timer();
+
+            std::unique_ptr<Botan::Private_Key> key;
+            try {
+               // For entries like "RSA/PSS", use just "RSA" for key generation
+               auto key_algo = config.algo_name;
+               if(auto slash = key_algo.find('/'); slash != std::string::npos) {
+                  key_algo = key_algo.substr(0, slash);
+               }
+               key = Botan::create_private_key(key_algo, rng(), config.key_params);
+            } catch(const Botan::Lookup_Error&) {
+               result.test_note("Skipping - algorithm not available");
+               result.end_timer();
+               results.push_back(std::move(result));
+               continue;
+            }
+
+            if(!key) {
+               result.test_note("Key generation unavailable");
+               result.end_timer();
+               results.push_back(std::move(result));
+               continue;
+            }
+
+            const auto pub = key->public_key();
+
+            // Test that the baseline options produce valid signatures; if the
+            // baseline itself is not available in this build (eg the padding
+            // scheme or hash was disabled) there is nothing further to test
+            if(!test_baseline(result, *key, *pub, config)) {
+               result.end_timer();
+               results.push_back(std::move(result));
+               continue;
+            }
+
+            // Test each option individually
+            for(const auto& [opt_name, supported] : config.option_support) {
+               if(supported) {
+                  test_option_accepted(result, *key, *pub, config, opt_name);
+               } else {
+                  test_option_rejected(result, *key, *pub, config, opt_name);
+               }
+            }
+
+            result.end_timer();
+            results.push_back(std::move(result));
+         }
+
+         return results;
+      }
+
+   private:
+      /*
+      * Return true if the exception indicates the configuration is not
+      * available in this build (as opposed to being rejected as invalid)
+      */
+      static bool is_unavailable(const Botan::Exception& e) {
+         return dynamic_cast<const Botan::Lookup_Error*>(&e) != nullptr ||
+                dynamic_cast<const Botan::Not_Implemented*>(&e) != nullptr;
+      }
+
+      bool test_baseline(Test::Result& result,
+                         const Botan::Private_Key& key,
+                         const Botan::Public_Key& pub,
+                         const AlgoTestConfig& config) {
+         try {
+            const auto opts = make_baseline(config);
+            Botan::PK_Signer signer(key, rng(), opts);
+            Botan::PK_Verifier verifier(pub, make_baseline(config));
+
+            const std::vector<uint8_t> message = {0x61, 0x62, 0x63, 0x64};
+            auto sig = signer.sign_message(message, rng());
+            result.test_is_true("Baseline sign/verify", verifier.verify_message(message, sig));
+            return true;
+         } catch(const Botan::Exception& e) {
+            if(is_unavailable(e)) {
+               result.test_note(std::string("Skipping - baseline not available in this build: ") + e.what());
+               return false;
+            }
+            result.test_failure("Baseline signer creation", e.what());
+            return false;
+         }
+      }
+
+      void test_option_accepted(Test::Result& result,
+                                const Botan::Private_Key& key,
+                                const Botan::Public_Key& pub,
+                                const AlgoTestConfig& config,
+                                const std::string& opt_name) {
+         try {
+            const auto opts = with_added_option(make_baseline(config), opt_name);
+            Botan::PK_Signer signer(key, rng(), opts);
+            Botan::PK_Verifier verifier(pub, with_added_option(make_baseline(config), opt_name));
+
+            const std::vector<uint8_t> original_message = {0x61, 0x62, 0x63, 0x64};
+
+            // With an external prehash the input must be a digest of the baseline hash
+            const bool prehashed = (opt_name == "ExternalPrehash" && !config.hash.empty());
+            const std::vector<uint8_t> message = [&]() {
+               if(prehashed) {
+                  return Botan::HashFunction::create_or_throw(config.hash)
+                     ->process<std::vector<uint8_t>>(original_message);
+               }
+               return original_message;  // NOLINT(*-no-automatic-move)
+            }();
+
+            auto sig = signer.sign_message(message, rng());
+            result.test_is_true(opt_name + " sign/verify", verifier.verify_message(message, sig));
+
+            if(prehashed) {
+               // Signing the digest must produce the same signature type as hashing the message
+               Botan::PK_Verifier baseline_verifier(pub, make_baseline(config));
+               result.test_is_true("ExternalPrehash signature verifies over the original message",
+                                   baseline_verifier.verify_message(original_message, sig));
+            }
+
+            // Now check that the option actually took effect
+            if(opt_name == "Deterministic") {
+               // Stateful schemes never produce the same signature twice
+               if(!key.stateful_operation()) {
+                  auto sig2 = signer.sign_message(message, rng());
+                  result.test_bin_eq("Deterministic signatures are identical", sig, sig2);
+               }
+            } else if(auto conflicting = conflicting_verifier_options(make_baseline(config), opt_name)) {
+               bool rejected = false;
+               try {
+                  Botan::PK_Verifier other_verifier(pub, *conflicting);
+                  rejected = !other_verifier.verify_message(message, sig);
+               } catch(Botan::Exception&) {
+                  rejected = true;
+               }
+               result.test_is_true(opt_name + " is applied (conflicting verifier rejects)", rejected);
+            }
+            result.test_success(opt_name + " accepted");
+         } catch(const Botan::Exception& e) {
+            if(is_unavailable(e)) {
+               // eg deterministic ECDSA in a build without RFC 6979
+               result.test_note(opt_name + " not available in this build: " + e.what());
+            } else {
+               result.test_failure(opt_name + " accepted", e.what());
+            }
+         }
+      }
+
+      void test_option_rejected(Test::Result& result,
+                                const Botan::Private_Key& key,
+                                const Botan::Public_Key& pub,
+                                const AlgoTestConfig& config,
+                                const std::string& opt_name) {
+         const auto opts = with_added_option(make_baseline(config), opt_name);
+
+         result.test_throws(opt_name + " rejected by signer", [&] { Botan::PK_Signer(key, rng(), opts); });
+
+         // Deterministic is a signing-only option; verifiers don't check it
+         if(opt_name == "Deterministic") {
+            return;
+         }
+
+         result.test_throws(opt_name + " rejected by verifier", [&] { Botan::PK_Verifier(pub, opts); });
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options", PK_Signature_Options_Test);
+
+   #if defined(BOTAN_HAS_ED25519)
+
+/*
+* An option which no part of the signature scheme examines must be rejected,
+* naming the offending option, without any scheme specific code.
+*/
+class PK_Signature_Options_Unexamined_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("PK_Signature_Options rejects unexamined options");
+
+         auto key = Botan::create_private_key("Ed25519", rng());
+         if(!key) {
+            result.test_note("Skipping - Ed25519 not available");
+            return {result};
+         }
+         const auto pub = key->public_key();
+
+         const auto opts = Botan::PK_Signature_Options().with_salt_size(32).with_explicit_trailer_field();
+
+         auto check_message = [&](const std::string& what, const std::exception& e) {
+            const std::string msg = e.what();
+            result.test_is_true(what + " names the unexamined options",
+                                msg.find("Ed25519 does not support the signature option(s): salt size, explicit "
+                                         "trailer field") != std::string::npos);
+         };
+
+         try {
+            const Botan::PK_Signer signer(*key, rng(), opts);
+            result.test_failure("PK_Signer accepted unexamined options");
+         } catch(Botan::Invalid_Argument& e) {
+            check_message("PK_Signer", e);
+         }
+
+         try {
+            const Botan::PK_Verifier verifier(*pub, opts);
+            result.test_failure("PK_Verifier accepted unexamined options");
+         } catch(Botan::Invalid_Argument& e) {
+            check_message("PK_Verifier", e);
+         }
+
+         // The deterministic option is only meaningful for signing; verifiers accept it
+         result.test_no_throw("Verifier ignores deterministic option", [&] {
+            const Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_deterministic_signature());
+         });
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options_unexamined", PK_Signature_Options_Unexamined_Test);
+
+   #endif
+
+   #if defined(BOTAN_HAS_RSA) && defined(BOTAN_HAS_EMSA_PKCS1) && defined(BOTAN_HAS_EMSA_RAW) && defined(BOTAN_HAS_PSS)
+
+/*
+* RSA must never fall back to raw or hashless signing when options are missing
+*/
+class PK_Signature_Options_RSA_Explicit_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("PK_Signature_Options RSA requires explicit padding");
+
+         auto key = Botan::create_private_key("RSA", rng(), "1024");
+         if(!key) {
+            result.test_note("Skipping - RSA not available");
+            return {result};
+         }
+         const auto pub = key->public_key();
+
+         auto rejected = [&](const std::string& what, const Botan::PK_Signature_Options& opts) {
+            result.test_throws(what + " rejected by signer", [&] { Botan::PK_Signer(*key, rng(), opts); });
+            result.test_throws(what + " rejected by verifier", [&] { Botan::PK_Verifier(*pub, opts); });
+         };
+
+         rejected("No options", Botan::PK_Signature_Options());
+         rejected("Hash without padding", Botan::PK_Signature_Options().with_hash("SHA-256"));
+         rejected("PKCS1v15 without hash", Botan::PK_Signature_Options().with_padding("PKCS1v15"));
+         rejected("PSS without hash", Botan::PK_Signature_Options().with_padding("PSS"));
+         rejected("Raw with unknown external prehash",
+                  Botan::PK_Signature_Options().with_padding("Raw").with_externally_computed_prehash("NoSuchHash"));
+         rejected("Raw with internal prehash", Botan::PK_Signature_Options().with_padding("Raw").with_prehash());
+         rejected("Raw with a hash but no external prehash",
+                  Botan::PK_Signature_Options().with_padding("Raw").with_hash("SHA-256"));
+         rejected("PKCS1v15 with internal prehash",
+                  Botan::PK_Signature_Options().with_padding("PKCS1v15").with_hash("SHA-256").with_prehash());
+         rejected("PKCS1v15 with Raw as the hash name",
+                  Botan::PK_Signature_Options().with_padding("PKCS1v15").with_hash("Raw"));
+         rejected("PKCS1v15 with mismatched external prehash",
+                  Botan::PK_Signature_Options()
+                     .with_padding("PKCS1v15")
+                     .with_hash("SHA-256")
+                     .with_externally_computed_prehash("SHA-384"));
+         rejected(
+            "PSS with external prehash",
+            Botan::PK_Signature_Options().with_padding("PSS").with_hash("SHA-256").with_externally_computed_prehash());
+
+         // Raw signing is still available, but only when asked for explicitly
+         result.test_no_throw("Explicit raw padding accepted", [&] {
+            Botan::PK_Signer signer(*key, rng(), Botan::PK_Signature_Options().with_padding("Raw"));
+            Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_padding("Raw"));
+            const std::vector<uint8_t> msg(32, 0x42);
+            const auto sig = signer.sign_message(msg, rng());
+            result.test_is_true("Raw roundtrip", verifier.verify_message(msg, sig));
+         });
+
+         // Naming the hash of an external prehash enforces the digest length
+         result.test_no_throw("Raw padding with named external prehash", [&] {
+            const auto raw_sha256 =
+               Botan::PK_Signature_Options().with_padding("Raw").with_externally_computed_prehash("SHA-256");
+            Botan::PK_Signer signer(*key, rng(), raw_sha256);
+            Botan::PK_Verifier verifier(*pub, raw_sha256);
+            const std::vector<uint8_t> digest(32, 0x42);
+            const auto sig = signer.sign_message(digest, rng());
+            result.test_is_true("Raw(SHA-256) roundtrip", verifier.verify_message(digest, sig));
+
+            const std::vector<uint8_t> short_digest(20, 0x42);
+            result.test_throws("Raw(SHA-256) rejects a 20 byte input",
+                               [&] { signer.sign_message(short_digest, rng()); });
+         });
+
+         result.test_no_throw("PKCS1v15 with unnamed external prehash", [&] {
+            const auto pkcs1_raw =
+               Botan::PK_Signature_Options().with_padding("PKCS1v15").with_externally_computed_prehash();
+            Botan::PK_Signer signer(*key, rng(), pkcs1_raw);
+            Botan::PK_Verifier verifier(*pub, pkcs1_raw);
+            const std::vector<uint8_t> digest(20, 0x42);
+            const auto sig = signer.sign_message(digest, rng());
+            result.test_is_true("PKCS1v15(Raw) roundtrip", verifier.verify_message(digest, sig));
+         });
+
+         // The deterministic option is ignored for verification, even where the
+         // padding scheme would reject it for signing
+         auto pss = Botan::PK_Signature_Options().with_padding("PSS").with_hash("SHA-256");
+         result.test_throws("PSS with salt cannot be deterministic when signing",
+                            [&] { Botan::PK_Signer(*key, rng(), pss.with_deterministic_signature()); });
+         result.test_no_throw("Verifier ignores deterministic for PSS", [&] {
+            Botan::PK_Signer signer(*key, rng(), pss);
+            Botan::PK_Verifier verifier(*pub, pss.with_deterministic_signature());
+            const std::vector<uint8_t> msg(32, 0x42);
+            const auto sig = signer.sign_message(msg, rng());
+            result.test_is_true("PSS roundtrip", verifier.verify_message(msg, sig));
+         });
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options_rsa_explicit", PK_Signature_Options_RSA_Explicit_Test);
+
+   #endif
+
+/*
+* Each boolean option can be requested at most once, matching the other setters
+*/
+class PK_Signature_Options_Duplicate_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("PK_Signature_Options rejects duplicate options");
+
+         result.test_throws<Botan::Invalid_State>("DER encoding twice", [] {
+            Botan::PK_Signature_Options().with_der_encoded_signature().with_der_encoded_signature();
+         });
+
+         result.test_throws<Botan::Invalid_State>("deterministic twice", [] {
+            Botan::PK_Signature_Options().with_deterministic_signature().with_deterministic_signature();
+         });
+
+         result.test_throws<Botan::Invalid_State>("explicit trailer twice", [] {
+            Botan::PK_Signature_Options().with_explicit_trailer_field().with_explicit_trailer_field();
+         });
+
+         result.test_throws<Botan::Invalid_State>(
+            "hash twice", [] { Botan::PK_Signature_Options().with_hash("SHA-256").with_hash("SHA-512"); });
+
+         result.test_throws<Botan::Invalid_State>("external prehash twice", [] {
+            Botan::PK_Signature_Options().with_externally_computed_prehash().with_externally_computed_prehash();
+         });
+
+         // The library either computes the prehash or the caller does, not both
+         result.test_throws<Botan::Invalid_State>("prehash then external prehash", [] {
+            Botan::PK_Signature_Options().with_prehash().with_externally_computed_prehash();
+         });
+
+         result.test_throws<Botan::Invalid_State>("external prehash then prehash", [] {
+            Botan::PK_Signature_Options().with_externally_computed_prehash().with_prehash();
+         });
+
+         result.test_no_throw("flags default off can be set once", [&] {
+            const auto opts = Botan::PK_Signature_Options()
+                                 .with_der_encoded_signature(false)
+                                 .with_der_encoded_signature()
+                                 .with_deterministic_signature(false)
+                                 .with_deterministic_signature()
+                                 .with_explicit_trailer_field(false)
+                                 .with_explicit_trailer_field();
+            result.test_is_true("DER flag set", opts.using_der_encoded_signature());
+            result.test_is_true("deterministic flag set", opts.using_deterministic_signature());
+            result.test_is_true("explicit trailer flag set", opts.using_explicit_trailer_field());
+         });
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options_duplicate", PK_Signature_Options_Duplicate_Test);
+
+   #if defined(BOTAN_HAS_ECDSA)
+
+/*
+* The deprecated string forms "EMSA1(hash)" and "Raw(hash)" must be well formed
+*/
+class PK_Signature_Options_Legacy_EMSA1_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("PK_Signature_Options legacy string parsing");
+
+         auto key = Botan::create_private_key("ECDSA", rng(), "secp256r1");
+         if(!key) {
+            result.test_note("Skipping - ECDSA not available");
+            return {result};
+         }
+         const auto pub = key->public_key();
+
+         const std::vector<uint8_t> message = {0x61, 0x62, 0x63, 0x64};
+
+         result.test_no_throw("EMSA1(SHA-256) is accepted", [&] {
+            Botan::PK_Signer signer(*key, rng(), "EMSA1(SHA-256)");
+            Botan::PK_Verifier verifier(*pub, "SHA-256");
+            const auto sig = signer.sign_message(message, rng());
+            result.test_is_true("EMSA1(SHA-256) signs with SHA-256", verifier.verify_message(message, sig));
+         });
+
+         for(const auto* params : {"EMSA1(SHA-256,extra)", "EMSA1", "EMSA1()", "EMSA1X(SHA-256)"}) {
+            const std::string what = std::string("'") + params + "' is rejected";
+            result.test_throws<Botan::Invalid_Argument>(what + " by signer",
+                                                        [&] { const Botan::PK_Signer signer(*key, rng(), params); });
+            result.test_throws<Botan::Invalid_Argument>(what + " by verifier",
+                                                        [&] { const Botan::PK_Verifier verifier(*pub, params); });
+         }
+
+      #if defined(BOTAN_HAS_RAW_HASH_FN)
+         // "Raw(hash)" signs a digest the caller computed, and must agree with signing the message
+         result.test_no_throw("Raw(SHA-256) is accepted", [&] {
+            Botan::PK_Signer signer(*key, rng(), "Raw(SHA-256)");
+            Botan::PK_Verifier verifier(*pub, "SHA-256");
+            const auto digest = Botan::HashFunction::create_or_throw("SHA-256")->process<std::vector<uint8_t>>(message);
+            const auto sig = signer.sign_message(digest, rng());
+            result.test_is_true("Raw(SHA-256) signature verifies over the message",
+                                verifier.verify_message(message, sig));
+            result.test_throws("Raw(SHA-256) rejects a 4 byte input", [&] { signer.sign_message(message, rng()); });
+         });
+
+         for(const auto* params : {"Raw(SHA-256,extra)", "Raw()", "RawX(SHA-256)"}) {
+            const std::string what = std::string("'") + params + "' is rejected";
+            result.test_throws<Botan::Invalid_Argument>(what + " by signer",
+                                                        [&] { const Botan::PK_Signer signer(*key, rng(), params); });
+            result.test_throws<Botan::Invalid_Argument>(what + " by verifier",
+                                                        [&] { const Botan::PK_Verifier verifier(*pub, params); });
+         }
+      #endif
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options_legacy_emsa1", PK_Signature_Options_Legacy_EMSA1_Test);
+
+   #endif
+
+/*
+* Hash-based schemes fix the hash in the key; the hash option is accepted only
+* if it names the hash the operation reports, so that a signer's hash_function()
+* can always be handed to a verifier, and every such scheme must behave the same way
+*/
+class PK_Signature_Options_Fixed_Hash_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         struct FixedHashScheme {
+               std::string algo;
+               std::string key_params;
+               std::string expected_hash;
+         };
+
+         const std::vector<FixedHashScheme> schemes = {
+   #if defined(BOTAN_HAS_HSS_LMS)
+            {"HSS-LMS", "SHA-256,HW(5,1)", "SHA-256"},
+            {"HSS-LMS", "Truncated(SHA-256,192),HW(5,1)", "Truncated(SHA-256,192)"},
+            {"HSS-LMS", "SHAKE-256(256),HW(5,1)", "SHAKE-256(256)"},
+   #endif
+   #if defined(BOTAN_HAS_XMSS_RFC8391)
+            {"XMSS", "XMSS-SHA2_10_256", "SHA-256"},
+            {"XMSS", "XMSS-SHA2_10_192", "Truncated(SHA-256,192)"},
+            {"XMSS", "XMSS-SHAKE_10_256", "SHAKE-128(256)"},
+   #endif
+   #if defined(BOTAN_HAS_SLH_DSA_WITH_SHA2)
+            {"SLH-DSA", "SLH-DSA-SHA2-128s", "SHA-256"},
+            // For n > 16 the SHA-2 parameter sets hash the message with SHA-512
+            {"SLH-DSA", "SLH-DSA-SHA2-192s", "SHA-512"},
+   #endif
+   #if defined(BOTAN_HAS_SLH_DSA_WITH_SHAKE)
+            // The message digest is longer than n
+            {"SLH-DSA", "SLH-DSA-SHAKE-128s", "SHAKE-256(240)"},
+   #endif
+         };
+
+         std::vector<Test::Result> results;
+
+         for(const auto& scheme : schemes) {
+            Test::Result result("PK_Signature_Options fixed hash " + scheme.key_params);
+
+            auto key = Botan::create_private_key(scheme.algo, rng(), scheme.key_params);
+            if(!key) {
+               result.test_note("Skipping - " + scheme.algo + " not available");
+               results.push_back(std::move(result));
+               continue;
+            }
+            const auto pub = key->public_key();
+
+            const std::vector<uint8_t> message = {0x61, 0x62, 0x63, 0x64};
+
+            const std::string reported = Botan::PK_Signer(*key, rng()).hash_function();
+            result.test_str_eq("Reported hash", reported, scheme.expected_hash);
+
+            result.test_no_throw("Reported hash accepted", [&] {
+               Botan::PK_Signer signer(*key, rng(), Botan::PK_Signature_Options().with_hash(reported));
+               Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_hash(reported));
+               result.test_str_eq("Verifier reports the same hash", verifier.hash_function(), reported);
+               const auto sig = signer.sign_message(message, rng());
+               result.test_is_true("Matching hash sign/verify", verifier.verify_message(message, sig));
+            });
+
+            const std::string other_hash = (reported == "SHA-512") ? "SHA-256" : "SHA-512";
+
+            result.test_throws<Botan::Invalid_Argument>("Mismatched hash rejected by signer", [&] {
+               const Botan::PK_Signer signer(*key, rng(), Botan::PK_Signature_Options().with_hash(other_hash));
+            });
+
+            result.test_throws<Botan::Invalid_Argument>("Mismatched hash rejected by verifier", [&] {
+               const Botan::PK_Verifier verifier(*pub, Botan::PK_Signature_Options().with_hash(other_hash));
+            });
+
+            results.push_back(std::move(result));
+         }
+
+         return results;
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "pk_sig_options_fixed_hash", PK_Signature_Options_Fixed_Hash_Test);
+
+}  // namespace
+
+}  // namespace Botan_Tests
+
+#endif

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -144,7 +144,7 @@ Test::Result PK_Signature_Generation_Test::run_one_test(const std::string& pad_h
    if(vars.has_key("Group")) {
       test_name << "-" << vars.get_req_str("Group");
    }
-   test_name << "/" << padding << " signature generation";
+   test_name << "/" << printed_params(vars, padding) << " signature generation";
 
    Test::Result result(test_name.str());
 

--- a/src/tests/test_pubkey.h
+++ b/src/tests/test_pubkey.h
@@ -42,6 +42,8 @@ class PK_Test : public Text_Based_Test {
          throw Test_Error("No default padding scheme set for " + algo_name());
       }
 
+      virtual std::string printed_params(const VarMap& /*vm*/, const std::string& padding) const { return padding; }
+
       virtual std::string choose_padding(const VarMap& vars, const std::string& pad_hdr);
 
    private:

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_RSA)
    #include "test_pubkey.h"
    #include "test_rng.h"
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/rsa.h>
    #include <botan/internal/blinding.h>
@@ -206,9 +207,9 @@ class RSA_Blinding_Tests final : public Test {
          * are used as an additional test on the blinders.
          */
 
-         Botan::PK_Signer signer(
-            rsa, this->rng(), "Raw", Botan::Signature_Format::Standard, "base");  // don't try this at home
-         Botan::PK_Verifier verifier(rsa, "Raw", Botan::Signature_Format::Standard, "base");
+         // don't try this at home
+         Botan::PK_Signer signer(rsa, this->rng(), Botan::PK_Signature_Options().with_hash("Raw"));
+         Botan::PK_Verifier verifier(rsa, Botan::PK_Signature_Options().with_hash("Raw"));
 
          for(size_t i = 1; i <= Botan::Blinder::ReinitInterval * 6; ++i) {
             std::vector<uint8_t> input(16);

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -10,6 +10,7 @@
    #include "test_pubkey.h"
    #include "test_rng.h"
    #include <botan/numthry.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/rsa.h>
    #include <botan/internal/blinding.h>
@@ -207,9 +208,9 @@ class RSA_Blinding_Tests final : public Test {
          * are used as an additional test on the blinders.
          */
 
-         Botan::PK_Signer signer(
-            rsa, this->rng(), "Raw", Botan::Signature_Format::Standard, "base");  // don't try this at home
-         Botan::PK_Verifier verifier(rsa, "Raw", Botan::Signature_Format::Standard, "base");
+         // don't try this at home
+         Botan::PK_Signer signer(rsa, this->rng(), Botan::PK_Signature_Options().with_padding("Raw"));
+         Botan::PK_Verifier verifier(rsa, Botan::PK_Signature_Options().with_padding("Raw"));
 
          for(size_t i = 1; i <= Botan::Blinder::ReinitInterval * 6; ++i) {
             std::vector<uint8_t> input(16);

--- a/src/tests/test_sm2.cpp
+++ b/src/tests/test_sm2.cpp
@@ -10,6 +10,7 @@
    #include "test_pubkey.h"
    #include "test_rng.h"
    #include <botan/ec_group.h>
+   #include <botan/hash.h>
    #include <botan/pubkey.h>
    #include <botan/sm2.h>
 #endif
@@ -131,6 +132,43 @@ class SM2_Invalid_Ciphertexts : public Text_Based_Test {
 };
 
 BOTAN_REGISTER_TEST("pubkey", "sm2_invalid_ctext", SM2_Invalid_Ciphertexts);
+
+class SM2_Default_Hash_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("SM2 signature default hash");
+
+         if(!Botan::EC_Group::supports_named_group("sm2p256v1")) {
+            result.test_note("Skipping - sm2p256v1 not available");
+            return {result};
+         }
+
+         const Botan::SM2_PrivateKey key(this->rng(), Botan::EC_Group::from_name("sm2p256v1"));
+         const std::vector<uint8_t> msg = {0x61, 0x62, 0x63};
+
+         Botan::PK_Signer signer(key, this->rng(), Botan::PK_Signature_Options());
+         const auto sig = signer.sign_message(msg, this->rng());
+         result.test_str_eq("Signer reports SM3", signer.hash_function(), "SM3");
+
+         Botan::PK_Verifier default_verifier(key, Botan::PK_Signature_Options());
+         result.test_is_true("Verifies with default hash", default_verifier.verify_message(msg, sig));
+
+         Botan::PK_Verifier sm3_verifier(key, Botan::PK_Signature_Options().with_hash("SM3"));
+         result.test_is_true("Verifies with explicit SM3", sm3_verifier.verify_message(msg, sig));
+
+         Botan::PK_Verifier legacy_verifier(key, "1234567812345678,SM3");
+         result.test_is_true("Verifies with legacy default userid and SM3", legacy_verifier.verify_message(msg, sig));
+
+         if(Botan::HashFunction::create("SHA-256")) {
+            Botan::PK_Verifier sha256_verifier(key, Botan::PK_Signature_Options().with_hash("SHA-256"));
+            result.test_is_false("Does not verify with SHA-256", sha256_verifier.verify_message(msg, sig));
+         }
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("pubkey", "sm2_default_hash", SM2_Default_Hash_Tests);
 
 #endif
 

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -14,6 +14,7 @@
    #include "test_rng.h"
    #include <botan/hash.h>
    #include <botan/hex.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/xmss.h>
    #include <botan/internal/buffer_slicer.h>
@@ -45,7 +46,11 @@ class XMSS_Signature_Tests final : public PK_Signature_Generation_Test {
          return false;
       }
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PrivateKey");
@@ -60,7 +65,11 @@ class XMSS_Signature_Verify_Tests final : public PK_Signature_Verification_Test 
       XMSS_Signature_Verify_Tests() :
             PK_Signature_Verification_Test("XMSS", "pubkey/xmss_verify.vec", "Params,Msg,PublicKey,Signature") {}
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PublicKey");
@@ -74,7 +83,11 @@ class XMSS_Signature_Verify_Invalid_Tests final : public PK_Signature_NonVerific
             PK_Signature_NonVerification_Test(
                "XMSS", "pubkey/xmss_invalid.vec", "Params,Msg,PublicKey,InvalidSignature") {}
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PublicKey");
@@ -147,7 +160,7 @@ std::vector<Test::Result> xmss_statefulness() {
    auto sign_something = [&rng](auto& sk) {
       auto msg = Botan::hex_decode("deadbeef");
 
-      Botan::PK_Signer signer(sk, *rng, "SHA2_10_256");
+      Botan::PK_Signer signer(sk, *rng, Botan::PK_Signature_Options());
       signer.sign_message(msg, *rng);
    };
 
@@ -269,34 +282,33 @@ std::vector<Test::Result> xmss_legacy_private_key() {
    Botan::XMSS_PublicKey legacy_public_key = Botan::XMSS_PublicKey(legacy_xmss_public_key);
 
    const auto message = Botan::hex_decode("deadcafe");
-   const auto* const algo_name = "SHA2_10_256";
 
    auto rng = Test::new_rng(__func__);
 
    return {
       CHECK("Use a legacy private key to create a signature",
             [&](auto& result) {
-               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               Botan::PK_Signer signer(legacy_secret_key, *rng, Botan::PK_Signature_Options());
                auto signature = signer.sign_message(message, *rng);
 
-               Botan::PK_Verifier verifier(*public_key_from_secret_key, algo_name);
+               Botan::PK_Verifier verifier(*public_key_from_secret_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, signature));
             }),
 
       CHECK("Verify a legacy signature",
             [&](auto& result) {
-               Botan::PK_Verifier verifier(*public_key_from_secret_key, algo_name);
+               Botan::PK_Verifier verifier(*public_key_from_secret_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, legacy_signature));
             }),
 
       CHECK("Verify a new signature by a legacy private key with a legacy public key",
             [&](auto& result) {
-               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               Botan::PK_Signer signer(legacy_secret_key, *rng, Botan::PK_Signature_Options());
                auto signature = signer.sign_message(message, *rng);
 
-               Botan::PK_Verifier verifier(legacy_public_key, algo_name);
+               Botan::PK_Verifier verifier(legacy_public_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, legacy_signature));
             }),

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -15,6 +15,7 @@
    #include <botan/asn1_obj.h>
    #include <botan/hash.h>
    #include <botan/hex.h>
+   #include <botan/pk_options.h>
    #include <botan/pubkey.h>
    #include <botan/xmss.h>
    #include <botan/internal/buffer_slicer.h>
@@ -46,7 +47,11 @@ class XMSS_Signature_Tests final : public PK_Signature_Generation_Test {
          return false;
       }
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Private_Key> load_private_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PrivateKey");
@@ -61,7 +66,11 @@ class XMSS_Signature_Verify_Tests final : public PK_Signature_Verification_Test 
       XMSS_Signature_Verify_Tests() :
             PK_Signature_Verification_Test("XMSS", "pubkey/xmss_verify.vec", "Params,Msg,PublicKey,Signature") {}
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PublicKey");
@@ -75,7 +84,11 @@ class XMSS_Signature_Verify_Invalid_Tests final : public PK_Signature_NonVerific
             PK_Signature_NonVerification_Test(
                "XMSS", "pubkey/xmss_invalid.vec", "Params,Msg,PublicKey,InvalidSignature") {}
 
-      std::string default_padding(const VarMap& vars) const override { return vars.get_req_str("Params"); }
+      std::string default_padding(const VarMap& /*vars*/) const override { return ""; }
+
+      std::string printed_params(const VarMap& vars, const std::string& /*padding*/) const override {
+         return vars.get_req_str("Params");
+      }
 
       std::unique_ptr<Botan::Public_Key> load_public_key(const VarMap& vars) override {
          const std::vector<uint8_t> raw_key = vars.get_req_bin("PublicKey");
@@ -148,7 +161,7 @@ std::vector<Test::Result> xmss_statefulness() {
    auto sign_something = [&rng](auto& sk) {
       auto msg = Botan::hex_decode("deadbeef");
 
-      Botan::PK_Signer signer(sk, *rng, "SHA2_10_256");
+      Botan::PK_Signer signer(sk, *rng, Botan::PK_Signature_Options());
       return signer.sign_message(msg, *rng);
    };
 
@@ -310,34 +323,33 @@ std::vector<Test::Result> xmss_legacy_private_key() {
       Botan::XMSS_PublicKey(Botan::AlgorithmIdentifier(), legacy_xmss_public_key);
 
    const auto message = Botan::hex_decode("deadcafe");
-   const auto* const algo_name = "SHA2_10_256";
 
    auto rng = Test::new_rng(__func__);
 
    return {
       CHECK("Use a legacy private key to create a signature",
             [&](auto& result) {
-               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               Botan::PK_Signer signer(legacy_secret_key, *rng, Botan::PK_Signature_Options());
                auto signature = signer.sign_message(message, *rng);
 
-               Botan::PK_Verifier verifier(*public_key_from_secret_key, algo_name);
+               Botan::PK_Verifier verifier(*public_key_from_secret_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, signature));
             }),
 
       CHECK("Verify a legacy signature",
             [&](auto& result) {
-               Botan::PK_Verifier verifier(*public_key_from_secret_key, algo_name);
+               Botan::PK_Verifier verifier(*public_key_from_secret_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, legacy_signature));
             }),
 
       CHECK("Verify a new signature by a legacy private key with a legacy public key",
             [&](auto& result) {
-               Botan::PK_Signer signer(legacy_secret_key, *rng, algo_name);
+               Botan::PK_Signer signer(legacy_secret_key, *rng, Botan::PK_Signature_Options());
                auto signature = signer.sign_message(message, *rng);
 
-               Botan::PK_Verifier verifier(legacy_public_key, algo_name);
+               Botan::PK_Verifier verifier(legacy_public_key, Botan::PK_Signature_Options());
                result.test_is_true("legacy private key generates signatures that are still verifiable",
                                    verifier.verify_message(message, legacy_signature));
             }),


### PR DESCRIPTION
This allows controlling all details of how signatures are created, without having to stuff values into the single parameters string which was previously available.

The PR previously known as #5021 #4318