### PR TITLE
Improve performance of SHA-512 AVX-512 codepath

### DIFF
--- a/src/lib/hash/sha2_64/sha2_64_avx512/sha2_64_avx512.cpp
+++ b/src/lib/hash/sha2_64/sha2_64_avx512/sha2_64_avx512.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 2025 Jack Lloyd
+* (C) 2025,2026 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -13,15 +13,24 @@
 
 namespace Botan {
 
+namespace SHA512_AVX512 {
+
 namespace {
 
-template <typename SIMD_T>
-BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 SIMD_T sha512_next_w_avx512(SIMD_T x[8]) {
-   auto t0 = SIMD_T::alignr8(x[1], x[0]);
-   auto t1 = SIMD_T::alignr8(x[5], x[4]);
+template <size_t R1, size_t R2, size_t S1>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 SIMD_2x64 avx512_sigma(SIMD_2x64 v) {
+   const auto vr1 = _mm_ror_epi64(v.raw(), R1);
+   const auto vr2 = _mm_ror_epi64(v.raw(), R2);
+   const auto vs1 = _mm_srli_epi64(v.raw(), S1);
+   return SIMD_2x64(_mm_ternarylogic_epi64(vr1, vr2, vs1, 0x96));
+}
 
-   auto s0 = t0.template rotr<1>() ^ t0.template rotr<8>() ^ t0.template shr<7>();
-   auto s1 = x[7].template rotr<19>() ^ x[7].template rotr<61>() ^ x[7].template shr<6>();
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 SIMD_2x64 sha512_next_w_avx512(SIMD_2x64 x[8]) {
+   auto t0 = SIMD_2x64::alignr8(x[1], x[0]);
+   auto t1 = SIMD_2x64::alignr8(x[5], x[4]);
+
+   auto s0 = avx512_sigma<1, 8, 7>(t0);
+   auto s1 = avx512_sigma<19, 61, 6>(x[7]);
 
    auto nx = x[0] + s0 + s1 + t1;
 
@@ -34,14 +43,43 @@ BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 SIMD_T sha512_next_w_avx512(SIMD_T x
    x[6] = x[7];
    x[7] = nx;
 
-   return x[7];
+   return nx;
+}
+
+template <size_t R1, size_t R2, size_t R3>
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 SIMD_2x64 rho(SIMD_2x64 v) {
+   const auto vr1 = _mm_ror_epi64(v.raw(), R1);
+   const auto vr2 = _mm_ror_epi64(v.raw(), R2);
+   const auto vr3 = _mm_ror_epi64(v.raw(), R3);
+   return SIMD_2x64(_mm_ternarylogic_epi64(vr1, vr2, vr3, 0x96));
+}
+
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AVX512_BMI2 void SHA2_64_F(SIMD_2x64 A,
+                                                           SIMD_2x64 B,
+                                                           SIMD_2x64 C,
+                                                           SIMD_2x64& D,
+                                                           SIMD_2x64 E,
+                                                           SIMD_2x64 F,
+                                                           SIMD_2x64 G,
+                                                           SIMD_2x64& H,
+                                                           uint64_t M) {
+   constexpr uint8_t ch = 0xca;
+   constexpr uint8_t maj = 0xe8;
+
+   H += rho<14, 18, 41>(E) + SIMD_2x64(_mm_ternarylogic_epi64(E.raw(), F.raw(), G.raw(), ch)) + SIMD_2x64::splat(M);
+   D += H;
+   H += rho<28, 34, 39>(A) + SIMD_2x64(_mm_ternarylogic_epi64(A.raw(), B.raw(), C.raw(), maj));
 }
 
 }  // namespace
 
+}  // namespace SHA512_AVX512
+
 BOTAN_FN_ISA_AVX512_BMI2 void SHA_512::compress_digest_x86_avx512(digest_type& digest,
                                                                   std::span<const uint8_t> input,
                                                                   size_t blocks) {
+   using namespace SHA512_AVX512;
+
    // clang-format off
    alignas(64) const uint64_t K[80] = {
       0x428A2F98D728AE22, 0x7137449123EF65CD, 0xB5C0FBCFEC4D3B2F, 0xE9B5DBA58189DBBC,
@@ -69,133 +107,26 @@ BOTAN_FN_ISA_AVX512_BMI2 void SHA_512::compress_digest_x86_avx512(digest_type& d
    // clang-format on
 
    alignas(64) uint64_t W[16] = {0};
-   alignas(64) uint64_t WN[3][80];
 
-   uint64_t A = digest[0];
-   uint64_t B = digest[1];
-   uint64_t C = digest[2];
-   uint64_t D = digest[3];
-   uint64_t E = digest[4];
-   uint64_t F = digest[5];
-   uint64_t G = digest[6];
-   uint64_t H = digest[7];
+   auto digest0 = SIMD_2x64::splat(digest[0]);
+   auto digest1 = SIMD_2x64::splat(digest[1]);
+   auto digest2 = SIMD_2x64::splat(digest[2]);
+   auto digest3 = SIMD_2x64::splat(digest[3]);
+   auto digest4 = SIMD_2x64::splat(digest[4]);
+   auto digest5 = SIMD_2x64::splat(digest[5]);
+   auto digest6 = SIMD_2x64::splat(digest[6]);
+   auto digest7 = SIMD_2x64::splat(digest[7]);
+
+   auto A = digest0;
+   auto B = digest1;
+   auto C = digest2;
+   auto D = digest3;
+   auto E = digest4;
+   auto F = digest5;
+   auto G = digest6;
+   auto H = digest7;
 
    const uint8_t* data = input.data();
-
-   while(blocks >= 4) {
-      SIMD_8x64 WS[8];
-
-      for(size_t i = 0; i < 8; i++) {
-         WS[i] = SIMD_8x64::load_be4(
-            &data[16 * i], &data[1 * 128 + 16 * i], &data[2 * 128 + 16 * i], &data[3 * 128 + 16 * i]);
-         auto WK = WS[i] + SIMD_8x64::broadcast_2x64(&K[2 * i]);
-         WK.store_le4(&W[2 * i], &WN[0][2 * i], &WN[1][2 * i], &WN[2][2 * i]);
-      }
-
-      data += 4 * 128;
-      blocks -= 4;
-
-      // First 64 rounds of SHA-512
-      for(size_t r = 0; r != 64; r += 16) {
-         auto w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 16]);
-         SHA2_64_F(A, B, C, D, E, F, G, H, W[0]);
-         SHA2_64_F(H, A, B, C, D, E, F, G, W[1]);
-         w.store_le4(&W[0], &WN[0][r + 16], &WN[1][r + 16], &WN[2][r + 16]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 18]);
-         SHA2_64_F(G, H, A, B, C, D, E, F, W[2]);
-         SHA2_64_F(F, G, H, A, B, C, D, E, W[3]);
-         w.store_le4(&W[2], &WN[0][r + 18], &WN[1][r + 18], &WN[2][r + 18]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 20]);
-         SHA2_64_F(E, F, G, H, A, B, C, D, W[4]);
-         SHA2_64_F(D, E, F, G, H, A, B, C, W[5]);
-         w.store_le4(&W[4], &WN[0][r + 20], &WN[1][r + 20], &WN[2][r + 20]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 22]);
-         SHA2_64_F(C, D, E, F, G, H, A, B, W[6]);
-         SHA2_64_F(B, C, D, E, F, G, H, A, W[7]);
-         w.store_le4(&W[6], &WN[0][r + 22], &WN[1][r + 22], &WN[2][r + 22]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 24]);
-         SHA2_64_F(A, B, C, D, E, F, G, H, W[8]);
-         SHA2_64_F(H, A, B, C, D, E, F, G, W[9]);
-         w.store_le4(&W[8], &WN[0][r + 24], &WN[1][r + 24], &WN[2][r + 24]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 26]);
-         SHA2_64_F(G, H, A, B, C, D, E, F, W[10]);
-         SHA2_64_F(F, G, H, A, B, C, D, E, W[11]);
-         w.store_le4(&W[10], &WN[0][r + 26], &WN[1][r + 26], &WN[2][r + 26]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 28]);
-         SHA2_64_F(E, F, G, H, A, B, C, D, W[12]);
-         SHA2_64_F(D, E, F, G, H, A, B, C, W[13]);
-         w.store_le4(&W[12], &WN[0][r + 28], &WN[1][r + 28], &WN[2][r + 28]);
-
-         w = sha512_next_w_avx512(WS) + SIMD_8x64::broadcast_2x64(&K[r + 30]);
-         SHA2_64_F(C, D, E, F, G, H, A, B, W[14]);
-         SHA2_64_F(B, C, D, E, F, G, H, A, W[15]);
-         w.store_le4(&W[14], &WN[0][r + 30], &WN[1][r + 30], &WN[2][r + 30]);
-      }
-
-      // Final 16 rounds of SHA-512
-      SHA2_64_F(A, B, C, D, E, F, G, H, W[0]);
-      SHA2_64_F(H, A, B, C, D, E, F, G, W[1]);
-      SHA2_64_F(G, H, A, B, C, D, E, F, W[2]);
-      SHA2_64_F(F, G, H, A, B, C, D, E, W[3]);
-      SHA2_64_F(E, F, G, H, A, B, C, D, W[4]);
-      SHA2_64_F(D, E, F, G, H, A, B, C, W[5]);
-      SHA2_64_F(C, D, E, F, G, H, A, B, W[6]);
-      SHA2_64_F(B, C, D, E, F, G, H, A, W[7]);
-      SHA2_64_F(A, B, C, D, E, F, G, H, W[8]);
-      SHA2_64_F(H, A, B, C, D, E, F, G, W[9]);
-      SHA2_64_F(G, H, A, B, C, D, E, F, W[10]);
-      SHA2_64_F(F, G, H, A, B, C, D, E, W[11]);
-      SHA2_64_F(E, F, G, H, A, B, C, D, W[12]);
-      SHA2_64_F(D, E, F, G, H, A, B, C, W[13]);
-      SHA2_64_F(C, D, E, F, G, H, A, B, W[14]);
-      SHA2_64_F(B, C, D, E, F, G, H, A, W[15]);
-
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
-      E = (digest[4] += E);
-      F = (digest[5] += F);
-      G = (digest[6] += G);
-      H = (digest[7] += H);
-
-      // Block 2,3,4 of SHA-512 compression, with pre-expanded messages
-      for(size_t b = 0; b != 3; ++b) {  // NOLINT(*-loop-convert)
-         for(size_t r = 0; r != 80; r += 16) {
-            SHA2_64_F(A, B, C, D, E, F, G, H, WN[b][r + 0]);
-            SHA2_64_F(H, A, B, C, D, E, F, G, WN[b][r + 1]);
-            SHA2_64_F(G, H, A, B, C, D, E, F, WN[b][r + 2]);
-            SHA2_64_F(F, G, H, A, B, C, D, E, WN[b][r + 3]);
-            SHA2_64_F(E, F, G, H, A, B, C, D, WN[b][r + 4]);
-            SHA2_64_F(D, E, F, G, H, A, B, C, WN[b][r + 5]);
-            SHA2_64_F(C, D, E, F, G, H, A, B, WN[b][r + 6]);
-            SHA2_64_F(B, C, D, E, F, G, H, A, WN[b][r + 7]);
-            SHA2_64_F(A, B, C, D, E, F, G, H, WN[b][r + 8]);
-            SHA2_64_F(H, A, B, C, D, E, F, G, WN[b][r + 9]);
-            SHA2_64_F(G, H, A, B, C, D, E, F, WN[b][r + 10]);
-            SHA2_64_F(F, G, H, A, B, C, D, E, WN[b][r + 11]);
-            SHA2_64_F(E, F, G, H, A, B, C, D, WN[b][r + 12]);
-            SHA2_64_F(D, E, F, G, H, A, B, C, WN[b][r + 13]);
-            SHA2_64_F(C, D, E, F, G, H, A, B, WN[b][r + 14]);
-            SHA2_64_F(B, C, D, E, F, G, H, A, WN[b][r + 15]);
-         }
-
-         A = (digest[0] += A);
-         B = (digest[1] += B);
-         C = (digest[2] += C);
-         D = (digest[3] += D);
-         E = (digest[4] += E);
-         F = (digest[5] += F);
-         G = (digest[6] += G);
-         H = (digest[7] += H);
-      }
-   }
 
    while(blocks > 0) {
       SIMD_2x64 WS[8];
@@ -270,15 +201,35 @@ BOTAN_FN_ISA_AVX512_BMI2 void SHA_512::compress_digest_x86_avx512(digest_type& d
       SHA2_64_F(C, D, E, F, G, H, A, B, W[14]);
       SHA2_64_F(B, C, D, E, F, G, H, A, W[15]);
 
-      A = (digest[0] += A);
-      B = (digest[1] += B);
-      C = (digest[2] += C);
-      D = (digest[3] += D);
-      E = (digest[4] += E);
-      F = (digest[5] += F);
-      G = (digest[6] += G);
-      H = (digest[7] += H);
+      digest0 += A;
+      digest1 += B;
+      digest2 += C;
+      digest3 += D;
+      digest4 += E;
+      digest5 += F;
+      digest6 += G;
+      digest7 += H;
+
+      A = digest0;
+      B = digest1;
+      C = digest2;
+      D = digest3;
+      E = digest4;
+      F = digest5;
+      G = digest6;
+      H = digest7;
    }
+
+   // Could be optimized a bit by interleaving the registers, reducing store pressure
+   // but probably not worth bothering with
+   _mm_mask_storeu_epi64(&digest[0], 0b01, digest0.raw());  // NOLINT(*-container-data-pointer)
+   _mm_mask_storeu_epi64(&digest[1], 0b01, digest1.raw());
+   _mm_mask_storeu_epi64(&digest[2], 0b01, digest2.raw());
+   _mm_mask_storeu_epi64(&digest[3], 0b01, digest3.raw());
+   _mm_mask_storeu_epi64(&digest[4], 0b01, digest4.raw());
+   _mm_mask_storeu_epi64(&digest[5], 0b01, digest5.raw());
+   _mm_mask_storeu_epi64(&digest[6], 0b01, digest6.raw());
+   _mm_mask_storeu_epi64(&digest[7], 0b01, digest7.raw());
 }
 
 }  // namespace Botan

--- a/src/lib/utils/simd/simd_2x64/simd_2x64.h
+++ b/src/lib/utils/simd/simd_2x64/simd_2x64.h
@@ -54,6 +54,14 @@ class SIMD_2x64 final {
       {
       }
 
+      static SIMD_2x64 BOTAN_FN_ISA_SIMD_2X64 splat(uint64_t v) {
+#if defined(BOTAN_SIMD_USE_SSSE3)
+         return SIMD_2x64(_mm_set1_epi64x(v));
+#elif defined(BOTAN_SIMD_USE_SIMD128)
+         return SIMD_2x64(wasm_u64x2_splat(v));
+#endif
+      }
+
       static SIMD_2x64 BOTAN_FN_ISA_SIMD_2X64 all_ones() {
 #if defined(BOTAN_SIMD_USE_SSSE3)
          return SIMD_2x64(_mm_set1_epi8(-1));


### PR DESCRIPTION
Keeping the state registers in xmm allows using ternlogd, and gives an extra 16 registers as compared to using GPRs

Fix an issue where rotation instructions were not being used in the short message expansion path.

With Clang 22: Improves performance by up to 50% for short messages (64 bytes or smaller), and ~25% for long messages. With GCC 15: slight improvements ~5%