### PR TITLE
Add Hash_Engine

### DIFF
--- a/src/cli/perf_hash_engine.cpp
+++ b/src/cli/perf_hash_engine.cpp
@@ -1,0 +1,81 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "perf.h"
+
+#if defined(BOTAN_HAS_HASH_ENGINES)
+
+   #include <botan/rng.h>
+   #include <botan/internal/fmt.h>
+   #include <botan/internal/hash_engine.h>
+   #include <botan/internal/int_utils.h>
+
+namespace Botan_CLI {
+
+namespace {
+
+class PerfTest_HashEngine final : public PerfTest {
+   public:
+      void go(const PerfConfig& config) override {
+         const std::vector<std::string> hashes = {"SHA-256", "SHA-512", "SHAKE-256(256)"};
+
+         const std::vector<size_t> counts = {16, 32, 128};
+
+         for(const auto& hash_fn : hashes) {
+            for(const auto& hash_provider : Botan::Hash_Engine::possible_providers(hash_fn)) {
+               auto engine = Botan::Hash_Engine::create_or_null(hash_fn, {}, hash_provider);
+
+               if(!engine) {
+                  continue;
+               }
+
+               const size_t out_len = engine->output_length();
+
+               for(const size_t msg_size : config.buffer_sizes()) {
+                  for(const size_t count : counts) {
+                     const auto total_input = Botan::checked_mul(count, msg_size);
+                     const auto total_output = Botan::checked_mul(count, out_len);
+
+                     if(!total_input || !total_output) {
+                        continue;
+                     }
+
+                     std::vector<uint8_t> input_buf(count * msg_size);
+                     std::vector<uint8_t> output_buf(count * out_len);
+
+                     config.rng().randomize(input_buf);
+
+                     std::vector<std::span<const uint8_t>> input_spans(count);
+                     std::vector<std::span<uint8_t>> output_spans(count);
+
+                     for(size_t i = 0; i < count; ++i) {
+                        input_spans[i] = std::span<const uint8_t>(input_buf.data() + i * msg_size, msg_size);
+                        output_spans[i] = std::span<uint8_t>(output_buf.data() + i * out_len, out_len);
+                     }
+
+                     const std::string name = Botan::fmt("Hash_Engine({}) n={}", hash_fn, count);
+
+                     const uint64_t total_bytes = static_cast<uint64_t>(count) * msg_size;
+                     auto timer = config.make_timer(name, total_bytes, "batch_hash", engine->provider(), msg_size);
+
+                     timer->run_until_elapsed(config.runtime(),
+                                              [&]() { engine->batch_hash(output_spans, input_spans); });
+
+                     config.record_result(*timer);
+                  }
+               }
+            }
+         }
+      }
+};
+
+}  // namespace
+
+BOTAN_REGISTER_PERF_TEST("hash_engine", PerfTest_HashEngine);
+
+}  // namespace Botan_CLI
+
+#endif

--- a/src/lib/hash_engine/hash_engine.cpp
+++ b/src/lib/hash_engine/hash_engine.cpp
@@ -1,0 +1,227 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/hash_engine.h>
+
+#include <botan/assert.h>
+#include <botan/exceptn.h>
+#include <botan/hash.h>
+#include <botan/internal/fmt.h>
+#include <algorithm>
+
+#if defined(BOTAN_HAS_THREAD_UTILS)
+   #include <botan/internal/thread_pool.h>
+#endif
+
+namespace Botan {
+
+namespace {
+
+class Base_Hash_Engine final : public Hash_Engine {
+   public:
+      Base_Hash_Engine(std::unique_ptr<HashFunction> hash, std::span<const uint8_t> common_prefix) :
+            Hash_Engine(common_prefix), m_hash(std::move(hash)) {}
+
+      std::string name() const override { return m_hash->name(); }
+
+      std::string provider() const override { return "base"; }
+
+      size_t output_length() const override { return m_hash->output_length(); }
+
+      size_t parallelism() const override { return 1; }
+
+      void batch_hash(std::span<std::span<uint8_t>> outputs,
+                      std::span<std::span<const uint8_t>> inputs1,
+                      std::span<std::span<const uint8_t>> inputs2) override {
+         check_batch_args(outputs, inputs1, inputs2);
+
+         for(size_t i = 0; i != inputs1.size(); ++i) {
+            m_hash->update(common_prefix());
+            m_hash->update(inputs1[i]);
+            if(!inputs2.empty()) {
+               m_hash->update(inputs2[i]);
+            }
+            m_hash->final(outputs[i].first(output_length()));
+         }
+      }
+
+   private:
+      std::unique_ptr<HashFunction> m_hash;
+};
+
+std::unique_ptr<Hash_Engine> make_base_engine(std::string_view hash_fn,
+                                              std::span<const uint8_t> common_prefix,
+                                              std::string_view provider) {
+   // SIMD specific dispatch added here later
+
+   if(provider.empty() || provider == "base") {
+      if(auto hash = HashFunction::create(hash_fn)) {
+         return std::make_unique<Base_Hash_Engine>(std::move(hash), common_prefix);
+      }
+   }
+
+   return nullptr;
+}
+
+#if defined(BOTAN_HAS_THREAD_UTILS)
+
+class Threaded_Hash_Engine final : public Hash_Engine {
+   public:
+      Threaded_Hash_Engine(std::string_view hash_fn,
+                           Thread_Pool& threadpool,
+                           size_t max_threads,
+                           std::span<const uint8_t> common_prefix) :
+            Hash_Engine(common_prefix), m_threadpool(threadpool), m_hash_fn(hash_fn), m_max_threads(max_threads) {
+         // Engines beyond the first are only instantiated once a batch is
+         // actually large enough to be worth splitting over threads
+
+         if(auto eng = make_base_engine(m_hash_fn, this->common_prefix(), "")) {
+            m_engines.push_back(std::move(eng));
+         } else {
+            throw Lookup_Error(fmt("Could not create a hash engine for {}", m_hash_fn));
+         }
+      }
+
+      std::string name() const override { return m_engines[0]->name(); }
+
+      std::string provider() const override { return "threads"; }
+
+      size_t output_length() const override { return m_engines[0]->output_length(); }
+
+      size_t parallelism() const override { return m_max_threads * m_engines[0]->parallelism(); }
+
+      void batch_hash(std::span<std::span<uint8_t>> outputs,
+                      std::span<std::span<const uint8_t>> inputs1,
+                      std::span<std::span<const uint8_t>> inputs2) override {
+         check_batch_args(outputs, inputs1, inputs2);
+
+         const size_t count = inputs1.size();
+         if(count == 0) {
+            return;
+         }
+
+         // Both inputs and outputs count towards the work estimate; for
+         // XOFs with long outputs squeezing dominates. The +64 approximates
+         // padding and finalization overhead.
+         const size_t per_hash_bytes = common_prefix().size() + inputs1[0].size() +
+                                       (inputs2.empty() ? 0 : inputs2[0].size()) + output_length() + 64;
+
+         const size_t threads = usable_threads(count, count * per_hash_bytes);
+
+         if(threads <= 1) {
+            m_engines[0]->batch_hash(outputs, inputs1, inputs2);
+            return;
+         }
+
+         while(m_engines.size() < threads) {
+            auto eng = make_base_engine(m_hash_fn, common_prefix(), "");
+            BOTAN_ASSERT_NONNULL(eng);  // previous attempt already succeeded
+            m_engines.push_back(std::move(eng));
+         }
+
+         dispatch(threads, count, [&](size_t t, size_t offset, size_t n) {
+            const auto in2 = inputs2.empty() ? inputs2 : inputs2.subspan(offset, n);
+            m_engines[t]->batch_hash(outputs.subspan(offset, n), inputs1.subspan(offset, n), in2);
+         });
+      }
+
+   private:
+      size_t usable_threads(size_t count, size_t total_bytes) const {
+         // Chunk work to not spread too thinly since just queuing the work
+         // in the pool has nonzero overhead.
+         constexpr size_t MIN_BYTES_PER_THREAD = 32 * 1024;
+
+         const size_t by_bytes = std::max<size_t>(total_bytes / MIN_BYTES_PER_THREAD, 1);
+         return std::min({m_max_threads, count, by_bytes});
+      }
+
+      template <typename F>
+      void dispatch(size_t threads, size_t count, F work_fn) {
+         const size_t per_thread = count / threads;
+         const size_t remainder = count % threads;
+
+         std::vector<std::future<void>> futures;
+         futures.reserve(threads);
+
+         size_t offset = 0;
+         for(size_t t = 0; t != threads; ++t) {
+            // First remainder threads get 1 extra hash over the main batch
+            const size_t n = per_thread + (t < remainder ? 1 : 0);
+            futures.push_back(m_threadpool.run(work_fn, t, offset, n));
+            offset += n;
+         }
+
+         for(auto& f : futures) {
+            f.get();
+         }
+      }
+
+      Thread_Pool& m_threadpool;
+      std::string m_hash_fn;
+      size_t m_max_threads;
+      std::vector<std::unique_ptr<Hash_Engine>> m_engines;
+};
+
+#endif
+
+}  // namespace
+
+void Hash_Engine::check_batch_args(std::span<std::span<uint8_t>> outputs,
+                                   std::span<std::span<const uint8_t>> inputs1,
+                                   std::span<std::span<const uint8_t>> inputs2) const {
+   BOTAN_ARG_CHECK(outputs.size() == inputs1.size(),
+                   "Hash_Engine::batch_hash requires same number of inputs and outputs");
+   BOTAN_ARG_CHECK(inputs2.empty() || inputs2.size() == inputs1.size(),
+                   "Hash_Engine::batch_hash second inputs must be empty or match first");
+
+   const size_t out_len = output_length();
+
+   for(size_t i = 0; i != inputs1.size(); ++i) {
+      BOTAN_ARG_CHECK(inputs1[i].size() == inputs1[0].size(), "Hash_Engine::batch_hash inputs must be equal length");
+      BOTAN_ARG_CHECK(outputs[i].size() >= out_len, "Hash_Engine::batch_hash output buffer too small");
+   }
+
+   for(size_t i = 0; i != inputs2.size(); ++i) {
+      BOTAN_ARG_CHECK(inputs2[i].size() == inputs2[0].size(), "Hash_Engine::batch_hash inputs must be equal length");
+   }
+}
+
+std::unique_ptr<Hash_Engine> Hash_Engine::create_or_null(std::string_view hash_fn,
+                                                         std::span<const uint8_t> common_prefix,
+                                                         std::string_view provider) {
+#if defined(BOTAN_HAS_THREAD_UTILS)
+   if(provider.empty() || provider == "threads") {
+      auto& threadpool = Thread_Pool::global_instance();
+      const size_t workers = threadpool.worker_count();
+      if(workers >= 2) {
+         return std::make_unique<Threaded_Hash_Engine>(hash_fn, threadpool, workers, common_prefix);
+      }
+   }
+#endif
+
+   if(auto engine = make_base_engine(hash_fn, common_prefix, provider)) {
+      return engine;
+   }
+
+   return nullptr;
+}
+
+std::unique_ptr<Hash_Engine> Hash_Engine::create_or_throw(std::string_view hash_fn,
+                                                          std::span<const uint8_t> common_prefix,
+                                                          std::string_view provider) {
+   if(auto engine = Hash_Engine::create_or_null(hash_fn, common_prefix, provider)) {
+      return engine;
+   } else {
+      throw Lookup_Error("Hash_Engine", hash_fn, provider);
+   }
+}
+
+std::vector<std::string> Hash_Engine::possible_providers(std::string_view hash_fn) {
+   BOTAN_UNUSED(hash_fn);
+   return {"base", "threads", "avx2", "avx512"};
+}
+
+}  // namespace Botan

--- a/src/lib/hash_engine/hash_engine.h
+++ b/src/lib/hash_engine/hash_engine.h
@@ -1,0 +1,133 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HASH_ENGINE_H_
+#define BOTAN_HASH_ENGINE_H_
+
+#include <botan/secmem.h>
+#include <botan/types.h>
+#include <memory>
+#include <span>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Botan {
+
+class BOTAN_TEST_API Hash_Engine {
+   public:
+      /**
+      * @return name of the hash
+      */
+      virtual std::string name() const = 0;
+
+      /**
+      * @return provider of the engine (eg "base", "avx2", "avx512")
+      */
+      virtual std::string provider() const = 0;
+
+      /**
+      * @return output length of the hash function
+      */
+      virtual size_t output_length() const = 0;
+
+      /**
+      * @return native parallelism of this implementation
+      */
+      virtual size_t parallelism() const = 0;
+
+      /**
+      * Hash many inputs
+      *
+      * Computes H(common_prefix || inputs[i]) into outputs[i]. Each input
+      * must be exactly identical length.
+      *
+      * outputs[i] may alias inputs[i], but must not otherwise overlap any
+      * other input or output.
+      */
+      void batch_hash(std::span<std::span<uint8_t>> outputs, std::span<std::span<const uint8_t>> inputs) {
+         batch_hash(outputs, inputs, {});
+      }
+
+      /**
+      * Hash many inputs, each formed from two parts
+      *
+      * Computes H(common_prefix || inputs1[i] || inputs2[i]) into
+      * outputs[i]. All inputs1 must be exactly identical length, as must all
+      * inputs2. Alternately inputs2 may be an empty list.
+      *
+      * outputs[i] may alias inputs1[i] and/or inputs2[i], but must not
+      * otherwise overlap any other input or output.
+      */
+      virtual void batch_hash(std::span<std::span<uint8_t>> outputs,
+                              std::span<std::span<const uint8_t>> inputs1,
+                              std::span<std::span<const uint8_t>> inputs2) = 0;
+
+      /**
+      * Create a new Hash_Engine
+      *
+      * @param hash_fn the hash function to compute
+      * @param common_prefix implicitly prepended to each message hashed;
+      *        implementations may precompute the resulting hash state
+      * @param provider if set, use this specific implementation
+      *
+      * Throws Lookup_Error if the hash function or requested provider is
+      * not available
+      */
+      static std::unique_ptr<Hash_Engine> create_or_throw(std::string_view hash_fn,
+                                                          std::span<const uint8_t> common_prefix = {},
+                                                          std::string_view provider = "");
+
+      /**
+      * Create a new Hash_Engine
+      *
+      * @param hash_fn the hash function to compute
+      * @param common_prefix implicitly prepended to each message hashed;
+      *        implementations may precompute the resulting hash state
+      * @param provider if set, use this specific implementation
+      * @return new object or nullptr if not available
+      */
+      static std::unique_ptr<Hash_Engine> create_or_null(std::string_view hash_fn,
+                                                         std::span<const uint8_t> common_prefix = {},
+                                                         std::string_view provider = "");
+
+      /**
+      * Return a list of possible providers for this hash function
+      */
+      static std::vector<std::string> possible_providers(std::string_view hash_fn);
+
+      Hash_Engine(const Hash_Engine& other) = delete;
+      Hash_Engine(Hash_Engine&& other) = delete;
+
+      Hash_Engine& operator=(const Hash_Engine& other) = delete;
+      Hash_Engine& operator=(Hash_Engine&& other) = delete;
+
+      virtual ~Hash_Engine() = default;
+
+   protected:
+      explicit Hash_Engine(std::span<const uint8_t> common_prefix) :
+            m_common_prefix(common_prefix.begin(), common_prefix.end()) {}
+
+      /**
+      * @return the prefix implicitly prepended to each message
+      */
+      std::span<const uint8_t> common_prefix() const { return m_common_prefix; }
+
+      /**
+      * Verify the batch_hash argument contract, throwing Invalid_Argument
+      * if violated
+      */
+      void check_batch_args(std::span<std::span<uint8_t>> outputs,
+                            std::span<std::span<const uint8_t>> inputs1,
+                            std::span<std::span<const uint8_t>> inputs2) const;
+
+   private:
+      secure_vector<uint8_t> m_common_prefix;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/hash_engine/info.txt
+++ b/src/lib/hash_engine/info.txt
@@ -1,0 +1,15 @@
+<internal_defines>
+HASH_ENGINES -> 20260813
+</internal_defines>
+
+<module_info>
+name -> "Hash Engine"
+</module_info>
+
+<requires>
+hash
+</requires>
+
+<header:internal>
+hash_engine.h
+</header:internal>

--- a/src/tests/test_hash_engine.cpp
+++ b/src/tests/test_hash_engine.cpp
@@ -1,0 +1,303 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include "tests.h"
+
+#if defined(BOTAN_HAS_HASH_ENGINES) && defined(BOTAN_HAS_HASH)
+
+   #include <botan/hash.h>
+   #include <botan/rng.h>
+   #include <botan/internal/fmt.h>
+   #include <botan/internal/hash_engine.h>
+   #include <algorithm>
+
+namespace Botan_Tests {
+
+namespace {
+
+class Hash_Engine_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         for(const auto& hash_fn : hash_engine_algorithms()) {
+            Test::Result result(Botan::fmt("Hash_Engine {}", hash_fn));
+
+            result.start_timer();
+
+            for(const auto& provider : Botan::Hash_Engine::possible_providers(hash_fn)) {
+               auto engine = Botan::Hash_Engine::create_or_null(hash_fn, {}, provider);
+               auto ref_hash = Botan::HashFunction::create(hash_fn);
+
+               if(!engine || !ref_hash) {
+                  continue;
+               }
+
+               result.test_str_eq("Hash_Engine::name", engine->name(), hash_fn);
+               result.test_str_eq("Hash_Engine::provider", engine->provider(), provider);
+
+               result.test_sz_eq("output_length", engine->output_length(), ref_hash->output_length());
+               result.test_sz_gte("parallelism >= 1", engine->parallelism(), 1);
+
+               test_batch_hash(result, rng(), *engine, *ref_hash);
+               test_two_part_inputs(result, rng(), *engine, *ref_hash);
+               test_common_prefix(result, rng(), *ref_hash, provider);
+               test_chaining_in_place(result, rng(), *engine, *ref_hash);
+            }
+
+            result.end_timer();
+            results.push_back(result);
+         }
+
+         return results;
+      }
+
+   private:
+      static void test_batch_hash(Test::Result& result,
+                                  Botan::RandomNumberGenerator& rng,
+                                  Botan::Hash_Engine& engine,
+                                  Botan::HashFunction& ref_hash) {
+         // Message sizes chosen to hit various padding edge cases
+         const std::vector<size_t> msg_sizes = {0,   1,   7,   24,  32,  55,  56,  63,  64,  65,  111, 112,
+                                                127, 128, 129, 135, 136, 137, 200, 255, 256, 257, 271, 272};
+
+         const size_t parallelism = engine.parallelism();
+         const size_t output_length = engine.output_length();
+
+         for(const size_t count : batch_counts(parallelism)) {
+            std::vector<std::vector<uint8_t>> input_bufs(count);
+            std::vector<std::vector<uint8_t>> output_bufs(count);
+            std::vector<std::span<const uint8_t>> input_spans(count);
+            std::vector<std::span<uint8_t>> output_spans(count);
+
+            for(size_t i = 0; i < count; ++i) {
+               output_bufs[i].resize(output_length);
+               output_spans[i] = output_bufs[i];
+            }
+
+            for(const size_t msg_len : msg_sizes) {
+               for(size_t i = 0; i < count; ++i) {
+                  input_bufs[i].resize(msg_len);
+                  rng.randomize(input_bufs[i]);
+                  input_spans[i] = input_bufs[i];
+               }
+
+               engine.batch_hash(output_spans, input_spans);
+
+               for(size_t i = 0; i < count; ++i) {
+                  auto expected = ref_hash.process<std::vector<uint8_t>>(input_spans[i]);
+                  result.test_bin_eq("batch_hash output", output_bufs[i], expected);
+               }
+            }
+         }
+      }
+
+      static void test_two_part_inputs(Test::Result& result,
+                                       Botan::RandomNumberGenerator& rng,
+                                       Botan::Hash_Engine& engine,
+                                       Botan::HashFunction& ref_hash) {
+         const size_t output_length = engine.output_length();
+         const size_t count = engine.parallelism() + 3;
+
+         const std::vector<size_t> part_sizes = {0, 1, 22, 32, 55, 64, 111, 137};
+
+         std::vector<std::vector<uint8_t>> in1_bufs(count);
+         std::vector<std::vector<uint8_t>> in2_bufs(count);
+         std::vector<std::vector<uint8_t>> output_bufs(count);
+         std::vector<std::span<const uint8_t>> in1_spans(count);
+         std::vector<std::span<const uint8_t>> in2_spans(count);
+         std::vector<std::span<uint8_t>> output_spans(count);
+
+         for(size_t i = 0; i < count; ++i) {
+            output_bufs[i].resize(output_length);
+            output_spans[i] = output_bufs[i];
+         }
+
+         for(const size_t len1 : part_sizes) {
+            for(const size_t len2 : part_sizes) {
+               for(size_t i = 0; i < count; ++i) {
+                  in1_bufs[i].resize(len1);
+                  in2_bufs[i].resize(len2);
+                  rng.randomize(in1_bufs[i]);
+                  rng.randomize(in2_bufs[i]);
+                  in1_spans[i] = in1_bufs[i];
+                  in2_spans[i] = in2_bufs[i];
+               }
+
+               engine.batch_hash(output_spans, in1_spans, in2_spans);
+
+               for(size_t i = 0; i < count; ++i) {
+                  ref_hash.update(in1_bufs[i]);
+                  ref_hash.update(in2_bufs[i]);
+                  const auto expected = ref_hash.final_stdvec();
+                  result.test_bin_eq("batch_hash split inputs", output_bufs[i], expected);
+               }
+            }
+         }
+      }
+
+      void test_common_prefix(Test::Result& result,
+                              Botan::RandomNumberGenerator& rng,
+                              Botan::HashFunction& ref_hash,
+                              std::string_view provider) {
+         const std::vector<size_t> prefix_sizes = {1, 17, 32, 55, 64, 100, 128, 200};
+         const std::vector<size_t> msg_sizes = {0, 22, 32, 100};
+
+         const std::string hash_fn = ref_hash.name();
+
+         for(const size_t prefix_len : prefix_sizes) {
+            const auto prefix = rng.random_vec(prefix_len);
+
+            auto engine = Botan::Hash_Engine::create_or_throw(hash_fn, prefix, provider);
+
+            const size_t output_length = engine->output_length();
+            const size_t count = engine->parallelism() + 3;
+
+            std::vector<std::vector<uint8_t>> in1_bufs(count);
+            std::vector<std::vector<uint8_t>> in2_bufs(count);
+            std::vector<std::vector<uint8_t>> output_bufs(count);
+            std::vector<std::span<const uint8_t>> in1_spans(count);
+            std::vector<std::span<const uint8_t>> in2_spans(count);
+            std::vector<std::span<uint8_t>> output_spans(count);
+
+            for(size_t i = 0; i < count; ++i) {
+               output_bufs[i].resize(output_length);
+               output_spans[i] = output_bufs[i];
+            }
+
+            for(const size_t msg_len : msg_sizes) {
+               for(size_t i = 0; i < count; ++i) {
+                  in1_bufs[i].resize(msg_len);
+                  rng.randomize(in1_bufs[i]);
+                  in1_spans[i] = in1_bufs[i];
+               }
+
+               engine->batch_hash(output_spans, in1_spans);
+
+               for(size_t i = 0; i < count; ++i) {
+                  ref_hash.update(prefix);
+                  ref_hash.update(in1_bufs[i]);
+                  const auto expected = ref_hash.final_stdvec();
+                  result.test_bin_eq("prefixed hash", output_bufs[i], expected);
+               }
+            }
+
+            // Also check the two part input form with a prefix
+            for(size_t i = 0; i < count; ++i) {
+               in1_bufs[i].resize(13);
+               in2_bufs[i].resize(19);
+               rng.randomize(in1_bufs[i]);
+               rng.randomize(in2_bufs[i]);
+               in1_spans[i] = in1_bufs[i];
+               in2_spans[i] = in2_bufs[i];
+            }
+
+            engine->batch_hash(output_spans, in1_spans, in2_spans);
+
+            for(size_t i = 0; i < count; ++i) {
+               ref_hash.update(prefix);
+               ref_hash.update(in1_bufs[i]);
+               ref_hash.update(in2_bufs[i]);
+               const auto expected = ref_hash.final_stdvec();
+               result.test_bin_eq("prefixed two part hash", output_bufs[i], expected);
+            }
+         }
+      }
+
+      void test_chaining_in_place(Test::Result& result,
+                                  Botan::RandomNumberGenerator& rng,
+                                  Botan::Hash_Engine& engine,
+                                  Botan::HashFunction& ref_hash) {
+         const size_t output_length = engine.output_length();
+         const size_t count = engine.parallelism() * 2 + 1;
+         const size_t steps = 7;
+
+         std::vector<std::vector<uint8_t>> bufs(count);
+         std::vector<std::span<const uint8_t>> input_spans(count);
+         std::vector<std::span<uint8_t>> output_spans(count);
+
+         for(size_t i = 0; i < count; ++i) {
+            bufs[i].resize(output_length);
+            rng.randomize(bufs[i]);
+            input_spans[i] = bufs[i];
+            output_spans[i] = bufs[i];
+         }
+
+         std::vector<std::vector<uint8_t>> expected = bufs;
+
+         // Outputs are documented as allowed to alias the respective input,
+         // as required for stepping OTS chains in place
+         for(size_t step = 0; step != steps; ++step) {
+            engine.batch_hash(output_spans, input_spans);
+         }
+
+         for(size_t i = 0; i < count; ++i) {
+            for(size_t step = 0; step != steps; ++step) {
+               expected[i] = ref_hash.process<std::vector<uint8_t>>(expected[i]);
+            }
+            result.test_bin_eq("chained hash", bufs[i], expected[i]);
+         }
+      }
+
+      /**
+      * Batch sizes exercising the empty case, partially filled batches
+      * around the parallelism boundaries, and counts large enough to
+      * require multiple threads or lane groups
+      */
+      static std::vector<size_t> batch_counts(size_t parallelism) {
+         std::vector<size_t> counts;
+         for(size_t i = 0; i <= std::min<size_t>(2 * parallelism, 33); ++i) {
+            counts.push_back(i);
+         }
+         counts.insert(counts.end(),
+                       {parallelism - 1,
+                        parallelism,
+                        parallelism + 1,
+                        2 * parallelism - 1,
+                        2 * parallelism,
+                        2 * parallelism + 1,
+                        64,
+                        65,
+                        128,
+                        200,
+                        257});
+
+         std::sort(counts.begin(), counts.end());
+         counts.erase(std::unique(counts.begin(), counts.end()), counts.end());
+         return counts;
+      }
+
+      static std::vector<std::string> hash_engine_algorithms() {
+         return std::vector<std::string> {
+   #if defined(BOTAN_HAS_SHA2_32)
+            "SHA-256",
+   #endif
+   #if defined(BOTAN_HAS_SHA2_32) && defined(BOTAN_HAS_TRUNCATED_HASH)
+               "Truncated(SHA-256,128)",
+   #endif
+   #if defined(BOTAN_HAS_SHA2_64)
+               "SHA-512", "SHA-384", "SHA-512-256", "Truncated(SHA-512,256)",
+   #endif
+   #if defined(BOTAN_HAS_SHAKE)
+               "SHAKE-128(256)", "SHAKE-256(192)", "SHAKE-256(256)", "SHAKE-256(2400)",
+   #endif
+   #if defined(BOTAN_HAS_SHA3)
+               "SHA-3(256)", "SHA-3(512)",
+   #endif
+   #if defined(BOTAN_HAS_SM3)
+               "SM3",
+   #endif
+         };
+      }
+};
+
+BOTAN_REGISTER_TEST("hash", "hash_engine", Hash_Engine_Tests);
+
+}  // namespace
+
+}  // namespace Botan_Tests
+
+#endif


### PR DESCRIPTION
This is a limited interface for cryptographic hashing of many messages in parallel, where all of the inputs are exactly the same length. This restriction simplifies the implementation while still being sufficient to meet the needs of hash based signatures.

This provides the interface but the current implementation is only marginally interesting. Future PRs will extend the implementation (given the interface restrictions, it's easy to implement SIMD parallel hashing, AVX512 in particular giving excellent results) and modify the hash-based signature schemes to make use of the available parallelism.

FYI @TJ-91 re #5256; not required to use this in the initial PR but might be of interest
