### PR TITLE
refactor(rng): Deprecate random_vec(span) in favor of randomize()

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -253,6 +253,14 @@ release, or where a backwards incompatible change is expected.
   "PSSR", "EMSA-PSS", "PSS-MGF1", "EMSA4": Use "PSS"
   "EMSA_X931", "EMSA2": Use "X9.31"
 
+- ``RandomNumberGenerator::random_vec(std::span<uint8_t>)`` is deprecated
+  in favor of ``RandomNumberGenerator::randomize(std::span<uint8_t>)``.
+  Unlike the other ``random_vec`` overloads it performs no resizing or
+  allocation, and is functionally identical to ``randomize``. Both take
+  the same ``std::span<uint8_t>`` parameter, so any contiguous byte range
+  that binds to one binds to the other. The remaining ``random_vec``
+  overloads are unaffected.
+
 Deprecated Headers
 ^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -196,12 +196,17 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       /**
       * Fill a given byte container with @p bytes random bytes
       *
-      * @todo deprecate this overload (in favor of randomize())
+      * Deprecated
+      * Use randomize(std::span<uint8_t>) overload instead. No resizing or
+      * allocation operations are performed here. This overload exists for
+      * historical reasons and will be removed in Botan4.
       *
       * @param  v     the container to be filled with @p bytes random bytes
       * @throws Exception if RNG fails
+      *
+      * TODO(Botan4) remove this function
       */
-      void random_vec(std::span<uint8_t> v) { this->randomize(v); }
+      BOTAN_DEPRECATED("Use randomize() instead") void random_vec(std::span<uint8_t> v) { this->randomize(v); }
 
       /**
       * Resize a given byte container to @p bytes and fill it with random bytes
@@ -214,7 +219,7 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       template <concepts::resizable_byte_buffer T>
       void random_vec(T& v, size_t bytes) {
          v.resize(bytes);
-         random_vec(v);
+         randomize(v);
       }
 
       /**
@@ -239,7 +244,7 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       template <size_t bytes>
       std::array<uint8_t, bytes> random_array() {
          std::array<uint8_t, bytes> result{};
-         random_vec(result);
+         randomize(result);
          return result;
       }
 

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -236,12 +236,14 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       /**
       * Fill a given byte container with @p bytes random bytes
       *
-      * @todo deprecate this overload (in favor of randomize())
-      *
       * @param  v     the container to be filled with @p bytes random bytes
       * @throws Exception if RNG fails
+      *
+      * TODO(Botan4) remove this function
       */
-      void random_vec(std::span<uint8_t> v) { this->randomize(v); }
+      BOTAN_DEPRECATED("Use randomize(std::span<uint8_t>) instead") void random_vec(std::span<uint8_t> v) {
+         this->randomize(v);
+      }
 
       /**
       * Resize a given byte container to @p bytes and fill it with random bytes
@@ -254,7 +256,7 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       template <concepts::resizable_byte_buffer T>
       void random_vec(T& v, size_t bytes) {
          v.resize(bytes);
-         random_vec(v);
+         randomize(v);
       }
 
       /**
@@ -279,7 +281,7 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       template <size_t bytes>
       std::array<uint8_t, bytes> random_array() {
          std::array<uint8_t, bytes> result{};
-         random_vec(result);
+         randomize(result);
          return result;
       }
 

--- a/src/tests/test_rng.h
+++ b/src/tests/test_rng.h
@@ -100,7 +100,7 @@ class Fixed_Output_Position_RNG final : public Fixed_Output_RNG {
             Fixed_Output_RNG::fill_bytes_with_input(output, input);
          } else {
             // return random
-            m_rng.random_vec(output);
+            m_rng.randomize(output);
          }
       }
 

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -265,7 +265,7 @@ class Strong_Type_Tests final : public Test {
          auto tb = rng.random_vec<Test_Buffer>(4);
          auto tsb = rng.random_vec<Test_Secure_Buffer>(4);
          Test_Fixed_Array tfa;
-         rng.random_vec(tfa);
+         rng.randomize(tfa);
 
          result.test_bin_eq("generated expected output", tb.get(), "deadbeef");
          result.test_bin_eq("generated expected secure output", tsb.get(), "baadcafe");


### PR DESCRIPTION
The `random_vec(std::span<uint8_t>)` overload marked with the `todo` message is functionally identical to `randomize(std::span<uint8_t>)`. It does not perform any resizing or allocation operations.

In this regard:
* `random_vec` function marked as deprecated.
* `todo` message updated for its removal in Botan4.
* Internal call sites have been migrated from `random_vec(std::span<uint8_t>)` to `randomize()`.

**Notes**
`random_vec(T& v, size_t bytes)` and `T random_vec(size_t bytes)` overloads are retained — they provide resize/allocate semantics that have no equivalent in `randomize()`.

**Notes 2**
The `@deprecated` Doxygen tag was considered but omitted — it is not used elsewhere in the project and triggers `-Wdocumentation-deprecated-sync` warnings across all translation units that include this header.


Updates:
06.05.2026 - Rebase master for `src/tests/test_strong_type.cpp` conflict.
24.05.2026 - Rebase master branch.
23.08.2026 - Rebased onto master. The deprecation rationale was moved out of the function's Doxygen block and into the `Other Deprecated Functionality` section of `deprecated.rst`, keeping the header comment limited to `@param/@throws/TODO(Botan4)`, consistent with `reseed()` elsewhere in this file.