### PR TITLE
Discard TLS handshake state after handshake has completed

### DIFF
--- a/src/lib/tls/tls12/info.txt
+++ b/src/lib/tls/tls12/info.txt
@@ -14,6 +14,7 @@ tls_extensions_12.h
 
 <header:internal>
 tls_channel_impl_12.h
+tls_connection_state_12.h
 tls_client_impl_12.h
 tls_record.h
 tls_server_impl_12.h

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -13,6 +13,7 @@
 #include <botan/tls_messages_12.h>
 #include <botan/tls_policy.h>
 #include <botan/x509cert.h>
+#include <botan/internal/concat_util.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/mem_utils.h>
@@ -97,19 +98,20 @@ std::shared_ptr<Connection_Cipher_State> Channel_Impl_12::write_cipher_state_epo
 }
 
 std::vector<X509_Certificate> Channel_Impl_12::peer_cert_chain() const {
-   if(const auto* active = active_state()) {
-      return get_peer_cert_chain(*active);
+   if(m_active_state.has_value()) {
+      return m_active_state->peer_certs();
    }
    return std::vector<X509_Certificate>();
 }
 
 std::optional<std::string> Channel_Impl_12::external_psk_identity() const {
-   const auto* state = (active_state() != nullptr) ? active_state() : pending_state();
-   if(state != nullptr) {
-      return state->psk_identity();
-   } else {
-      return std::nullopt;
+   if(m_active_state.has_value()) {
+      return m_active_state->psk_identity();
    }
+   if(const auto* state = pending_state()) {
+      return state->psk_identity();
+   }
+   return std::nullopt;
 }
 
 Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version version) {
@@ -117,8 +119,8 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
       throw Internal_Error("create_handshake_state called during handshake");
    }
 
-   if(const auto* active = active_state()) {
-      const Protocol_Version active_version = active->version();
+   if(m_active_state.has_value()) {
+      const Protocol_Version active_version = m_active_state->version();
 
       if(active_version.is_datagram_protocol() != version.is_datagram_protocol()) {
          throw TLS_Exception(Alert::ProtocolVersion,
@@ -161,8 +163,8 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
 
    m_pending_state = new_handshake_state(std::move(io));
 
-   if(const auto* active = active_state()) {
-      m_pending_state->set_version(active->version());
+   if(m_active_state.has_value()) {
+      m_pending_state->set_version(m_active_state->version());
    }
 
    return *m_pending_state;
@@ -182,12 +184,12 @@ void Channel_Impl_12::renegotiate(bool force_full_renegotiation) {
       return;
    }
 
-   if(const auto* active = active_state()) {
+   if(m_active_state.has_value()) {
       if(!force_full_renegotiation) {
          force_full_renegotiation = !policy().allow_resumption_for_renegotiation();
       }
 
-      initiate_handshake(create_handshake_state(active->version()), force_full_renegotiation);
+      initiate_handshake(create_handshake_state(m_active_state->version()), force_full_renegotiation);
    } else {
       throw Invalid_State("Cannot renegotiate on inactive connection");
    }
@@ -250,7 +252,7 @@ void Channel_Impl_12::change_cipher_spec_writer(Connection_Side side) {
 }
 
 bool Channel_Impl_12::is_handshake_complete() const {
-   return (active_state() != nullptr);
+   return m_active_state.has_value();
 }
 
 bool Channel_Impl_12::is_active() const {
@@ -262,10 +264,11 @@ bool Channel_Impl_12::is_closed() const {
 }
 
 void Channel_Impl_12::activate_session() {
-   std::swap(m_active_state, m_pending_state);
-   m_pending_state.reset();
+   BOTAN_ASSERT_NONNULL(m_pending_state);
 
-   if(!m_active_state->version().is_datagram_protocol()) {
+   const auto& state = *m_pending_state;
+
+   if(!state.version().is_datagram_protocol()) {
       // TLS is easy just remove all but the current state
       const uint16_t current_epoch = sequence_numbers().current_write_epoch();
 
@@ -274,6 +277,15 @@ void Channel_Impl_12::activate_session() {
       map_remove_if(not_current_epoch, m_write_cipher_states);
       map_remove_if(not_current_epoch, m_read_cipher_states);
    }
+
+   // For DTLS, keep the handshake IO for last-flight retransmission.
+   if(m_is_datagram) {
+      m_active_state = Active_Connection_State_12(state, application_protocol(), m_pending_state->take_handshake_io());
+   } else {
+      m_active_state = Active_Connection_State_12(state, application_protocol());
+   }
+
+   m_pending_state.reset();
 
    callbacks().tls_session_activated();
 }
@@ -324,10 +336,10 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
             throw TLS_Exception(Alert::RecordOverflow, "TLS plaintext record is larger than allowed maximum");
          }
 
-         const bool epoch0_restart = m_is_datagram && record.epoch() == 0 && active_state() != nullptr;
+         const bool epoch0_restart = m_is_datagram && record.epoch() == 0 && m_active_state.has_value();
          BOTAN_ASSERT_IMPLICATION(epoch0_restart, allow_epoch0_restart, "Allowed state");
 
-         const bool initial_record = epoch0_restart || (pending_state() == nullptr && active_state() == nullptr);
+         const bool initial_record = epoch0_restart || (pending_state() == nullptr && !m_active_state.has_value());
          bool initial_handshake_message = false;
          if(record.type() == Record_Type::Handshake && !m_record_buf.empty()) {
             const Handshake_Type type = static_cast<Handshake_Type>(m_record_buf[0]);
@@ -345,8 +357,8 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
                   record.version() != pending->version()) {
                   throw TLS_Exception(Alert::ProtocolVersion, "Received unexpected record version");
                }
-            } else if(const auto* active = active_state()) {
-               if(record.version() != active->version() && !initial_handshake_message) {
+            } else if(m_active_state.has_value()) {
+               if(record.version() != m_active_state->version() && !initial_handshake_message) {
                   throw TLS_Exception(Alert::ProtocolVersion, "Received unexpected record version");
                }
             }
@@ -410,8 +422,10 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
             if(epoch == current_epoch) {
                create_handshake_state(record_version);
             } else if(current_epoch > 0 && epoch == current_epoch - 1) {
-               BOTAN_ASSERT(m_active_state, "Have active state here");
-               m_active_state->handshake_io().add_record(record.data(), record.size(), record_type, record_sequence);
+               BOTAN_ASSERT(m_active_state.has_value() && m_active_state->dtls_handshake_io(),
+                            "Have DTLS handshake IO for retransmission");
+               m_active_state->dtls_handshake_io()->add_record(
+                  record.data(), record.size(), record_type, record_sequence);
             }
          } else {
             create_handshake_state(record_version);
@@ -432,7 +446,7 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
             break;
          }
 
-         process_handshake_msg(active_state(), *pending, msg.first, msg.second, epoch0_restart);
+         process_handshake_msg(*pending, msg.first, msg.second, epoch0_restart);
 
          if(!m_pending_state) {
             break;
@@ -442,7 +456,7 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
 }
 
 void Channel_Impl_12::process_application_data(uint64_t seq_no, const secure_vector<uint8_t>& record) {
-   if(active_state() == nullptr) {
+   if(!m_active_state.has_value()) {
       throw Unexpected_Message("Application data before handshake done");
    }
 
@@ -463,19 +477,17 @@ void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record) {
    //    no_renegotiation
    //       Sent by the client in response to a hello request or by the
    //       server in response to a client hello after initial handshaking.
-   if(alert_msg.type() == Alert::NoRenegotiation && active_state() != nullptr) {
+   if(alert_msg.type() == Alert::NoRenegotiation && m_active_state.has_value()) {
       m_pending_state.reset();
    }
 
    callbacks().tls_alert(alert_msg);
 
-   if(alert_msg.is_fatal()) {
-      if(const auto* active = active_state()) {
-         BOTAN_ASSERT_NONNULL(active->server_hello());
-         const auto& session_id = active->server_hello()->session_id();
-         if(!session_id.empty()) {
-            session_manager().remove(Session_Handle(session_id));
-         }
+   // If the alert is fatal on an active session, prevent later resumptions
+   if(alert_msg.is_fatal() && m_active_state.has_value()) {
+      const auto& sid = m_active_state->session_id();
+      if(!sid.empty()) {
+         session_manager().remove(Session_Handle(sid));
       }
    }
 
@@ -496,10 +508,9 @@ void Channel_Impl_12::write_record(Connection_Cipher_State* cipher_state,
                                    Record_Type record_type,
                                    const uint8_t input[],
                                    size_t length) {
-   BOTAN_ASSERT(m_pending_state || m_active_state, "Some connection state exists");
+   BOTAN_ASSERT(m_pending_state || m_active_state.has_value(), "Some connection state exists");
 
-   const Protocol_Version record_version =
-      (m_pending_state) ? (m_pending_state->version()) : (m_active_state->version());
+   const Protocol_Version record_version = (m_pending_state) ? (m_pending_state->version()) : m_active_state->version();
 
    const uint64_t next_seq = sequence_numbers().next_write_sequence(epoch);
 
@@ -555,16 +566,15 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
       }
    }
 
-   if(alert.type() == Alert::NoRenegotiation && active_state() != nullptr) {
+   if(alert.type() == Alert::NoRenegotiation && m_active_state.has_value()) {
       m_pending_state.reset();
    }
 
    if(alert.is_fatal()) {
-      if(const auto* active = active_state()) {
-         BOTAN_ASSERT_NONNULL(active->server_hello());
-         const auto& session_id = active->server_hello()->session_id();
-         if(!session_id.empty()) {
-            session_manager().remove(Session_Handle(Session_ID(session_id)));
+      if(m_active_state.has_value()) {
+         const auto& sid = m_active_state->session_id();
+         if(!sid.empty()) {
+            session_manager().remove(Session_Handle(sid));
          }
       }
       reset_state();
@@ -579,13 +589,8 @@ void Channel_Impl_12::secure_renegotiation_check(const Client_Hello_12* client_h
    BOTAN_ASSERT_NONNULL(client_hello);
    const bool secure_renegotiation = client_hello->secure_renegotiation();
 
-   if(const auto* active = active_state()) {
-      BOTAN_ASSERT_NONNULL(active->client_hello());
-      const bool active_sr = active->client_hello()->secure_renegotiation();
-
-      if(active_sr != secure_renegotiation) {
-         throw TLS_Exception(Alert::HandshakeFailure, "Client changed its mind about secure renegotiation");
-      }
+   if(m_active_state && m_active_state->client_supports_secure_renegotiation() != secure_renegotiation) {
+      throw TLS_Exception(Alert::HandshakeFailure, "Client changed its mind about secure renegotiation");
    }
 
    if(secure_renegotiation) {
@@ -602,13 +607,8 @@ void Channel_Impl_12::secure_renegotiation_check(const Server_Hello_12* server_h
    BOTAN_ASSERT_NONNULL(server_hello);
    const bool secure_renegotiation = server_hello->secure_renegotiation();
 
-   if(const auto* active = active_state()) {
-      BOTAN_ASSERT_NONNULL(active->server_hello());
-      const bool active_sr = active->server_hello()->secure_renegotiation();
-
-      if(active_sr != secure_renegotiation) {
-         throw TLS_Exception(Alert::HandshakeFailure, "Server changed its mind about secure renegotiation");
-      }
+   if(m_active_state && m_active_state->server_supports_secure_renegotiation() != secure_renegotiation) {
+      throw TLS_Exception(Alert::HandshakeFailure, "Server changed its mind about secure renegotiation");
    }
 
    if(secure_renegotiation) {
@@ -622,28 +622,23 @@ void Channel_Impl_12::secure_renegotiation_check(const Server_Hello_12* server_h
 }
 
 std::vector<uint8_t> Channel_Impl_12::secure_renegotiation_data_for_client_hello() const {
-   if(const auto* active = active_state()) {
-      BOTAN_ASSERT_NONNULL(active->client_finished());
-      return active->client_finished()->verify_data();
+   if(m_active_state.has_value()) {
+      return m_active_state->client_finished_verify_data();
    }
    return std::vector<uint8_t>();
 }
 
 std::vector<uint8_t> Channel_Impl_12::secure_renegotiation_data_for_server_hello() const {
-   if(const auto* active = active_state()) {
-      BOTAN_ASSERT_NONNULL(active->client_finished());
-      BOTAN_ASSERT_NONNULL(active->server_finished());
-      std::vector<uint8_t> buf = active->client_finished()->verify_data();
-      buf += active->server_finished()->verify_data();
-      return buf;
+   if(m_active_state.has_value()) {
+      return concat(m_active_state->client_finished_verify_data(), m_active_state->server_finished_verify_data());
+   } else {
+      return {};
    }
-
-   return std::vector<uint8_t>();
 }
 
 bool Channel_Impl_12::secure_renegotiation_supported() const {
-   if(const auto* active = active_state()) {
-      return active->server_hello()->secure_renegotiation();
+   if(m_active_state.has_value()) {
+      return m_active_state->server_supports_secure_renegotiation();
    }
 
    if(const auto* pending = pending_state()) {
@@ -658,35 +653,28 @@ bool Channel_Impl_12::secure_renegotiation_supported() const {
 SymmetricKey Channel_Impl_12::key_material_export(std::string_view label,
                                                   std::string_view context,
                                                   size_t length) const {
-   if(const auto* active = active_state()) {
-      if(pending_state() != nullptr) {
-         throw Invalid_State("Channel_Impl_12::key_material_export cannot export during renegotiation");
-      }
-
-      auto prf = active->protocol_specific_prf();
-
-      const secure_vector<uint8_t>& master_secret = active->session_keys().master_secret();
-
-      BOTAN_ASSERT_NONNULL(active->client_hello());
-      BOTAN_ASSERT_NONNULL(active->server_hello());
-      std::vector<uint8_t> salt;
-      salt += active->client_hello()->random();
-      salt += active->server_hello()->random();
-
-      if(!context.empty()) {
-         const size_t context_size = context.length();
-         if(context_size > 0xFFFF) {
-            throw Invalid_Argument("key_material_export context is too long");
-         }
-         salt.push_back(get_byte<0>(static_cast<uint16_t>(context_size)));
-         salt.push_back(get_byte<1>(static_cast<uint16_t>(context_size)));
-         salt += as_span_of_bytes(context);
-      }
-
-      return SymmetricKey(prf->derive_key(length, master_secret, salt, as_span_of_bytes(label)));
-   } else {
+   if(!m_active_state.has_value()) {
       throw Invalid_State("Channel_Impl_12::key_material_export connection not active");
    }
+
+   if(pending_state() != nullptr) {
+      throw Invalid_State("Channel_Impl_12::key_material_export cannot export during renegotiation");
+   }
+
+   auto prf = callbacks().tls12_protocol_specific_kdf(m_active_state->prf_algo());
+
+   const auto salt = [&] {
+      if(context.empty()) {
+         return concat(m_active_state->client_random(), m_active_state->server_random());
+      } else {
+         return concat(m_active_state->client_random(),
+                       m_active_state->server_random(),
+                       store_be(static_cast<uint16_t>(context.size())),
+                       as_span_of_bytes(context));
+      }
+   }();
+
+   return SymmetricKey(prf->derive_key(length, m_active_state->master_secret(), salt, as_span_of_bytes(label)));
 }
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -12,6 +12,7 @@
 #include <botan/tls_alert.h>
 #include <botan/tls_session_manager.h>
 #include <botan/internal/tls_channel_impl.h>
+#include <botan/internal/tls_connection_state_12.h>
 #include <map>
 #include <memory>
 #include <string>
@@ -149,8 +150,9 @@ class Channel_Impl_12 : public Channel_Impl {
       bool timeout_check() override;
 
    protected:
-      virtual void process_handshake_msg(const Handshake_State* active_state,
-                                         Handshake_State& pending_state,
+      const std::optional<Active_Connection_State_12>& active_state() const { return m_active_state; }
+
+      virtual void process_handshake_msg(Handshake_State& pending_state,
                                          Handshake_Type type,
                                          const std::vector<uint8_t>& contents,
                                          bool epoch0_restart) = 0;
@@ -186,8 +188,6 @@ class Channel_Impl_12 : public Channel_Impl {
 
       virtual void initiate_handshake(Handshake_State& state, bool force_full_renegotiation) = 0;
 
-      virtual std::vector<X509_Certificate> get_peer_cert_chain(const Handshake_State& state) const = 0;
-
    private:
       void send_record(Record_Type record_type, const std::vector<uint8_t>& record);
 
@@ -205,8 +205,6 @@ class Channel_Impl_12 : public Channel_Impl {
       std::shared_ptr<Connection_Cipher_State> read_cipher_state_epoch(uint16_t epoch) const;
 
       std::shared_ptr<Connection_Cipher_State> write_cipher_state_epoch(uint16_t epoch) const;
-
-      const Handshake_State* active_state() const { return m_active_state.get(); }
 
       const Handshake_State* pending_state() const { return m_pending_state.get(); }
 
@@ -235,8 +233,7 @@ class Channel_Impl_12 : public Channel_Impl {
       /* sequence number state */
       std::unique_ptr<Connection_Sequence_Numbers> m_sequence_numbers;
 
-      /* pending and active connection states */
-      std::unique_ptr<Handshake_State> m_active_state;
+      /* pending handshake state (null when no handshake is in progress) */
       std::unique_ptr<Handshake_State> m_pending_state;
 
       /* cipher states for each epoch */
@@ -249,6 +246,8 @@ class Channel_Impl_12 : public Channel_Impl {
       secure_vector<uint8_t> m_record_buf;
 
       bool m_has_been_closed;
+
+      std::optional<Active_Connection_State_12> m_active_state;
 };
 
 }  // namespace TLS

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -74,6 +74,16 @@ class Client_Handshake_State_12 final : public Handshake_State {
          return m_resumed_session->ciphersuite_code();
       }
 
+      std::vector<X509_Certificate> peer_cert_chain() const override {
+         if(is_a_resumption()) {
+            return resume_peer_certs();
+         }
+         if(server_certs() != nullptr) {
+            return server_certs()->cert_chain();
+         }
+         return {};
+      }
+
    private:
       std::unique_ptr<Public_Key> m_server_public_key;
 
@@ -144,19 +154,6 @@ Client_Impl_12::Client_Impl_12(const Channel_Impl::Downgrade_Information& downgr
 
 std::unique_ptr<Handshake_State> Client_Impl_12::new_handshake_state(std::unique_ptr<Handshake_IO> io) {
    return std::make_unique<Client_Handshake_State_12>(std::move(io), callbacks());
-}
-
-std::vector<X509_Certificate> Client_Impl_12::get_peer_cert_chain(const Handshake_State& state) const {
-   const Client_Handshake_State_12& cstate = dynamic_cast<const Client_Handshake_State_12&>(state);
-
-   if(cstate.is_a_resumption()) {
-      return cstate.resume_peer_certs();
-   }
-
-   if(state.server_certs() != nullptr) {
-      return state.server_certs()->cert_chain();
-   }
-   return std::vector<X509_Certificate>();
 }
 
 /*
@@ -250,8 +247,7 @@ bool key_usage_matches_ciphersuite(Key_Constraints usage, const Ciphersuite& sui
 /*
 * Process a handshake message
 */
-void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
-                                           Handshake_State& state_base,
+void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
                                            Handshake_Type type,
                                            const std::vector<uint8_t>& contents,
                                            bool epoch0_restart) {
@@ -259,7 +255,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
 
    Client_Handshake_State_12& state = dynamic_cast<Client_Handshake_State_12&>(state_base);
 
-   if(type == Handshake_Type::HelloRequest && active_state != nullptr) {
+   if(type == Handshake_Type::HelloRequest && active_state().has_value()) {
       const Hello_Request hello_request(contents);
 
       if(state.client_hello() != nullptr) {
@@ -449,17 +445,17 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
       } else {
          // new session
 
-         if(active_state != nullptr) {
+         if(active_state().has_value()) {
             // Here we are testing things that should not change during a renegotiation,
             // even if the server creates a new session. However they might change
             // in a resumption scenario.
 
-            if(active_state->version() != state.server_hello()->legacy_version()) {
+            if(active_state()->version() != state.server_hello()->legacy_version()) {
                throw TLS_Exception(Alert::ProtocolVersion, "Server changed version after renegotiation");
             }
 
             if(state.server_hello()->supports_extended_master_secret() !=
-               active_state->server_hello()->supports_extended_master_secret()) {
+               active_state()->supports_extended_master_secret()) {
                throw TLS_Exception(Alert::HandshakeFailure, "Server changed its mind about extended master secret");
             }
          }
@@ -523,8 +519,8 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
 
       const X509_Certificate server_cert = server_certs[0];
 
-      if(active_state != nullptr && active_state->server_certs() != nullptr) {
-         const X509_Certificate current_cert = active_state->server_certs()->cert_chain().at(0);
+      if(active_state().has_value() && !active_state()->peer_certs().empty()) {
+         const X509_Certificate& current_cert = active_state()->peer_certs().at(0);
 
          if(current_cert != server_cert) {
             throw TLS_Exception(Alert::BadCertificate, "Server certificate changed during renegotiation");
@@ -713,7 +709,7 @@ void Client_Impl_12::process_handshake_msg(const Handshake_State* active_state,
                            Connection_Side::Client,
                            state.server_hello()->supports_extended_master_secret(),
                            state.server_hello()->supports_encrypt_then_mac(),
-                           get_peer_cert_chain(state),
+                           state.peer_cert_chain(),
                            m_info,
                            state.server_hello()->srtp_profile(),
                            callbacks().tls_current_timestamp(),

--- a/src/lib/tls/tls12/tls_client_impl_12.h
+++ b/src/lib/tls/tls12/tls_client_impl_12.h
@@ -64,8 +64,6 @@ class Client_Impl_12 : public Channel_Impl_12 {
       std::string application_protocol() const override { return m_application_protocol; }
 
    private:
-      std::vector<X509_Certificate> get_peer_cert_chain(const Handshake_State& state) const override;
-
       void initiate_handshake(Handshake_State& state, bool force_full_renegotiation) override;
 
       void send_client_hello(Handshake_State& state,
@@ -74,8 +72,7 @@ class Client_Impl_12 : public Channel_Impl_12 {
                              std::optional<Session_with_Handle> session_and_handle = std::nullopt,
                              const std::vector<std::string>& next_protocols = {});
 
-      void process_handshake_msg(const Handshake_State* active_state,
-                                 Handshake_State& pending_state,
+      void process_handshake_msg(Handshake_State& pending_state,
                                  Handshake_Type type,
                                  const std::vector<uint8_t>& contents,
                                  bool epoch0_restart) override;

--- a/src/lib/tls/tls12/tls_connection_state_12.cpp
+++ b/src/lib/tls/tls12/tls_connection_state_12.cpp
@@ -1,0 +1,47 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/tls_connection_state_12.h>
+
+#include <botan/tls_messages_12.h>
+#include <botan/internal/tls_handshake_io.h>
+#include <botan/internal/tls_handshake_state.h>
+
+namespace Botan::TLS {
+
+Active_Connection_State_12::~Active_Connection_State_12() = default;
+Active_Connection_State_12::Active_Connection_State_12(Active_Connection_State_12&&) noexcept = default;
+Active_Connection_State_12& Active_Connection_State_12::operator=(Active_Connection_State_12&&) noexcept = default;
+
+Active_Connection_State_12::Active_Connection_State_12(const Handshake_State& state, std::string application_protocol) :
+      m_version(state.version()),
+      m_ciphersuite_code(state.server_hello()->ciphersuite()),
+      m_application_protocol(std::move(application_protocol)),
+      m_peer_certs(state.peer_cert_chain()),
+      m_client_random(state.client_hello()->random()),
+      m_psk_identity(state.psk_identity()),
+      m_server_random(state.server_hello()->random()),
+      m_session_id(state.server_hello()->session_id()),
+      m_master_secret(state.session_keys().master_secret()),
+      m_prf_algo(state.ciphersuite().prf_algo()),
+      m_client_supports_secure_renegotiation(state.client_hello()->secure_renegotiation()),
+      m_server_supports_secure_renegotiation(state.server_hello()->secure_renegotiation()),
+      m_client_finished_verify_data(state.client_finished()->verify_data()),
+      m_server_finished_verify_data(state.server_finished()->verify_data()),
+      m_supports_extended_master_secret(state.server_hello()->supports_extended_master_secret()) {}
+
+Active_Connection_State_12::Active_Connection_State_12(const Handshake_State& state,
+                                                       std::string application_protocol,
+                                                       std::unique_ptr<Handshake_IO> io) :
+      Active_Connection_State_12(state, std::move(application_protocol)) {
+   BOTAN_ASSERT_NOMSG(m_version.is_datagram_protocol());
+   auto* dtls_io = dynamic_cast<Datagram_Handshake_IO*>(io.get());
+   BOTAN_ASSERT_NOMSG(dtls_io != nullptr);
+   m_dtls_handshake_io.reset(dtls_io);
+   io.release();  // NOLINT(*-unused-return-value)
+}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_connection_state_12.h
+++ b/src/lib/tls/tls12/tls_connection_state_12.h
@@ -1,0 +1,105 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_CONNECTION_STATE_12_H_
+#define BOTAN_TLS_CONNECTION_STATE_12_H_
+
+#include <botan/secmem.h>
+#include <botan/tls_session_id.h>
+#include <botan/tls_version.h>
+#include <botan/x509cert.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Botan::TLS {
+
+class Handshake_IO;
+class Datagram_Handshake_IO;
+class Handshake_State;
+
+/**
+* Captures the state of a completed TLS 1.2 handshake that is needed
+* for the lifetime of an active connection.
+ */
+class Active_Connection_State_12 final {
+   public:
+      ~Active_Connection_State_12();
+
+      Active_Connection_State_12(Active_Connection_State_12&&) noexcept;
+      Active_Connection_State_12& operator=(Active_Connection_State_12&&) noexcept;
+
+      Active_Connection_State_12(const Active_Connection_State_12&) = delete;
+      Active_Connection_State_12& operator=(const Active_Connection_State_12&) = delete;
+
+      Active_Connection_State_12(const Handshake_State& state, std::string application_protocol);
+
+      // DTLS variant: takes the handshake IO for replay of final flight
+      Active_Connection_State_12(const Handshake_State& state,
+                                 std::string application_protocol,
+                                 std::unique_ptr<Handshake_IO> io);
+
+      Protocol_Version version() const { return m_version; }
+
+      uint16_t ciphersuite_code() const { return m_ciphersuite_code; }
+
+      const std::string& application_protocol() const { return m_application_protocol; }
+
+      const std::vector<X509_Certificate>& peer_certs() const { return m_peer_certs; }
+
+      const std::vector<uint8_t>& client_random() const { return m_client_random; }
+
+      const std::optional<std::string>& psk_identity() const { return m_psk_identity; }
+
+      const std::vector<uint8_t>& server_random() const { return m_server_random; }
+
+      const Session_ID& session_id() const { return m_session_id; }
+
+      const secure_vector<uint8_t>& master_secret() const { return m_master_secret; }
+
+      const std::string& prf_algo() const { return m_prf_algo; }
+
+      bool client_supports_secure_renegotiation() const { return m_client_supports_secure_renegotiation; }
+
+      bool server_supports_secure_renegotiation() const { return m_server_supports_secure_renegotiation; }
+
+      const std::vector<uint8_t>& client_finished_verify_data() const { return m_client_finished_verify_data; }
+
+      const std::vector<uint8_t>& server_finished_verify_data() const { return m_server_finished_verify_data; }
+
+      bool supports_extended_master_secret() const { return m_supports_extended_master_secret; }
+
+      /**
+       * For DTLS: the handshake IO from the completed handshake, needed
+       * to retransmit the last flight when records arrive under the
+       * previous epoch. Null for stream TLS.
+       */
+      Datagram_Handshake_IO* dtls_handshake_io() { return m_dtls_handshake_io.get(); }
+
+   private:
+      Protocol_Version m_version;
+      uint16_t m_ciphersuite_code = 0;
+      std::string m_application_protocol;
+      std::vector<X509_Certificate> m_peer_certs;
+      std::vector<uint8_t> m_client_random;
+      std::optional<std::string> m_psk_identity;
+      std::vector<uint8_t> m_server_random;
+      Session_ID m_session_id;
+      secure_vector<uint8_t> m_master_secret;
+      std::string m_prf_algo;
+      bool m_client_supports_secure_renegotiation = false;
+      bool m_server_supports_secure_renegotiation = false;
+      std::vector<uint8_t> m_client_finished_verify_data;
+      std::vector<uint8_t> m_server_finished_verify_data;
+      bool m_supports_extended_master_secret = false;
+      std::unique_ptr<Datagram_Handshake_IO> m_dtls_handshake_io;
+};
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls12/tls_handshake_state.h
+++ b/src/lib/tls/tls12/tls_handshake_state.h
@@ -14,11 +14,13 @@
 #include <botan/tls_extensions.h>
 #include <botan/tls_handshake_msg.h>
 #include <botan/tls_session.h>
+#include <botan/x509cert.h>
 #include <botan/internal/tls_handshake_hash.h>
 #include <botan/internal/tls_handshake_io.h>
 #include <botan/internal/tls_handshake_transitions.h>
 #include <botan/internal/tls_session_key.h>
 #include <optional>
+#include <vector>
 
 namespace Botan {
 
@@ -67,6 +69,8 @@ class Handshake_State {
       Handshake_State& operator=(Handshake_State&& other) = delete;
 
       Handshake_IO& handshake_io() { return *m_handshake_io; }
+
+      std::unique_ptr<Handshake_IO> take_handshake_io() { return std::move(m_handshake_io); }
 
       /**
       * Return true iff we have received a particular message already
@@ -155,6 +159,8 @@ class Handshake_State {
       const Finished_12* server_finished() const { return m_server_finished.get(); }
 
       const Finished_12* client_finished() const { return m_client_finished.get(); }
+
+      virtual std::vector<X509_Certificate> peer_cert_chain() const = 0;
 
       const Ciphersuite& ciphersuite() const;
 

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -44,6 +44,16 @@ class Server_Handshake_State final : public Handshake_State {
 
       bool is_a_resumption() const { return m_is_a_resumption; }
 
+      std::vector<X509_Certificate> peer_cert_chain() const override {
+         if(!m_resume_peer_certs.empty()) {
+            return m_resume_peer_certs;
+         }
+         if(client_certs() != nullptr) {
+            return client_certs()->cert_chain();
+         }
+         return {};
+      }
+
    private:
       // Used by the server only, in case of RSA key exchange.
       std::shared_ptr<Private_Key> m_server_rsa_kex_key;
@@ -272,18 +282,6 @@ std::unique_ptr<Handshake_State> Server_Impl_12::new_handshake_state(std::unique
    return state;
 }
 
-std::vector<X509_Certificate> Server_Impl_12::get_peer_cert_chain(const Handshake_State& state_base) const {
-   const Server_Handshake_State& state = dynamic_cast<const Server_Handshake_State&>(state_base);
-   if(!state.resume_peer_certs().empty()) {
-      return state.resume_peer_certs();
-   }
-
-   if(state.client_certs() != nullptr) {
-      return state.client_certs()->cert_chain();
-   }
-   return std::vector<X509_Certificate>();
-}
-
 /*
 * Send a hello request to the client
 */
@@ -351,13 +349,12 @@ Protocol_Version select_version(const TLS::Policy& policy,
 /*
 * Process a Client Hello Message
 */
-void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_state,
-                                              Server_Handshake_State& pending_state,
+void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_state,
                                               const std::vector<uint8_t>& contents,
                                               bool epoch0_restart) {
-   BOTAN_ASSERT_IMPLICATION(epoch0_restart, active_state != nullptr, "Can't restart with a dead connection");
+   BOTAN_ASSERT_IMPLICATION(epoch0_restart, active_state().has_value(), "Can't restart with a dead connection");
 
-   const bool initial_handshake = epoch0_restart || active_state == nullptr;
+   const bool initial_handshake = epoch0_restart || !active_state().has_value();
 
    if(initial_handshake == false && policy().allow_client_initiated_renegotiation() == false) {
       if(policy().abort_connection_on_undesired_renegotiation()) {
@@ -407,7 +404,7 @@ void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_stat
    const Protocol_Version negotiated_version =
       select_version(policy(),
                      client_offer,
-                     active_state != nullptr ? active_state->version() : Protocol_Version(),
+                     active_state().has_value() ? active_state()->version() : Protocol_Version(),
                      pending_state.client_hello()->supported_versions());
 
    pending_state.set_version(negotiated_version);
@@ -448,8 +445,6 @@ void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_stat
    if(epoch0_restart) {
       // If we reached here then we were able to verify the cookie
       reset_active_association_state();
-      // This was pointing to m_active_state which was freed by reset_active_association_state
-      active_state = nullptr;
    }
 
    secure_renegotiation_check(pending_state.client_hello());
@@ -469,11 +464,12 @@ void Server_Impl_12::process_client_hello_msg(const Handshake_State* active_stat
    // There is apparently no RFC requirement that a client must not drop EMS between the
    // initial negotiation and a renegotiation... but there is also no RFC requirement
    // that we must accept it. So we don't.
-   if(active_state != nullptr && active_state->server_hello() != nullptr &&
-      active_state->server_hello()->supports_extended_master_secret() &&
-      !pending_state.client_hello()->supports_extended_master_secret()) {
-      throw TLS_Exception(Alert::HandshakeFailure,
-                          "Renegotiation ClientHello dropped the Extended Master Secret extension");
+   if(const auto& active = active_state()) {
+      const bool ems_pending = pending_state.client_hello()->supports_extended_master_secret();
+      if(active->supports_extended_master_secret() == true && ems_pending == false) {
+         throw TLS_Exception(Alert::HandshakeFailure,
+                             "Renegotiation ClientHello dropped the Extended Master Secret extension");
+      }
    }
 
    callbacks().tls_examine_extensions(
@@ -620,7 +616,7 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
                            Connection_Side::Server,
                            pending_state.server_hello()->supports_extended_master_secret(),
                            pending_state.server_hello()->supports_encrypt_then_mac(),
-                           get_peer_cert_chain(pending_state),
+                           pending_state.peer_cert_chain(),
                            Server_Information(pending_state.client_hello()->sni_hostname()),
                            pending_state.server_hello()->srtp_profile(),
                            callbacks().tls_current_timestamp());
@@ -666,8 +662,7 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
 /*
 * Process a handshake message
 */
-void Server_Impl_12::process_handshake_msg(const Handshake_State* active_state,
-                                           Handshake_State& state_base,
+void Server_Impl_12::process_handshake_msg(Handshake_State& state_base,
                                            Handshake_Type type,
                                            const std::vector<uint8_t>& contents,
                                            bool epoch0_restart) {
@@ -688,7 +683,7 @@ void Server_Impl_12::process_handshake_msg(const Handshake_State* active_state,
 
    switch(type) {
       case Handshake_Type::ClientHello:
-         return this->process_client_hello_msg(active_state, state, contents, epoch0_restart);
+         return this->process_client_hello_msg(state, contents, epoch0_restart);
 
       case Handshake_Type::Certificate:
          return this->process_certificate_msg(state, contents);

--- a/src/lib/tls/tls12/tls_server_impl_12.h
+++ b/src/lib/tls/tls12/tls_server_impl_12.h
@@ -63,18 +63,14 @@ class Server_Impl_12 : public Channel_Impl_12 {
       */
       std::string application_protocol() const override { return m_next_protocol; }
 
-      std::vector<X509_Certificate> get_peer_cert_chain(const Handshake_State& state) const override;
-
       void initiate_handshake(Handshake_State& state, bool force_full_renegotiation) override;
 
-      void process_handshake_msg(const Handshake_State* active_state,
-                                 Handshake_State& pending_state,
+      void process_handshake_msg(Handshake_State& pending_state,
                                  Handshake_Type type,
                                  const std::vector<uint8_t>& contents,
                                  bool epoch0_restart) override;
 
-      void process_client_hello_msg(const Handshake_State* active_state,
-                                    Server_Handshake_State& pending_state,
+      void process_client_hello_msg(Server_Handshake_State& pending_state,
                                     const std::vector<uint8_t>& contents,
                                     bool epoch0_restart);
 

--- a/src/lib/tls/tls13/info.txt
+++ b/src/lib/tls/tls13/info.txt
@@ -16,6 +16,7 @@ tls_psk_identity_13.h
 
 <header:internal>
 tls_channel_impl_13.h
+tls_connection_state_13.h
 tls_cipher_state.h
 tls_client_impl_13.h
 tls_handshake_layer_13.h

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -417,6 +417,7 @@ void Channel_Impl_13::shutdown() {
    m_can_read = false;
    m_can_write = false;
    m_cipher_state.reset();
+   m_active_state.reset();
 }
 
 void Channel_Impl_13::expect_downgrade(const Server_Information& server_info,

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -13,6 +13,7 @@
 #include <botan/tls_messages_13.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tls_channel_impl.h>
+#include <botan/internal/tls_connection_state_13.h>
 #include <botan/internal/tls_handshake_layer_13.h>
 #include <botan/internal/tls_record_layer_13.h>
 #include <botan/internal/tls_transcript_hash_13.h>
@@ -285,9 +286,10 @@ class Channel_Impl_13 : public Channel_Impl,
       void shutdown();
 
    protected:
-      const Connection_Side m_side;                  // NOLINT(*non-private-member-variable*)
-      Transcript_Hash_State m_transcript_hash;       // NOLINT(*non-private-member-variable*)
-      std::unique_ptr<Cipher_State> m_cipher_state;  // NOLINT(*non-private-member-variable*)
+      const Connection_Side m_side;                              // NOLINT(*non-private-member-variable*)
+      Transcript_Hash_State m_transcript_hash;                   // NOLINT(*non-private-member-variable*)
+      std::unique_ptr<Cipher_State> m_cipher_state;              // NOLINT(*non-private-member-variable*)
+      std::optional<Active_Connection_State_13> m_active_state;  // NOLINT(*non-private-member-variable*)
 
       /**
        * Indicate that we have to expect a downgrade to TLS 1.2. In which case the current

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -32,7 +32,7 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
                                const std::vector<std::string>& next_protocols) :
       Channel_Impl_13(callbacks, session_manager, creds, rng, policy, false /* is_server */),
       m_info(std::move(info)),
-      m_should_send_ccs(false) {
+      m_handshake(std::make_unique<Pending_Handshake>()) {
 #if defined(BOTAN_HAS_TLS_12)
    if(policy->allow_tls12()) {
       expect_downgrade(m_info, next_protocols);
@@ -41,7 +41,7 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
 
    if(auto session = find_session_for_resumption()) {
       if(!session->session.version().is_pre_tls_13()) {
-         m_resumed_session = std::move(session);
+         m_handshake->resumed_session = std::move(session);
       } else if(expects_downgrade()) {
          // If we found a session that was created with TLS 1.2, we downgrade
          // the implementation right away, before even issuing a Client Hello.
@@ -50,13 +50,13 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
       }
    }
 
-   auto msg = send_handshake_message(m_handshake_state.sending(
+   auto msg = send_handshake_message(m_handshake->state.sending(
       Client_Hello_13(*policy,
                       *callbacks,
                       *rng,
                       m_info.hostname(),
                       next_protocols,
-                      m_resumed_session,
+                      m_handshake->resumed_session,
                       creds->find_preshared_keys(m_info.hostname(), Connection_Side::Client))));
 
    if(expects_downgrade()) {
@@ -70,17 +70,19 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
    //
    // TODO: don't schedule ccs here when early data is used
    if(policy->tls_13_middlebox_compatibility_mode()) {
-      m_should_send_ccs = true;
+      m_handshake->should_send_ccs = true;
    }
 
-   m_transitions.set_expected_next({Handshake_Type::ServerHello, Handshake_Type::HelloRetryRequest});
+   m_handshake->transitions.set_expected_next({Handshake_Type::ServerHello, Handshake_Type::HelloRetryRequest});
 }
 
 void Client_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
+   BOTAN_STATE_CHECK(m_handshake != nullptr);
+
    std::visit(
       [&](auto msg) {
          // first verify that the message was expected by the state machine...
-         m_transitions.confirm_transition_to(msg.get().type());
+         m_handshake->transitions.confirm_transition_to(msg.get().type());
 
          // ... then allow the library user to abort on their discretion
          callbacks().tls_inspect_handshake_msg(msg.get());
@@ -88,13 +90,21 @@ void Client_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
          // ... finally handle the message
          handle(msg.get());
       },
-      m_handshake_state.received(std::move(message)));
+      m_handshake->state.received(std::move(message)));
 }
 
 void Client_Impl_13::process_post_handshake_msg(Post_Handshake_Message_13 message) {
    BOTAN_STATE_CHECK(is_handshake_complete());
 
-   std::visit([&](auto msg) { handle(msg); }, m_handshake_state.received(std::move(message)));
+   std::visit(
+      [&](auto msg) {
+         if constexpr(std::is_constructible_v<Server_Post_Handshake_13_Message, decltype(msg)>) {
+            handle(msg);
+         } else {
+            throw TLS_Exception(Alert::UnexpectedMessage, "received an unexpected post-handshake message");
+         }
+      },
+      std::move(message));
 }
 
 void Client_Impl_13::process_dummy_change_cipher_spec() {
@@ -102,7 +112,7 @@ void Client_Impl_13::process_dummy_change_cipher_spec() {
    //    If an implementation detects a change_cipher_spec record received before
    //    the first ClientHello message or after the peer's Finished message, it MUST be
    //    treated as an unexpected record type [("unexpected_message" alert)].
-   if(!m_handshake_state.has_client_hello() || m_handshake_state.has_server_finished()) {
+   if(!m_handshake || !m_handshake->state.has_client_hello() || m_handshake->state.has_server_finished()) {
       throw TLS_Exception(Alert::UnexpectedMessage, "Received an unexpected dummy Change Cipher Spec");
    }
 
@@ -116,7 +126,7 @@ void Client_Impl_13::process_dummy_change_cipher_spec() {
 }
 
 bool Client_Impl_13::is_handshake_complete() const {
-   return m_handshake_state.handshake_finished();
+   return m_active_state.has_value();
 }
 
 std::optional<Session_with_Handle> Client_Impl_13::find_session_for_resumption() {
@@ -149,7 +159,9 @@ std::optional<Session_with_Handle> Client_Impl_13::find_session_for_resumption()
 }
 
 void Client_Impl_13::handle(const Server_Hello_12_Shim& server_hello_msg) {
-   if(m_handshake_state.has_hello_retry_request()) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
+   if(m_handshake->state.has_hello_retry_request()) {
       throw TLS_Exception(Alert::UnexpectedMessage, "Version downgrade received after Hello Retry");
    }
 
@@ -189,14 +201,14 @@ void Client_Impl_13::handle(const Server_Hello_12_Shim& server_hello_msg) {
    //    If the version chosen by the server is not supported by the client
    //    (or is not acceptable), the client MUST abort the handshake with a
    //    "protocol_version" alert.
-   const auto& client_hello_exts = m_handshake_state.client_hello().extensions();
+   const auto& client_hello_exts = m_handshake->state.client_hello().extensions();
    BOTAN_ASSERT_NOMSG(client_hello_exts.has<Supported_Versions>());
    if(!client_hello_exts.get<Supported_Versions>()->supports(server_hello_msg.selected_version())) {
       throw TLS_Exception(Alert::ProtocolVersion, "Protocol version was not offered");
    }
 
    if(policy().tls_13_middlebox_compatibility_mode() &&
-      m_handshake_state.client_hello().session_id() == server_hello_msg.session_id()) {
+      m_handshake->state.client_hello().session_id() == server_hello_msg.session_id()) {
       // In compatibility mode, the server will reflect the session ID we sent in the client hello.
       // However, a TLS 1.2 server that wants to downgrade cannot have found the random session ID
       // we sent. Therefore, we have to consider this as an attack.
@@ -208,7 +220,7 @@ void Client_Impl_13::handle(const Server_Hello_12_Shim& server_hello_msg) {
 
    // After this, no further messages are expected here because this instance will be replaced
    // by a Client_Impl_12.
-   m_transitions.set_expected_next({});
+   m_handshake->transitions.set_expected_next({});
 }
 
 namespace {
@@ -244,8 +256,9 @@ void validate_server_hello_ish(const Client_Hello_13& ch, const Server_Hello_13&
 void Client_Impl_13::handle(const Server_Hello_13& sh) {
    // Note: Basic checks (that do not require contextual information) were already
    //       performed during the construction of the Server_Hello_13 object.
+   BOTAN_ASSERT_NONNULL(m_handshake);
 
-   const auto& ch = m_handshake_state.client_hello();
+   const auto& ch = m_handshake->state.client_hello();
 
    validate_server_hello_ish(ch, sh);
 
@@ -268,8 +281,8 @@ void Client_Impl_13::handle(const Server_Hello_13& sh) {
       throw TLS_Exception(Alert::UnsupportedExtension, "Unsupported extension found in Server Hello");
    }
 
-   if(m_handshake_state.has_hello_retry_request()) {
-      const auto& hrr = m_handshake_state.hello_retry_request();
+   if(m_handshake->state.has_hello_retry_request()) {
+      const auto& hrr = m_handshake->state.hello_retry_request();
 
       // RFC 8446 4.1.4
       //    Upon receiving the ServerHello, clients MUST check that the cipher suite
@@ -320,14 +333,14 @@ void Client_Impl_13::handle(const Server_Hello_13& sh) {
    m_transcript_hash.set_algorithm(cipher.value().prf_algo());
 
    if(sh.extensions().has<PSK>()) {
-      std::tie(m_psk_identity, m_cipher_state) =
+      std::tie(m_handshake->psk_identity, m_cipher_state) =
          ch.extensions().get<PSK>()->take_selected_psk_info(*sh.extensions().get<PSK>(), cipher.value());
 
       // If we offered a session for resumption *and* an externally provided PSK
       // and the latter was chosen by the server over the offered resumption, we
-      // want to invalidate the now-outdated session in m_resumed_session.
-      if(m_psk_identity.has_value() && m_resumed_session.has_value()) {
-         m_resumed_session.reset();
+      // want to invalidate the now-outdated session in m_handshake->resumed_session.
+      if(m_handshake->psk_identity.has_value() && m_handshake->resumed_session.has_value()) {
+         m_handshake->resumed_session.reset();
       }
 
       // TODO: When implementing early data, `advance_with_client_hello` must
@@ -337,22 +350,23 @@ void Client_Impl_13::handle(const Server_Hello_13& sh) {
       m_cipher_state->advance_with_server_hello(
          cipher.value(), std::move(shared_secret), m_transcript_hash.current(), *this);
    } else {
-      m_resumed_session.reset();  // might have been set if we attempted a resumption
+      m_handshake->resumed_session.reset();  // might have been set if we attempted a resumption
       m_cipher_state = Cipher_State::init_with_server_hello(
          m_side, std::move(shared_secret), cipher.value(), m_transcript_hash.current(), *this);
    }
 
    callbacks().tls_examine_extensions(sh.extensions(), Connection_Side::Server, Handshake_Type::ServerHello);
 
-   m_transitions.set_expected_next(Handshake_Type::EncryptedExtensions);
+   m_handshake->transitions.set_expected_next(Handshake_Type::EncryptedExtensions);
 }
 
 void Client_Impl_13::handle(const Hello_Retry_Request& hrr) {
    // Note: Basic checks (that do not require contextual information) were already
    //       performed during the construction of the Hello_Retry_Request object as
    //       a subclass of Server_Hello_13.
+   BOTAN_ASSERT_NONNULL(m_handshake);
 
-   auto& ch = m_handshake_state.client_hello();
+   auto& ch = m_handshake->state.client_hello();
 
    validate_server_hello_ish(ch, hrr);
 
@@ -388,10 +402,12 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr) {
    // RFC 8446 4.1.4
    //    If a client receives a second HelloRetryRequest in the same connection [...],
    //    it MUST abort the handshake with an "unexpected_message" alert.
-   m_transitions.set_expected_next(Handshake_Type::ServerHello);
+   m_handshake->transitions.set_expected_next(Handshake_Type::ServerHello);
 }
 
 void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    const auto& exts = encrypted_extensions_msg.extensions();
 
    // RFC 8446 4.2
@@ -399,7 +415,7 @@ void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg
    //    endpoint did not send the corresponding extension requests, [...]. Upon
    //    receiving such an extension, an endpoint MUST abort the handshake
    //    with an "unsupported_extension" alert.
-   const auto& requested_exts = m_handshake_state.client_hello().extensions().extension_types();
+   const auto& requested_exts = m_handshake->state.client_hello().extensions().extension_types();
    if(exts.contains_other_than(requested_exts)) {
       throw TLS_Exception(Alert::UnsupportedExtension,
                           "Encrypted Extensions contained an extension that was not offered");
@@ -416,7 +432,7 @@ void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg
       const auto* server_alpn = exts.get<Application_Layer_Protocol_Notification>();
       const auto selected = server_alpn->single_protocol();
       const auto* client_alpn =
-         m_handshake_state.client_hello().extensions().get<Application_Layer_Protocol_Notification>();
+         m_handshake->state.client_hello().extensions().get<Application_Layer_Protocol_Notification>();
       BOTAN_ASSERT_NONNULL(client_alpn);  // unrequested extension check above ensures this
       const auto& offered = client_alpn->protocols();
       if(!value_exists(offered, selected)) {
@@ -424,7 +440,7 @@ void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg
       }
    }
 
-   if(exts.has<Record_Size_Limit>() && m_handshake_state.client_hello().extensions().has<Record_Size_Limit>()) {
+   if(exts.has<Record_Size_Limit>() && m_handshake->state.client_hello().extensions().has<Record_Size_Limit>()) {
       // RFC 8449 4.
       //     The record size limit only applies to records sent toward the
       //     endpoint that advertises the limit.  An endpoint can send records
@@ -433,15 +449,15 @@ void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg
       // Hence, the "outgoing" limit is what the server requested and the
       // "incoming" limit is what we requested in the Client Hello.
       auto* const outgoing_limit = exts.get<Record_Size_Limit>();
-      auto* const incoming_limit = m_handshake_state.client_hello().extensions().get<Record_Size_Limit>();
+      auto* const incoming_limit = m_handshake->state.client_hello().extensions().get<Record_Size_Limit>();
       set_record_size_limits(outgoing_limit->limit(), incoming_limit->limit());
    }
 
    if(exts.has<Server_Certificate_Type>()) {
       // The unrequested-extension check above ensures the client offered this.
-      BOTAN_ASSERT_NOMSG(m_handshake_state.client_hello().extensions().has<Server_Certificate_Type>());
+      BOTAN_ASSERT_NOMSG(m_handshake->state.client_hello().extensions().has<Server_Certificate_Type>());
       const auto* server_cert_type = exts.get<Server_Certificate_Type>();
-      const auto* our_server_cert_types = m_handshake_state.client_hello().extensions().get<Server_Certificate_Type>();
+      const auto* our_server_cert_types = m_handshake->state.client_hello().extensions().get<Server_Certificate_Type>();
       our_server_cert_types->validate_selection(*server_cert_type);
 
       // RFC 7250 4.2
@@ -456,17 +472,19 @@ void Client_Impl_13::handle(const Encrypted_Extensions& encrypted_extensions_msg
 
    callbacks().tls_examine_extensions(exts, Connection_Side::Server, Handshake_Type::EncryptedExtensions);
 
-   if(m_handshake_state.server_hello().extensions().has<PSK>()) {
+   if(m_handshake->state.server_hello().extensions().has<PSK>()) {
       // RFC 8446 2.2
       //    As the server is authenticating via a PSK, it does not send a
       //    Certificate or a CertificateVerify message.
-      m_transitions.set_expected_next(Handshake_Type::Finished);
+      m_handshake->transitions.set_expected_next(Handshake_Type::Finished);
    } else {
-      m_transitions.set_expected_next({Handshake_Type::Certificate, Handshake_Type::CertificateRequest});
+      m_handshake->transitions.set_expected_next({Handshake_Type::Certificate, Handshake_Type::CertificateRequest});
    }
 }
 
 void Client_Impl_13::handle(const Certificate_Request_13& certificate_request_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.3.2
    //    [The 'context' field] SHALL be zero length unless used for the
    //    post-handshake authentication exchanges described in Section 4.6.2.
@@ -476,10 +494,12 @@ void Client_Impl_13::handle(const Certificate_Request_13& certificate_request_ms
 
    callbacks().tls_examine_extensions(
       certificate_request_msg.extensions(), Connection_Side::Server, Handshake_Type::CertificateRequest);
-   m_transitions.set_expected_next(Handshake_Type::Certificate);
+   m_handshake->transitions.set_expected_next(Handshake_Type::Certificate);
 }
 
 void Client_Impl_13::handle(const Certificate_13& certificate_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.4.2
    //    certificate_request_context:  [...] In the case of server authentication,
    //    this field SHALL be zero length.
@@ -490,17 +510,19 @@ void Client_Impl_13::handle(const Certificate_13& certificate_msg) {
    // RFC 8446 4.4.2
    //    Extensions in the Certificate message from the server MUST correspond
    //    to ones from the ClientHello message.
-   certificate_msg.validate_extensions(m_handshake_state.client_hello().extensions().extension_types(), callbacks());
+   certificate_msg.validate_extensions(m_handshake->state.client_hello().extensions().extension_types(), callbacks());
    certificate_msg.verify(callbacks(),
                           policy(),
                           credentials_manager(),
                           m_info.hostname(),
-                          m_handshake_state.client_hello().extensions().has<Certificate_Status_Request>());
+                          m_handshake->state.client_hello().extensions().has<Certificate_Status_Request>());
 
-   m_transitions.set_expected_next(Handshake_Type::CertificateVerify);
+   m_handshake->transitions.set_expected_next(Handshake_Type::CertificateVerify);
 }
 
 void Client_Impl_13::handle(const Certificate_Verify_13& certificate_verify_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.4.3
    //    If the CertificateVerify message is sent by a server, the signature
    //    algorithm MUST be one offered in the client's "signature_algorithms"
@@ -509,7 +531,7 @@ void Client_Impl_13::handle(const Certificate_Verify_13& certificate_verify_msg)
    //
    // Note: if the server failed to produce a certificate chain without using
    //       an unsupported signature scheme, we opt to abort the handshake.
-   const auto offered = m_handshake_state.client_hello().signature_schemes();
+   const auto offered = m_handshake->state.client_hello().signature_schemes();
    if(!value_exists(offered, certificate_verify_msg.signature_scheme())) {
       throw TLS_Exception(Alert::IllegalParameter,
                           "We did not offer the usage of " + certificate_verify_msg.signature_scheme().to_string() +
@@ -517,22 +539,22 @@ void Client_Impl_13::handle(const Certificate_Verify_13& certificate_verify_msg)
    }
 
    const bool sig_valid = certificate_verify_msg.verify(
-      *m_handshake_state.server_certificate().public_key(), callbacks(), m_transcript_hash.previous());
+      *m_handshake->state.server_certificate().public_key(), callbacks(), m_transcript_hash.previous());
 
    if(!sig_valid) {
       throw TLS_Exception(Alert::DecryptError, "Server certificate verification failed");
    }
 
-   m_transitions.set_expected_next(Handshake_Type::Finished);
+   m_handshake->transitions.set_expected_next(Handshake_Type::Finished);
 }
 
 void Client_Impl_13::send_client_authentication(Channel_Impl_13::AggregatedHandshakeMessages& flight) {
-   BOTAN_ASSERT_NOMSG(m_handshake_state.has_certificate_request());
-   const auto& cert_request = m_handshake_state.certificate_request();
+   BOTAN_ASSERT_NOMSG(m_handshake->state.has_certificate_request());
+   const auto& cert_request = m_handshake->state.certificate_request();
 
    const auto cert_type = [&] {
-      const auto& exts = m_handshake_state.encrypted_extensions().extensions();
-      const auto& chexts = m_handshake_state.client_hello().extensions();
+      const auto& exts = m_handshake->state.encrypted_extensions().extensions();
+      const auto& chexts = m_handshake->state.client_hello().extensions();
       if(exts.has<Client_Certificate_Type>()) {
          // The unrequested-extension check in handle(Encrypted_Extensions) ensures the client offered this.
          BOTAN_ASSERT_NOMSG(chexts.has<Client_Certificate_Type>());
@@ -560,7 +582,7 @@ void Client_Impl_13::send_client_authentication(Channel_Impl_13::AggregatedHands
    //    certificate_request_context:  If this message is in response to a
    //       CertificateRequest, the value of certificate_request_context in
    //       that message.
-   flight.add(m_handshake_state.sending(
+   flight.add(m_handshake->state.sending(
       Certificate_13(cert_request, m_info.hostname(), credentials_manager(), callbacks(), cert_type)));
 
    // RFC 8446 4.4.2
@@ -569,20 +591,22 @@ void Client_Impl_13::send_client_authentication(Channel_Impl_13::AggregatedHands
    //    certificates.
    //
    // In that case, no Certificate Verify message will be sent.
-   if(!m_handshake_state.client_certificate().empty()) {
-      flight.add(m_handshake_state.sending(Certificate_Verify_13(m_handshake_state.client_certificate(),
-                                                                 cert_request.signature_schemes(),
-                                                                 m_info.hostname(),
-                                                                 m_transcript_hash.current(),
-                                                                 Connection_Side::Client,
-                                                                 credentials_manager(),
-                                                                 policy(),
-                                                                 callbacks(),
-                                                                 rng())));
+   if(!m_handshake->state.client_certificate().empty()) {
+      flight.add(m_handshake->state.sending(Certificate_Verify_13(m_handshake->state.client_certificate(),
+                                                                  cert_request.signature_schemes(),
+                                                                  m_info.hostname(),
+                                                                  m_transcript_hash.current(),
+                                                                  Connection_Side::Client,
+                                                                  credentials_manager(),
+                                                                  policy(),
+                                                                  callbacks(),
+                                                                  rng())));
    }
 }
 
 void Client_Impl_13::handle(const Finished_13& finished_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.4.4
    //    Recipients of Finished messages MUST verify that the contents are
    //    correct and if incorrect MUST terminate the connection with a
@@ -591,16 +615,16 @@ void Client_Impl_13::handle(const Finished_13& finished_msg) {
       throw TLS_Exception(Alert::DecryptError, "Finished message didn't verify");
    }
 
-   m_handshake_state.confirm_peer_finished_verified();
+   m_handshake->state.confirm_peer_finished_verified();
 
    // Give the application a chance for a final veto before fully
    // establishing the connection.
-   callbacks().tls_session_established(Session_Summary(m_handshake_state.server_hello(),
+   callbacks().tls_session_established(Session_Summary(m_handshake->state.server_hello(),
                                                        Connection_Side::Client,
                                                        peer_cert_chain(),
                                                        peer_raw_public_key(),
                                                        external_psk_identity(),
-                                                       m_resumed_session.has_value(),
+                                                       m_handshake->resumed_session.has_value(),
                                                        m_info,
                                                        callbacks().tls_current_timestamp()));
 
@@ -613,12 +637,12 @@ void Client_Impl_13::handle(const Finished_13& finished_msg) {
    // RFC 8446 4.4.2
    //    The client MUST send a Certificate message if and only if the server
    //    has requested client authentication via a CertificateRequest message.
-   if(m_handshake_state.has_certificate_request()) {
+   if(m_handshake->state.has_certificate_request()) {
       send_client_authentication(flight);
    }
 
    // send client finished handshake message (still using handshake traffic secrets)
-   flight.add(m_handshake_state.sending(Finished_13(m_cipher_state.get(), m_transcript_hash.current())));
+   flight.add(m_handshake->state.sending(Finished_13(m_cipher_state.get(), m_transcript_hash.current())));
 
    flight.send();
 
@@ -630,12 +654,50 @@ void Client_Impl_13::handle(const Finished_13& finished_msg) {
    //       callback's doc string.
 
    // no more handshake messages expected
-   m_transitions.set_expected_next({});
+   m_handshake->transitions.set_expected_next({});
 
+   // Extract post-handshake state before signaling activation.
+   // After this point, only m_active_state should be consulted
+   // for connection properties.
+   {
+      auto extract_certs = [&]() -> std::vector<X509_Certificate> {
+         if(m_handshake->state.has_server_certificate_msg() &&
+            m_handshake->state.server_certificate().has_certificate_chain()) {
+            return m_handshake->state.server_certificate().cert_chain();
+         }
+         if(m_handshake->resumed_session.has_value()) {
+            return m_handshake->resumed_session->session.peer_certs();
+         }
+         return {};
+      };
+
+      auto extract_raw_pk = [&]() -> std::shared_ptr<const Public_Key> {
+         if(m_handshake->state.has_server_certificate_msg() &&
+            m_handshake->state.server_certificate().is_raw_public_key()) {
+            return m_handshake->state.server_certificate().public_key();
+         }
+         if(m_handshake->resumed_session.has_value()) {
+            return m_handshake->resumed_session->session.peer_raw_public_key();
+         }
+         return nullptr;
+      };
+
+      m_active_state = Active_Connection_State_13(m_handshake->state,
+                                                  extract_certs(),
+                                                  extract_raw_pk(),
+                                                  m_handshake->psk_identity,
+                                                  m_info.hostname(),
+                                                  false /* peer_supports_psk_dhe_ke - client doesn't need this */);
+   }
+
+   m_handshake.reset();
+   m_transcript_hash = Transcript_Hash_State();
    callbacks().tls_session_activated();
 }
 
 void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket) {
+   BOTAN_STATE_CHECK(m_active_state.has_value());
+
    if(const size_t max_tickets = policy().maximum_session_tickets_per_connection();
       max_tickets > 0 && m_session_tickets_received >= max_tickets) {
       // Silently ignore excess tickets rather than terminating the connection,
@@ -651,8 +713,8 @@ void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket
                          new_session_ticket.early_data_byte_limit(),
                          new_session_ticket.ticket_age_add(),
                          new_session_ticket.lifetime_hint(),
-                         m_handshake_state.server_hello().selected_version(),
-                         m_handshake_state.server_hello().ciphersuite(),
+                         m_active_state->version(),
+                         m_active_state->ciphersuite_code(),
                          Connection_Side::Client,
                          peer_cert_chain(),
                          peer_raw_public_key(),
@@ -665,50 +727,72 @@ void TLS::Client_Impl_13::handle(const New_Session_Ticket_13& new_session_ticket
 }
 
 std::vector<X509_Certificate> Client_Impl_13::peer_cert_chain() const {
-   if(m_handshake_state.has_server_certificate_msg() &&
-      m_handshake_state.server_certificate().has_certificate_chain()) {
-      return m_handshake_state.server_certificate().cert_chain();
+   if(m_active_state.has_value()) {
+      return m_active_state->peer_certs();
    }
 
-   if(m_resumed_session.has_value()) {
-      return m_resumed_session->session.peer_certs();
+   // During handshake, before m_active_state is populated
+   if(m_handshake) {
+      if(m_handshake->state.has_server_certificate_msg() &&
+         m_handshake->state.server_certificate().has_certificate_chain()) {
+         return m_handshake->state.server_certificate().cert_chain();
+      }
+
+      if(m_handshake->resumed_session.has_value()) {
+         return m_handshake->resumed_session->session.peer_certs();
+      }
    }
 
    return {};
 }
 
 std::shared_ptr<const Public_Key> Client_Impl_13::peer_raw_public_key() const {
-   if(m_handshake_state.has_server_certificate_msg() && m_handshake_state.server_certificate().is_raw_public_key()) {
-      return m_handshake_state.server_certificate().public_key();
+   if(m_active_state.has_value()) {
+      return m_active_state->peer_raw_public_key();
    }
 
-   if(m_resumed_session.has_value()) {
-      return m_resumed_session->session.peer_raw_public_key();
+   // During handshake, before m_active_state is populated
+   if(m_handshake) {
+      if(m_handshake->state.has_server_certificate_msg() &&
+         m_handshake->state.server_certificate().is_raw_public_key()) {
+         return m_handshake->state.server_certificate().public_key();
+      }
+
+      if(m_handshake->resumed_session.has_value()) {
+         return m_handshake->resumed_session->session.peer_raw_public_key();
+      }
    }
 
    return nullptr;
 }
 
 std::optional<std::string> Client_Impl_13::external_psk_identity() const {
-   return m_psk_identity;
+   if(m_active_state.has_value()) {
+      return m_active_state->psk_identity();
+   }
+   if(m_handshake) {
+      return m_handshake->psk_identity;
+   }
+   return std::nullopt;
 }
 
 bool Client_Impl_13::prepend_ccs() {
-   return std::exchange(m_should_send_ccs, false);  // test-and-set
+   return m_handshake && std::exchange(m_handshake->should_send_ccs, false);
 }
 
 void Client_Impl_13::maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const {
    if(policy().allow_ssl_key_log_file()) {
-      callbacks().tls_ssl_key_log_data(label, m_handshake_state.client_hello().random(), secret);
+      if(m_active_state.has_value()) {
+         callbacks().tls_ssl_key_log_data(label, m_active_state->client_random(), secret);
+      } else {
+         callbacks().tls_ssl_key_log_data(label, m_handshake->state.client_hello().random(), secret);
+      }
    }
 }
 
 std::string Client_Impl_13::application_protocol() const {
-   if(is_handshake_complete()) {
-      const auto& eee = m_handshake_state.encrypted_extensions().extensions();
-      if(eee.has<Application_Layer_Protocol_Notification>()) {
-         return eee.get<Application_Layer_Protocol_Notification>()->single_protocol();
-      }
+   if(m_active_state.has_value()) {
+      return m_active_state->application_protocol();
    }
 
    return "";

--- a/src/lib/tls/tls13/tls_client_impl_13.h
+++ b/src/lib/tls/tls13/tls_client_impl_13.h
@@ -104,14 +104,15 @@ class Client_Impl_13 : public Channel_Impl_13 {
    private:
       const Server_Information m_info;
 
-      Client_Handshake_State_13 m_handshake_state;
-      Handshake_Transitions m_transitions;
+      struct Pending_Handshake {
+            Client_Handshake_State_13 state;
+            Handshake_Transitions transitions;
+            bool should_send_ccs = false;
+            std::optional<Session_with_Handle> resumed_session;
+            std::optional<std::string> psk_identity;
+      };
 
-      bool m_should_send_ccs;
-
-      std::optional<Session_with_Handle> m_resumed_session;
-      std::optional<std::string> m_psk_identity;
-
+      std::unique_ptr<Pending_Handshake> m_handshake;
       size_t m_session_tickets_received = 0;
 };
 

--- a/src/lib/tls/tls13/tls_connection_state_13.cpp
+++ b/src/lib/tls/tls13/tls_connection_state_13.cpp
@@ -1,0 +1,46 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/tls_connection_state_13.h>
+
+#include <botan/tls_extensions.h>
+#include <botan/internal/tls_handshake_state_13.h>
+
+namespace Botan::TLS {
+
+namespace {
+
+std::string extract_alpn(const Internal::Handshake_State_13_Base& state) {
+   const auto& eee = state.encrypted_extensions().extensions();
+   if(const auto* alpn = eee.get<Application_Layer_Protocol_Notification>()) {
+      return alpn->single_protocol();
+   }
+   return {};
+}
+
+}  // namespace
+
+Active_Connection_State_13::~Active_Connection_State_13() = default;
+Active_Connection_State_13::Active_Connection_State_13(Active_Connection_State_13&&) noexcept = default;
+Active_Connection_State_13& Active_Connection_State_13::operator=(Active_Connection_State_13&&) noexcept = default;
+
+Active_Connection_State_13::Active_Connection_State_13(const Internal::Handshake_State_13_Base& state,
+                                                       std::vector<X509_Certificate> peer_certs,
+                                                       std::shared_ptr<const Public_Key> peer_raw_public_key,
+                                                       std::optional<std::string> psk_identity,
+                                                       std::string sni_hostname,
+                                                       bool peer_supports_psk_dhe_ke) :
+      m_version(state.server_hello().selected_version()),
+      m_ciphersuite_code(state.server_hello().ciphersuite()),
+      m_application_protocol(extract_alpn(state)),
+      m_peer_certs(std::move(peer_certs)),
+      m_client_random(state.client_hello().random()),
+      m_psk_identity(std::move(psk_identity)),
+      m_peer_raw_public_key(std::move(peer_raw_public_key)),
+      m_sni_hostname(std::move(sni_hostname)),
+      m_peer_supports_psk_dhe_ke(peer_supports_psk_dhe_ke) {}
+
+}  // namespace Botan::TLS

--- a/src/lib/tls/tls13/tls_connection_state_13.h
+++ b/src/lib/tls/tls13/tls_connection_state_13.h
@@ -1,0 +1,82 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_TLS_CONNECTION_STATE_13_H_
+#define BOTAN_TLS_CONNECTION_STATE_13_H_
+
+#include <botan/tls_version.h>
+#include <botan/x509cert.h>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace Botan {
+
+class Public_Key;
+
+}  // namespace Botan
+
+namespace Botan::TLS {
+
+namespace Internal {
+class Handshake_State_13_Base;
+}
+
+/**
+* Captures the state of a completed TLS 1.3 handshake that is needed
+* for the lifetime of an active connection.
+*/
+class Active_Connection_State_13 final {
+   public:
+      Active_Connection_State_13(const Internal::Handshake_State_13_Base& state,
+                                 std::vector<X509_Certificate> peer_certs,
+                                 std::shared_ptr<const Public_Key> peer_raw_public_key,
+                                 std::optional<std::string> psk_identity,
+                                 std::string sni_hostname,
+                                 bool peer_supports_psk_dhe_ke);
+
+      ~Active_Connection_State_13();
+      Active_Connection_State_13(Active_Connection_State_13&&) noexcept;
+      Active_Connection_State_13& operator=(Active_Connection_State_13&&) noexcept;
+
+      Active_Connection_State_13(const Active_Connection_State_13&) = delete;
+      Active_Connection_State_13& operator=(const Active_Connection_State_13&) = delete;
+
+      Protocol_Version version() const { return m_version; }
+
+      uint16_t ciphersuite_code() const { return m_ciphersuite_code; }
+
+      const std::string& application_protocol() const { return m_application_protocol; }
+
+      const std::vector<X509_Certificate>& peer_certs() const { return m_peer_certs; }
+
+      const std::vector<uint8_t>& client_random() const { return m_client_random; }
+
+      const std::optional<std::string>& psk_identity() const { return m_psk_identity; }
+
+      const std::shared_ptr<const Public_Key>& peer_raw_public_key() const { return m_peer_raw_public_key; }
+
+      const std::string& sni_hostname() const { return m_sni_hostname; }
+
+      bool peer_supports_psk_dhe_ke() const { return m_peer_supports_psk_dhe_ke; }
+
+   private:
+      Protocol_Version m_version;
+      uint16_t m_ciphersuite_code = 0;
+      std::string m_application_protocol;
+      std::vector<X509_Certificate> m_peer_certs;
+      std::vector<uint8_t> m_client_random;
+      std::optional<std::string> m_psk_identity;
+      std::shared_ptr<const Public_Key> m_peer_raw_public_key;
+      std::string m_sni_hostname;
+      bool m_peer_supports_psk_dhe_ke = false;
+};
+
+}  // namespace Botan::TLS
+
+#endif

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -14,6 +14,7 @@
 #include <botan/tls_extensions_13.h>
 #include <botan/tls_policy.h>
 #include <botan/x509cert.h>
+#include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>
 #include <botan/internal/tls_cipher_state.h>
 
@@ -24,54 +25,71 @@ Server_Impl_13::Server_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
                                const std::shared_ptr<Credentials_Manager>& credentials_manager,
                                const std::shared_ptr<const Policy>& policy,
                                const std::shared_ptr<RandomNumberGenerator>& rng) :
-      Channel_Impl_13(callbacks, session_manager, credentials_manager, rng, policy, true /* is_server */) {
+      Channel_Impl_13(callbacks, session_manager, credentials_manager, rng, policy, true /* is_server */),
+      m_handshake(std::make_unique<Pending_Handshake>()) {
 #if defined(BOTAN_HAS_TLS_12)
    if(policy->allow_tls12()) {
       expect_downgrade({}, {});
    }
 #endif
 
-   m_transitions.set_expected_next(Handshake_Type::ClientHello);
+   m_handshake->transitions.set_expected_next(Handshake_Type::ClientHello);
 }
 
 std::string Server_Impl_13::application_protocol() const {
-   if(is_handshake_complete()) {
-      const auto& eee = m_handshake_state.encrypted_extensions().extensions();
-      if(auto* const alpn = eee.get<Application_Layer_Protocol_Notification>()) {
-         return alpn->single_protocol();
-      }
+   if(m_active_state.has_value()) {
+      return m_active_state->application_protocol();
    }
 
    return "";
 }
 
 std::vector<X509_Certificate> Server_Impl_13::peer_cert_chain() const {
-   if(m_handshake_state.has_client_certificate_msg() &&
-      m_handshake_state.client_certificate().has_certificate_chain()) {
-      return m_handshake_state.client_certificate().cert_chain();
+   if(m_active_state.has_value()) {
+      return m_active_state->peer_certs();
    }
 
-   if(m_resumed_session.has_value()) {
-      return m_resumed_session->peer_certs();
+   if(m_handshake) {
+      if(m_handshake->state.has_client_certificate_msg() &&
+         m_handshake->state.client_certificate().has_certificate_chain()) {
+         return m_handshake->state.client_certificate().cert_chain();
+      }
+
+      if(m_handshake->resumed_session.has_value()) {
+         return m_handshake->resumed_session->peer_certs();
+      }
    }
 
    return {};
 }
 
 std::shared_ptr<const Public_Key> Server_Impl_13::peer_raw_public_key() const {
-   if(m_handshake_state.has_client_certificate_msg() && m_handshake_state.client_certificate().is_raw_public_key()) {
-      return m_handshake_state.client_certificate().public_key();
+   if(m_active_state.has_value()) {
+      return m_active_state->peer_raw_public_key();
    }
 
-   if(m_resumed_session.has_value()) {
-      return m_resumed_session->peer_raw_public_key();
+   if(m_handshake) {
+      if(m_handshake->state.has_client_certificate_msg() &&
+         m_handshake->state.client_certificate().is_raw_public_key()) {
+         return m_handshake->state.client_certificate().public_key();
+      }
+
+      if(m_handshake->resumed_session.has_value()) {
+         return m_handshake->resumed_session->peer_raw_public_key();
+      }
    }
 
    return nullptr;
 }
 
 std::optional<std::string> Server_Impl_13::external_psk_identity() const {
-   return m_psk_identity;
+   if(m_active_state.has_value()) {
+      return m_active_state->psk_identity();
+   } else if(m_handshake) {
+      return m_handshake->psk_identity;
+   } else {
+      return std::nullopt;
+   }
 }
 
 bool Server_Impl_13::new_session_ticket_supported() const {
@@ -85,9 +103,7 @@ bool Server_Impl_13::new_session_ticket_supported() const {
    //       regardless of this method indicating no support for tickets.
    //
    // TODO: Implement other PSK KE modes than PSK_DHE_KE
-   return is_handshake_complete() && m_handshake_state.client_hello().extensions().has<PSK_Key_Exchange_Modes>() &&
-          value_exists(m_handshake_state.client_hello().extensions().get<PSK_Key_Exchange_Modes>()->modes(),
-                       PSK_Key_Exchange_Mode::PSK_DHE_KE);
+   return is_handshake_complete() && m_active_state.has_value() && m_active_state->peer_supports_psk_dhe_ke();
 }
 
 size_t Server_Impl_13::send_new_session_tickets(const size_t tickets) {
@@ -100,17 +116,22 @@ size_t Server_Impl_13::send_new_session_tickets(const size_t tickets) {
    auto flight = aggregate_post_handshake_messages();
    size_t tickets_created = 0;
 
+   BOTAN_STATE_CHECK(m_active_state.has_value());
+
    for(size_t i = 0; i < tickets; ++i) {
       auto nonce = m_cipher_state->next_ticket_nonce();
+      const uint32_t ticket_age_add = load_be(rng().random_array<4>());
       const Session session(m_cipher_state->psk(nonce),
                             std::nullopt,  // early data not yet implemented
+                            ticket_age_add,
                             policy().session_ticket_lifetime(),
+                            m_active_state->version(),
+                            m_active_state->ciphersuite_code(),
+                            Connection_Side::Server,
                             peer_cert_chain(),
                             peer_raw_public_key(),
-                            m_handshake_state.client_hello(),
-                            m_handshake_state.server_hello(),
-                            callbacks(),
-                            rng());
+                            Server_Information(m_active_state->sni_hostname()),
+                            callbacks().tls_current_timestamp());
 
       if(callbacks().tls_should_persist_resumption_information(session)) {
          if(auto handle = session_manager().establish(session)) {
@@ -128,10 +149,12 @@ size_t Server_Impl_13::send_new_session_tickets(const size_t tickets) {
 }
 
 void Server_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
+   BOTAN_STATE_CHECK(m_handshake != nullptr);
+
    std::visit(
       [&](auto msg) {
          // first verify that the message was expected by the state machine...
-         m_transitions.confirm_transition_to(msg.get().type());
+         m_handshake->transitions.confirm_transition_to(msg.get().type());
 
          // ... then allow the library user to abort on their discretion
          callbacks().tls_inspect_handshake_msg(msg.get());
@@ -139,13 +162,28 @@ void Server_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
          // ... finally handle the message
          handle(msg.get());
       },
-      m_handshake_state.received(std::move(message)));
+      m_handshake->state.received(std::move(message)));
 }
 
 void Server_Impl_13::process_post_handshake_msg(Post_Handshake_Message_13 message) {
    BOTAN_STATE_CHECK(is_handshake_complete());
 
-   std::visit([&](auto msg) { handle(msg); }, m_handshake_state.received(std::move(message)));
+   // The throw is outside the lambda to work around a ICE in GCC 11
+   // TODO(Botan4) clean this up
+   const bool handled = std::visit(
+      [&](auto msg) -> bool {
+         if constexpr(std::is_constructible_v<Client_Post_Handshake_13_Message, decltype(msg)>) {
+            handle(msg);
+            return true;
+         } else {
+            return false;
+         }
+      },
+      std::move(message));
+
+   if(!handled) {
+      throw TLS_Exception(Alert::UnexpectedMessage, "Received an unexpected post-handshake message");
+   }
 }
 
 void Server_Impl_13::process_dummy_change_cipher_spec() {
@@ -153,7 +191,7 @@ void Server_Impl_13::process_dummy_change_cipher_spec() {
    //    If an implementation detects a change_cipher_spec record received before
    //    the first ClientHello message or after the peer's Finished message, it MUST be
    //    treated as an unexpected record type [("unexpected_message" alert)].
-   if(!m_handshake_state.has_client_hello() || m_handshake_state.has_client_finished()) {
+   if(!m_handshake || !m_handshake->state.has_client_hello() || m_handshake->state.has_client_finished()) {
       throw TLS_Exception(Alert::UnexpectedMessage, "Received an unexpected dummy Change Cipher Spec");
    }
 
@@ -167,12 +205,16 @@ void Server_Impl_13::process_dummy_change_cipher_spec() {
 }
 
 bool Server_Impl_13::is_handshake_complete() const {
-   return m_handshake_state.handshake_finished();
+   return m_active_state.has_value() || (m_handshake != nullptr && m_handshake->state.has_client_finished());
 }
 
 void Server_Impl_13::maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const {
    if(policy().allow_ssl_key_log_file()) {
-      callbacks().tls_ssl_key_log_data(label, m_handshake_state.client_hello().random(), secret);
+      if(m_active_state.has_value()) {
+         callbacks().tls_ssl_key_log_data(label, m_active_state->client_random(), secret);
+      } else {
+         callbacks().tls_ssl_key_log_data(label, m_handshake->state.client_hello().random(), secret);
+      }
    }
 }
 
@@ -183,12 +225,12 @@ void Server_Impl_13::downgrade() {
 
    // After this, no further messages are expected here because this instance
    // will be replaced by a Server_Impl_12.
-   m_transitions.set_expected_next({});
+   m_handshake->transitions.set_expected_next({});
 }
 
 void Server_Impl_13::maybe_handle_compatibility_mode() {
-   BOTAN_ASSERT_NOMSG(m_handshake_state.has_client_hello());
-   BOTAN_ASSERT_NOMSG(m_handshake_state.has_hello_retry_request() || m_handshake_state.has_server_hello());
+   BOTAN_ASSERT_NOMSG(m_handshake->state.has_client_hello());
+   BOTAN_ASSERT_NOMSG(m_handshake->state.has_hello_retry_request() || m_handshake->state.has_server_hello());
 
    // RFC 8446 Appendix D.4  (Middlebox Compatibility Mode)
    //    The server sends a dummy change_cipher_spec record immediately after
@@ -211,8 +253,8 @@ void Server_Impl_13::maybe_handle_compatibility_mode() {
    // after Hello Retry Request (exclusively) or after a Server Hello that was
    // not preseded by a Hello Retry Request.
    const bool just_after_first_handshake_message =
-      m_handshake_state.has_hello_retry_request() ^ m_handshake_state.has_server_hello();
-   const bool client_requested_compatibility_mode = !m_handshake_state.client_hello().session_id().empty();
+      m_handshake->state.has_hello_retry_request() ^ m_handshake->state.has_server_hello();
+   const bool client_requested_compatibility_mode = !m_handshake->state.client_hello().session_id().empty();
 
    if(just_after_first_handshake_message &&
       (policy().tls_13_middlebox_compatibility_mode() || client_requested_compatibility_mode)) {
@@ -221,7 +263,7 @@ void Server_Impl_13::maybe_handle_compatibility_mode() {
 }
 
 void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) {
-   const auto& client_hello = m_handshake_state.client_hello();
+   const auto& client_hello = m_handshake->state.client_hello();
    const auto& exts = client_hello.extensions();
 
    const bool uses_psk = server_hello.extensions().has<PSK>();
@@ -235,22 +277,22 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
    if(uses_psk) {
       auto* psk_extension = server_hello.extensions().get<PSK>();
 
-      psk_cipher_state =
-         std::visit(overloaded{[&, this](Session session) {
-                                  m_resumed_session = std::move(session);
-                                  return Cipher_State::init_with_psk(Connection_Side::Server,
-                                                                     Cipher_State::PSK_Type::Resumption,
-                                                                     m_resumed_session->extract_master_secret(),
-                                                                     cipher.prf_algo());
-                               },
-                               [&, this](ExternalPSK psk) {
-                                  m_psk_identity = psk.identity();
-                                  const auto psk_type = psk.is_imported() ? Cipher_State::PSK_Type::Imported
-                                                                          : Cipher_State::PSK_Type::External;
-                                  return Cipher_State::init_with_psk(
-                                     Connection_Side::Server, psk_type, psk.extract_master_secret(), cipher.prf_algo());
-                               }},
-                    psk_extension->take_session_to_resume_or_psk());
+      psk_cipher_state = std::visit(
+         overloaded{[&, this](Session session) {
+                       m_handshake->resumed_session = std::move(session);
+                       return Cipher_State::init_with_psk(Connection_Side::Server,
+                                                          Cipher_State::PSK_Type::Resumption,
+                                                          m_handshake->resumed_session->extract_master_secret(),
+                                                          cipher.prf_algo());
+                    },
+                    [&, this](ExternalPSK psk) {
+                       m_handshake->psk_identity = psk.identity();
+                       const auto psk_type =
+                          psk.is_imported() ? Cipher_State::PSK_Type::Imported : Cipher_State::PSK_Type::External;
+                       return Cipher_State::init_with_psk(
+                          Connection_Side::Server, psk_type, psk.extract_master_secret(), cipher.prf_algo());
+                    }},
+         psk_extension->take_session_to_resume_or_psk());
 
       // RFC 8446 4.2.11
       //    Prior to accepting PSK key establishment, the server MUST validate
@@ -285,13 +327,13 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
    // NOTE: the server_hello variable is moved into the handshake state. Later
    //       references to the Server Hello will need to consult the handshake
    //       state object!
-   send_handshake_message(m_handshake_state.sending(std::move(server_hello)));
+   send_handshake_message(m_handshake->state.sending(std::move(server_hello)));
    maybe_handle_compatibility_mode();
 
    // Setup encryption for all the remaining handshake messages
    m_cipher_state = [&] {
       // Currently, PSK without DHE is not implemented...
-      auto* const my_keyshare = m_handshake_state.server_hello().extensions().get<Key_Share>();
+      auto* const my_keyshare = m_handshake->state.server_hello().extensions().get<Key_Share>();
       BOTAN_ASSERT_NONNULL(my_keyshare);
 
       if(uses_psk) {
@@ -315,8 +357,11 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
                : Certificate_Request_13::maybe_create(client_hello, credentials_manager(), callbacks(), policy());
 
    auto flight = aggregate_handshake_messages();
-   flight.add(m_handshake_state.sending(Encrypted_Extensions(
-      client_hello, policy(), callbacks(), m_resumed_session.has_value(), certificate_request.has_value())));
+   const bool is_resumption = m_handshake->resumed_session.has_value();
+   const bool requesting_client_auth = certificate_request.has_value();
+
+   flight.add(m_handshake->state.sending(
+      Encrypted_Extensions(client_hello, policy(), callbacks(), is_resumption, requesting_client_auth)));
 
    if(!uses_psk) {
       // RFC 8446 4.3.2
@@ -324,10 +369,10 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
       //    request a certificate from the client. This message, if sent, MUST
       //    follow EncryptedExtensions.
       if(certificate_request.has_value()) {
-         flight.add(m_handshake_state.sending(std::move(certificate_request.value())));
+         flight.add(m_handshake->state.sending(std::move(certificate_request.value())));
       }
 
-      const auto& enc_exts = m_handshake_state.encrypted_extensions().extensions();
+      const auto& enc_exts = m_handshake->state.encrypted_extensions().extensions();
 
       // RFC 7250 4.2
       //   This client_certificate_type extension in the server hello then
@@ -353,22 +398,23 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
          }
       }();
 
-      flight.add(m_handshake_state.sending(Certificate_13(client_hello, credentials_manager(), callbacks(), cert_type)))
-         .add(m_handshake_state.sending(Certificate_Verify_13(m_handshake_state.server_certificate(),
-                                                              client_hello.signature_schemes(),
-                                                              client_hello.sni_hostname(),
-                                                              m_transcript_hash.current(),
-                                                              Connection_Side::Server,
-                                                              credentials_manager(),
-                                                              policy(),
-                                                              callbacks(),
-                                                              rng())));
+      flight
+         .add(m_handshake->state.sending(Certificate_13(client_hello, credentials_manager(), callbacks(), cert_type)))
+         .add(m_handshake->state.sending(Certificate_Verify_13(m_handshake->state.server_certificate(),
+                                                               client_hello.signature_schemes(),
+                                                               client_hello.sni_hostname(),
+                                                               m_transcript_hash.current(),
+                                                               Connection_Side::Server,
+                                                               credentials_manager(),
+                                                               policy(),
+                                                               callbacks(),
+                                                               rng())));
    }
 
-   flight.add(m_handshake_state.sending(Finished_13(m_cipher_state.get(), m_transcript_hash.current())));
+   flight.add(m_handshake->state.sending(Finished_13(m_cipher_state.get(), m_transcript_hash.current())));
 
    if(client_hello.extensions().has<Record_Size_Limit>() &&
-      m_handshake_state.encrypted_extensions().extensions().has<Record_Size_Limit>()) {
+      m_handshake->state.encrypted_extensions().extensions().has<Record_Size_Limit>()) {
       // RFC 8449 4.
       //    When the "record_size_limit" extension is negotiated, an endpoint
       //    MUST NOT generate a protected record with plaintext that is larger
@@ -385,7 +431,7 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
       // Hence, the "outgoing" limit is what the client requested and the
       // "incoming" limit is what we will request in the Encrypted Extensions.
       auto* const outgoing_limit = client_hello.extensions().get<Record_Size_Limit>();
-      auto* const incoming_limit = m_handshake_state.encrypted_extensions().extensions().get<Record_Size_Limit>();
+      auto* const incoming_limit = m_handshake->state.encrypted_extensions().extensions().get<Record_Size_Limit>();
       set_record_size_limits(outgoing_limit->limit(), incoming_limit->limit());
    }
 
@@ -393,16 +439,16 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
 
    m_cipher_state->advance_with_server_finished(m_transcript_hash.current(), *this);
 
-   if(m_handshake_state.has_certificate_request()) {
+   if(m_handshake->state.has_certificate_request()) {
       // RFC 8446 4.4.2
       //    The client MUST send a Certificate message if and only if the server
       //    has requested client authentication via a CertificateRequest message
       //    [...]. If the server requests client authentication but no
       //    suitable certificate is available, the client MUST send a Certificate
       //    message containing no certificates [...].
-      m_transitions.set_expected_next(Handshake_Type::Certificate);
+      m_handshake->transitions.set_expected_next(Handshake_Type::Certificate);
    } else {
-      m_transitions.set_expected_next(Handshake_Type::Finished);
+      m_handshake->transitions.set_expected_next(Handshake_Type::Finished);
    }
 }
 
@@ -410,21 +456,22 @@ void Server_Impl_13::handle_reply_to_client_hello(Hello_Retry_Request hello_retr
    auto cipher = Ciphersuite::by_id(hello_retry_request.ciphersuite());
    BOTAN_ASSERT_NOMSG(cipher.has_value());  // should work, since we chose that suite
 
-   send_handshake_message(m_handshake_state.sending(std::move(hello_retry_request)));
+   send_handshake_message(m_handshake->state.sending(std::move(hello_retry_request)));
    maybe_handle_compatibility_mode();
 
    m_transcript_hash = Transcript_Hash_State::recreate_after_hello_retry_request(cipher->prf_algo(), m_transcript_hash);
 
-   m_transitions.set_expected_next(Handshake_Type::ClientHello);
+   m_handshake->transitions.set_expected_next(Handshake_Type::ClientHello);
 }
 
 void Server_Impl_13::handle(const Client_Hello_12_Shim& ch) {
    // The detailed handling of the TLS 1.2 compliant Client Hello is left to
    // the TLS 1.2 server implementation.
    BOTAN_UNUSED(ch);
+   BOTAN_ASSERT_NONNULL(m_handshake);
 
    // After we sent a Hello Retry Request we must not accept a downgrade.
-   if(m_handshake_state.has_hello_retry_request()) {
+   if(m_handshake->state.has_hello_retry_request()) {
       throw TLS_Exception(Alert::UnexpectedMessage, "Received a TLS 1.2 Client Hello after Hello Retry Request");
    }
 
@@ -442,9 +489,11 @@ void Server_Impl_13::handle(const Client_Hello_12_Shim& ch) {
 }
 
 void Server_Impl_13::handle(const Client_Hello_13& client_hello) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    const auto& exts = client_hello.extensions();
 
-   const bool is_initial_client_hello = !m_handshake_state.has_hello_retry_request();
+   const bool is_initial_client_hello = !m_handshake->state.has_hello_retry_request();
 
    if(is_initial_client_hello) {
       const auto preferred_version = client_hello.highest_supported_version(policy());
@@ -474,7 +523,7 @@ void Server_Impl_13::handle(const Client_Hello_13& client_hello) {
    BOTAN_ASSERT_NOMSG(exts.has<Key_Share>());
 
    if(!is_initial_client_hello) {
-      const auto& hrr_exts = m_handshake_state.hello_retry_request().extensions();
+      const auto& hrr_exts = m_handshake->state.hello_retry_request().extensions();
       const auto offered_groups = exts.get<Key_Share>()->offered_groups();
       const auto* hrr_key_share = hrr_exts.get<Key_Share>();
       BOTAN_ASSERT_NONNULL(hrr_key_share);
@@ -496,6 +545,8 @@ void Server_Impl_13::handle(const Client_Hello_13& client_hello) {
 }
 
 void Server_Impl_13::handle(const Certificate_13& certificate_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.3.2
    //    certificate_request_context:  [...] This field SHALL be zero length
    //    unless used for the post-handshake authentication exchanges [...].
@@ -506,7 +557,7 @@ void Server_Impl_13::handle(const Certificate_13& certificate_msg) {
    // RFC 8446 4.4.2
    //    Extensions in the Certificate message from the client MUST correspond
    //    to extensions in the CertificateRequest message from the server.
-   certificate_msg.validate_extensions(m_handshake_state.certificate_request().extensions().extension_types(),
+   certificate_msg.validate_extensions(m_handshake->state.certificate_request().extensions().extension_types(),
                                        callbacks());
 
    // RFC 8446 4.4.2.4
@@ -522,7 +573,7 @@ void Server_Impl_13::handle(const Certificate_13& certificate_msg) {
       // RFC 8446 4.4.2
       //    A Finished message MUST be sent regardless of whether the
       //    Certificate message is empty.
-      m_transitions.set_expected_next(Handshake_Type::Finished);
+      m_handshake->transitions.set_expected_next(Handshake_Type::Finished);
    } else {
       // RFC 8446 4.4.2.4
       //    [...], if some aspect of the certificate chain was unacceptable
@@ -536,35 +587,37 @@ void Server_Impl_13::handle(const Certificate_13& certificate_msg) {
       certificate_msg.verify(callbacks(),
                              policy(),
                              credentials_manager(),
-                             m_handshake_state.client_hello().sni_hostname(),
-                             m_handshake_state.client_hello().extensions().has<Certificate_Status_Request>());
+                             m_handshake->state.client_hello().sni_hostname(),
+                             m_handshake->state.client_hello().extensions().has<Certificate_Status_Request>());
 
       // RFC 8446 4.4.3
       //    Clients MUST send this message whenever authenticating via a
       //    certificate (i.e., when the Certificate message
       //    is non-empty). When sent, this message MUST appear immediately after
       //    the Certificate message [...].
-      m_transitions.set_expected_next(Handshake_Type::CertificateVerify);
+      m_handshake->transitions.set_expected_next(Handshake_Type::CertificateVerify);
    }
 }
 
 void Server_Impl_13::handle(const Certificate_Verify_13& certificate_verify_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.4.3
    //    If sent by a client, the signature algorithm used in the signature
    //    MUST be one of those present in the supported_signature_algorithms
    //    field of the "signature_algorithms" extension in the
    //    CertificateRequest message.
-   const auto offered = m_handshake_state.certificate_request().signature_schemes();
+   const auto offered = m_handshake->state.certificate_request().signature_schemes();
    if(!value_exists(offered, certificate_verify_msg.signature_scheme())) {
       throw TLS_Exception(Alert::IllegalParameter,
                           "We did not offer the usage of " + certificate_verify_msg.signature_scheme().to_string() +
                              " as a signature scheme");
    }
 
-   BOTAN_ASSERT_NOMSG(m_handshake_state.has_client_certificate_msg() &&
-                      !m_handshake_state.client_certificate().empty());
+   BOTAN_ASSERT_NOMSG(m_handshake->state.has_client_certificate_msg() &&
+                      !m_handshake->state.client_certificate().empty());
    const bool sig_valid = certificate_verify_msg.verify(
-      *m_handshake_state.client_certificate().public_key(), callbacks(), m_transcript_hash.previous());
+      *m_handshake->state.client_certificate().public_key(), callbacks(), m_transcript_hash.previous());
 
    // RFC 8446 4.4.3
    //   If the verification fails, the receiver MUST terminate the handshake
@@ -573,10 +626,12 @@ void Server_Impl_13::handle(const Certificate_Verify_13& certificate_verify_msg)
       throw TLS_Exception(Alert::DecryptError, "Client certificate verification failed");
    }
 
-   m_transitions.set_expected_next(Handshake_Type::Finished);
+   m_handshake->transitions.set_expected_next(Handshake_Type::Finished);
 }
 
 void Server_Impl_13::handle(const Finished_13& finished_msg) {
+   BOTAN_ASSERT_NONNULL(m_handshake);
+
    // RFC 8446 4.4.4
    //    Recipients of Finished messages MUST verify that the contents are
    //    correct and if incorrect MUST terminate the connection with a
@@ -585,25 +640,64 @@ void Server_Impl_13::handle(const Finished_13& finished_msg) {
       throw TLS_Exception(Alert::DecryptError, "Finished message didn't verify");
    }
 
-   m_handshake_state.confirm_peer_finished_verified();
+   m_handshake->state.confirm_peer_finished_verified();
 
    // Give the application a chance for a final veto before fully
    // establishing the connection.
    callbacks().tls_session_established(
-      Session_Summary(m_handshake_state.server_hello(),
+      Session_Summary(m_handshake->state.server_hello(),
                       Connection_Side::Server,
                       peer_cert_chain(),
                       peer_raw_public_key(),
-                      m_psk_identity,
-                      m_resumed_session.has_value(),
-                      Server_Information(m_handshake_state.client_hello().sni_hostname()),
+                      m_handshake->psk_identity,
+                      m_handshake->resumed_session.has_value(),
+                      Server_Information(m_handshake->state.client_hello().sni_hostname()),
                       callbacks().tls_current_timestamp()));
 
    m_cipher_state->advance_with_client_finished(m_transcript_hash.current());
 
    // no more handshake messages expected
-   m_transitions.set_expected_next({});
+   m_handshake->transitions.set_expected_next({});
 
+   // Extract post-handshake state before signaling activation.
+   {
+      auto extract_certs = [&]() -> std::vector<X509_Certificate> {
+         if(m_handshake->state.has_client_certificate_msg() &&
+            m_handshake->state.client_certificate().has_certificate_chain()) {
+            return m_handshake->state.client_certificate().cert_chain();
+         }
+         if(m_handshake->resumed_session.has_value()) {
+            return m_handshake->resumed_session->peer_certs();
+         }
+         return {};
+      };
+
+      auto extract_raw_pk = [&]() -> std::shared_ptr<const Public_Key> {
+         if(m_handshake->state.has_client_certificate_msg() &&
+            m_handshake->state.client_certificate().is_raw_public_key()) {
+            return m_handshake->state.client_certificate().public_key();
+         }
+         if(m_handshake->resumed_session.has_value()) {
+            return m_handshake->resumed_session->peer_raw_public_key();
+         }
+         return nullptr;
+      };
+
+      const bool supports_psk_dhe =
+         m_handshake->state.client_hello().extensions().has<PSK_Key_Exchange_Modes>() &&
+         value_exists(m_handshake->state.client_hello().extensions().get<PSK_Key_Exchange_Modes>()->modes(),
+                      PSK_Key_Exchange_Mode::PSK_DHE_KE);
+
+      m_active_state = Active_Connection_State_13(m_handshake->state,
+                                                  extract_certs(),
+                                                  extract_raw_pk(),
+                                                  m_handshake->psk_identity,
+                                                  m_handshake->state.client_hello().sni_hostname(),
+                                                  supports_psk_dhe);
+   }
+
+   m_handshake.reset();
+   m_transcript_hash = Transcript_Hash_State();
    callbacks().tls_session_activated();
 
    if(new_session_ticket_supported()) {

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -58,11 +58,14 @@ class Server_Impl_13 : public Channel_Impl_13 {
       void downgrade();
 
    private:
-      Server_Handshake_State_13 m_handshake_state;
-      Handshake_Transitions m_transitions;
+      struct Pending_Handshake {
+            Server_Handshake_State_13 state;
+            Handshake_Transitions transitions;
+            std::optional<Session> resumed_session;
+            std::optional<std::string> psk_identity;
+      };
 
-      std::optional<Session> m_resumed_session;
-      std::optional<std::string> m_psk_identity;
+      std::unique_ptr<Pending_Handshake> m_handshake;
 };
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls_session.cpp
+++ b/src/lib/tls/tls_session.cpp
@@ -306,34 +306,6 @@ Session::Session(const secure_vector<uint8_t>& session_psk,
    BOTAN_ARG_CHECK(!version.is_pre_tls_13(), "Instantiated a TLS 1.3 session object with a TLS version older than 1.3");
 }
 
-Session::Session(secure_vector<uint8_t>&& session_psk,
-                 const std::optional<uint32_t>& max_early_data_bytes,
-                 std::chrono::seconds lifetime_hint,
-                 const std::vector<X509_Certificate>& peer_certs,
-                 std::shared_ptr<const Public_Key> peer_raw_public_key,
-                 const Client_Hello_13& client_hello,
-                 const Server_Hello_13& server_hello,
-                 Callbacks& callbacks,
-                 RandomNumberGenerator& rng) :
-      Session_Base(callbacks.tls_current_timestamp(),
-                   server_hello.selected_version(),
-                   server_hello.ciphersuite(),
-                   Connection_Side::Server,
-                   0,
-                   true,
-                   false,  // see constructor above for rationales
-                   peer_certs,
-                   std::move(peer_raw_public_key),
-                   Server_Information(client_hello.sni_hostname())),
-      m_master_secret(std::move(session_psk)),
-      m_early_data_allowed(max_early_data_bytes.has_value()),
-      m_max_early_data_bytes(max_early_data_bytes.value_or(0)),
-      m_ticket_age_add(load_be<uint32_t>(rng.random_vec(4).data(), 0)),
-      m_lifetime_hint(lifetime_hint) {
-   BOTAN_ARG_CHECK(!m_version.is_pre_tls_13(),
-                   "Instantiated a TLS 1.3 session object with a TLS version older than 1.3");
-}
-
 #endif
 
 Session::Session(std::string_view pem) : Session(PEM_Code::decode_check_label(pem, "TLS SESSION")) {}

--- a/src/lib/tls/tls_session.h
+++ b/src/lib/tls/tls_session.h
@@ -30,7 +30,6 @@ class X509_Certificate;
 
 namespace Botan::TLS {
 
-class Client_Hello_13;
 class Server_Hello_13;
 class Callbacks;
 
@@ -269,20 +268,6 @@ class BOTAN_PUBLIC_API(3, 0) Session final : public Session_Base {
               std::shared_ptr<const Public_Key> peer_raw_public_key,
               const Server_Information& server_info,
               std::chrono::system_clock::time_point current_timestamp);
-
-      /**
-       * Create a new TLS 1.3 session object from server data structures
-       * after a successful handshake with a TLS 1.3 client
-       */
-      Session(secure_vector<uint8_t>&& session_psk,
-              const std::optional<uint32_t>& max_early_data_bytes,
-              std::chrono::seconds lifetime_hint,
-              const std::vector<X509_Certificate>& peer_certs,
-              std::shared_ptr<const Public_Key> peer_raw_public_key,
-              const Client_Hello_13& client_hello,
-              const Server_Hello_13& server_hello,
-              Callbacks& callbacks,
-              RandomNumberGenerator& rng);
 
 #endif
 


### PR DESCRIPTION
Various bits of data relating to the handshake remained attached to the Channel even after the handshake completed, but in practice we only need a few pieces of information. Collect those into a new class, Active_Connection_State_{12,13}, and discard the rest.