### PR TITLE
Feature: More configuration options for installation directory structure

### DIFF
--- a/configure.py
+++ b/configure.py
@@ -2236,7 +2236,7 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'bindir': absolute_install_dir(options.bindir or osinfo.bin_dir),
         'libdir': absolute_install_dir(options.libdir or osinfo.lib_dir),
         'mandir': options.mandir or osinfo.man_dir,
-        'includedir': options.includedir or osinfo.header_dir,
+        'includedir': absolute_install_dir(options.includedir or osinfo.header_dir),
         'docdir': options.docdir or osinfo.doc_dir,
 
         'with_documentation': options.with_documentation,
@@ -2376,18 +2376,32 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'disabled_mod_list': sorted([m.basename for m in disabled_modules]),
     }
 
+    if not os.path.isabs(variables['prefix']):
+        raise UserError("The installation root must be an absolute path")
+
+    if not is_subpath(variables['libdir'], variables['prefix']):
+        raise UserError("The libdir must be a subdirectory of the prefix")
+
+    if not is_subpath(variables['includedir'], variables['prefix']):
+        raise UserError("The includedir must be a subdirectory of the prefix")
+
     variables['namespaced_includedir'] = os.path.join(
         variables['includedir'],
         ('botan-%d' % Version.major()) if options.with_include_namespace else '')
     variables['installed_include_dir'] = os.path.join(
-        variables['prefix'],
         variables['namespaced_includedir'],
         'botan')
 
+    # A long time ago some packages required a bindir that was outside the installation
+    # prefix. In the CMake config we need the bindir to find DLLs on Windows. If the
+    # bindir is configured to be outside the prefix, CMake will fall back to a hard-coded
+    # path instead of a relative path for relocatability.
+    if is_subpath(variables['bindir'], variables['prefix']):
+        variables['bindir_rel'] = normalize_source_path(os.path.relpath(variables['bindir'], variables['prefix']))
+
     variables['libdir_rel'] = normalize_source_path(os.path.relpath(variables['libdir'], variables['prefix']))
-    variables['bindir_rel'] = normalize_source_path(os.path.relpath(variables['bindir'], variables['prefix']))
-    variables['includedir_rel'] = normalize_source_path(os.path.relpath(absolute_install_dir(variables['includedir']), variables['prefix']))
-    variables['namespaced_includedir_rel'] = normalize_source_path(os.path.relpath(absolute_install_dir(variables['namespaced_includedir']), variables['prefix']))
+    variables['includedir_rel'] = normalize_source_path(os.path.relpath(variables['includedir'], variables['prefix']))
+    variables['namespaced_includedir_rel'] = normalize_source_path(os.path.relpath(variables['namespaced_includedir'], variables['prefix']))
 
     # On MSVC, the "ABI flags" should be passed to the compiler only, on other platforms, the
     # ABI flags are passed to both the compiler and the linker and the compiler flags are also

--- a/configure.py
+++ b/configure.py
@@ -664,6 +664,7 @@ def process_command_line(args):
                              help='set the include file install dir')
     install_group.add_option('--cmakeconfigdir', metavar='DIR',
                              help='set the CMake config (botan-config.cmake, botan-config-version.cmake) install dir')
+    add_with_without_pair(install_group, 'include-namespace', default=True, msg="don't add a 'botan-%d/' namespace to the include path" % (Version.major()))
 
     info_group = optparse.OptionGroup(parser, 'Informational')
 
@@ -2375,10 +2376,18 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         'disabled_mod_list': sorted([m.basename for m in disabled_modules]),
     }
 
+    variables['namespaced_includedir'] = os.path.join(
+        variables['includedir'],
+        ('botan-%d' % Version.major()) if options.with_include_namespace else '')
     variables['installed_include_dir'] = os.path.join(
         variables['prefix'],
-        variables['includedir'],
-        'botan-%d' % (Version.major()), 'botan')
+        variables['namespaced_includedir'],
+        'botan')
+
+    variables['libdir_rel'] = normalize_source_path(os.path.relpath(variables['libdir'], variables['prefix']))
+    variables['bindir_rel'] = normalize_source_path(os.path.relpath(variables['bindir'], variables['prefix']))
+    variables['includedir_rel'] = normalize_source_path(os.path.relpath(absolute_install_dir(variables['includedir']), variables['prefix']))
+    variables['namespaced_includedir_rel'] = normalize_source_path(os.path.relpath(absolute_install_dir(variables['namespaced_includedir']), variables['prefix']))
 
     # On MSVC, the "ABI flags" should be passed to the compiler only, on other platforms, the
     # ABI flags are passed to both the compiler and the linker and the compiler flags are also
@@ -2408,8 +2417,6 @@ def create_template_vars(source_paths, build_paths, options, modules, disabled_m
         if not is_subpath(cmake_install_dir, variables['prefix']):
             logging.error("The CMake module must be installed into a subdirectory of the install prefix.")
         variables['cmake_install_dir'] = normalize_source_path(cmake_install_dir)
-        variables['libdir_rel'] = normalize_source_path(os.path.relpath(variables['libdir'], variables['prefix']))
-        variables['bindir_rel'] = normalize_source_path(os.path.relpath(variables['bindir'], variables['prefix']))
         cmake_rel = os.path.relpath(cmake_install_dir, variables['prefix'])
         variables['cmake_relpath_components'] = [p for p in cmake_rel.replace('\\', '/').split('/') if p and p != '.']
 

--- a/doc/building.rst
+++ b/doc/building.rst
@@ -1105,6 +1105,16 @@ Set the man page installation dir.
 
 Set the include file installation dir.
 
+``--without-include-namespace``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, the header files (e.g. ``botan/hex.h``) are installed into an
+additional subdirectory named ``botan-<version>``. This option causes them to be
+installed directly into ``<includedir>`` instead.
+
+This option is not needed for normal usage and is only required in order to work
+around limitations in certain package managers.
+
 ``--cmakeconfigdir=DIR``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/build-data/botan-config.cmake.in
+++ b/src/build-data/botan-config.cmake.in
@@ -118,7 +118,13 @@ endif()
 
 set(_Botan_INCLUDE_DIR "${_Botan_PREFIX}/%{namespaced_includedir_rel}")
 set(_Botan_LIB_PREFIX  "${_Botan_PREFIX}/%{libdir_rel}")
+
+%{if bindir_rel}
 set(_Botan_BIN_DIR     "${_Botan_PREFIX}/%{bindir_rel}")
+%{endif}
+%{unless bindir_rel}
+set(_Botan_BIN_DIR     "%{bindir}")
+%{endif}
 
 %{if build_static_lib}
 if(NOT TARGET botan::botan-static)

--- a/src/build-data/botan-config.cmake.in
+++ b/src/build-data/botan-config.cmake.in
@@ -116,7 +116,7 @@ if(_Botan_PREFIX STREQUAL "/")
   set(_Botan_PREFIX "")
 endif()
 
-set(_Botan_INCLUDE_DIR "${_Botan_PREFIX}/%{includedir}/botan-%{version_major}")
+set(_Botan_INCLUDE_DIR "${_Botan_PREFIX}/%{namespaced_includedir_rel}")
 set(_Botan_LIB_PREFIX  "${_Botan_PREFIX}/%{libdir_rel}")
 set(_Botan_BIN_DIR     "${_Botan_PREFIX}/%{bindir_rel}")
 

--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -1,6 +1,6 @@
 prefix=%{prefix}
 exec_prefix=${prefix}
-libdir=%{libdir}
+libdir=${prefix}/%{libdir_rel}
 includedir=${prefix}/%{namespaced_includedir_rel}
 
 Name: Botan

--- a/src/build-data/botan.pc.in
+++ b/src/build-data/botan.pc.in
@@ -1,7 +1,7 @@
 prefix=%{prefix}
 exec_prefix=${prefix}
 libdir=%{libdir}
-includedir=${prefix}/include/botan-%{version_major}
+includedir=${prefix}/%{namespaced_includedir_rel}
 
 Name: Botan
 Description: Crypto and TLS for Modern C++

--- a/src/build-data/target_info.h.in
+++ b/src/build-data/target_info.h.in
@@ -96,7 +96,7 @@
 * System paths
 */
 #define BOTAN_INSTALL_PREFIX R"(%{prefix})"
-#define BOTAN_INSTALL_HEADER_DIR R"(%{includedir}/botan-%{version_major})"
+#define BOTAN_INSTALL_HEADER_DIR R"(%{namespaced_includedir_rel})"
 #define BOTAN_INSTALL_LIB_DIR R"(%{libdir})"
 #define BOTAN_LIB_LINK "%{link_to}"
 #define BOTAN_LINK_FLAGS "%{cxx_abi_flags}"

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -308,7 +308,7 @@ def cli_config_tests(_tmp_dir):
             logging.error("Bad prefix %s", prefix)
         if not ldflags.endswith(("-L%s/lib" % (prefix))):
             logging.error("Bad ldflags %s", ldflags)
-    if ("-I%s/include/botan-3" % (prefix)) not in cflags:
+    if ("-I%s/include/botan-3" % (prefix)) not in cflags and ("-I%s/include" % (prefix)) not in cflags:
         logging.error("Bad cflags %s", cflags)
     if "-lbotan-3" not in libs:
         logging.error("Bad libs %s", libs)


### PR DESCRIPTION
This provides `./configure.py --without-include-namespace` to let botan install headers straight into "\<prefix>/include" instead of using "\<prefix>/include/botan-3". That's required to fix the vcpkg build, see here: https://github.com/microsoft/vcpkg/issues/50177

Note that this also adds additional sanity checks:

* libdir, bindir and includedir are now all opportunistically prefixed with 'prefix', if they weren't provided as absolute paths to begin with
* libdir, bindir and includedir are validated to be subpaths of prefix