### PR TITLE
Refactor and optimize Windows certificate store

### DIFF
--- a/src/lib/x509/certstor_system/certstor_system.cpp
+++ b/src/lib/x509/certstor_system/certstor_system.cpp
@@ -61,6 +61,10 @@ std::optional<X509_CRL> System_Certificate_Store::find_crl_for(const X509_Certif
    return m_system_store->find_crl_for(subject);
 }
 
+bool System_Certificate_Store::contains(const X509_Certificate& cert) const {
+   return m_system_store->contains(cert);
+}
+
 std::vector<X509_DN> System_Certificate_Store::all_subjects() const {
    return m_system_store->all_subjects();
 }

--- a/src/lib/x509/certstor_system/certstor_system.h
+++ b/src/lib/x509/certstor_system/certstor_system.h
@@ -31,6 +31,8 @@ class BOTAN_PUBLIC_API(2, 11) System_Certificate_Store final : public Certificat
 
       std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
+      bool contains(const X509_Certificate& cert) const override;
+
       std::vector<X509_DN> all_subjects() const override;
 
    private:

--- a/src/lib/x509/certstor_system_windows/certstor_windows.cpp
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.cpp
@@ -1,6 +1,6 @@
 /*
 * Certificate Store
-* (C) 1999-2021 Jack Lloyd
+* (C) 1999-2021,2026 Jack Lloyd
 * (C) 2018-2019 Patrik Fiedler, Tim Oesterreich
 * (C) 2021      René Meusel
 *
@@ -12,10 +12,15 @@
 #include <botan/assert.h>
 #include <botan/ber_dec.h>
 #include <botan/hash.h>
+#include <botan/mutex.h>
 #include <botan/pkix_types.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/x509_cert_cache.h>
 #include <algorithm>
 #include <array>
 #include <functional>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #define NOMINMAX 1
@@ -24,193 +29,369 @@
 
 #include <wincrypt.h>
 
-#define WINCRYPT_UNUSED_PARAM \
-   0  // for avoiding warnings when passing NULL to unused params in win32 api that accept integer types
-
 namespace Botan {
 namespace {
 
-const std::array<const char*, 2> cert_store_names{"Root", "CA"};
+constexpr std::array<const char*, 2> cert_store_names{"Root", "CA"};
 
 /**
- * Abstract RAII wrapper for PCCERT_CONTEXT and HCERTSTORE
- * The Windows API partly takes care of those pointers destructions itself.
- * Especially, iteratively calling `CertFindCertificateInStore` with the previous PCCERT_CONTEXT
- * will free the context and return a new one. In this case, this guard takes care of freeing the context
- * in case of an exception and at the end of the iterative process.
+ * RAII wrapper for PCCERT_CONTEXT used as iteration state in
+ * CertFindCertificateInStore / CertEnumCertificatesInStore loops.
+ *
+ * The Windows API takes ownership of the previous context when the next one
+ * is requested: passing a non-null PCCERT_CONTEXT as the iteration state
+ * causes the API to free it and return a new one. This wrapper takes care of
+ * freeing the trailing context after the loop ends or on early return.
  */
-template <class T>
-class Handle_Guard {
+class Cert_Context final {
    public:
-      Handle_Guard(T context) : m_context(context) {}
+      Cert_Context() : m_ctx(nullptr) {}
 
-      Handle_Guard(const Handle_Guard<T>& rhs) = delete;
-
-      Handle_Guard(Handle_Guard<T>&& rhs) : m_context(std::move(rhs.m_context)) { rhs.m_context = nullptr; }
-
-      ~Handle_Guard() { close<T>(); }
-
-      operator bool() const { return m_context != nullptr; }
-
-      bool assign(T context) {
-         m_context = context;
-         return m_context != nullptr;
+      ~Cert_Context() {
+         if(m_ctx != nullptr) {
+            CertFreeCertificateContext(m_ctx);
+         }
       }
 
-      T& get() { return m_context; }
+      Cert_Context(const Cert_Context&) = delete;
+      Cert_Context(Cert_Context&&) = delete;
+      Cert_Context& operator=(const Cert_Context&) = delete;
+      Cert_Context& operator=(Cert_Context&&) = delete;
 
-      const T& get() const { return m_context; }
+      bool assign(PCCERT_CONTEXT ctx) {
+         m_ctx = ctx;
+         return m_ctx != nullptr;
+      }
 
-      T operator->() { return m_context; }
+      PCCERT_CONTEXT get() const { return m_ctx; }
+
+      PCCERT_CONTEXT operator->() const { return m_ctx; }
 
    private:
-      template <class T2 = T>
-      typename std::enable_if<std::is_same<T2, PCCERT_CONTEXT>::value>::type close() {
-         if(m_context) {
-            CertFreeCertificateContext(m_context);
-         }
-      }
-
-      template <class T2 = T>
-      typename std::enable_if<std::is_same<T2, HCERTSTORE>::value>::type close() {
-         if(m_context) {
-            // second parameter is a flag that tells the store how to deallocate memory
-            // using the default "0", this function works like decreasing the reference counter
-            // in a shared_ptr
-            CertCloseStore(m_context, 0);
-         }
-      }
-
-      T m_context;
+      PCCERT_CONTEXT m_ctx;
 };
 
-HCERTSTORE open_cert_store(const char* cert_store_name) {
-   auto store = CertOpenSystemStoreA(WINCRYPT_UNUSED_PARAM, cert_store_name);
-   if(!store) {
-      throw Internal_Error("failed to open windows certificate store '" + std::string(cert_store_name) +
-                           "' (Error Code: " + std::to_string(::GetLastError()) + ")");
-   }
-   return store;
-}
+/**
+ * Iterate every certificate returned by a Windows API walk function across
+ * a sequence of already-open stores. The walk function is called with the
+ * current store and the previously returned context; returning nullptr ends
+ * the current store and advances to the next. The final non-null context is
+ * owned by this object and freed on destruction or on the terminating walk
+ * call that returns nullptr.
+ */
+class Cert_Enumerator final {
+   public:
+      using Next_Fn = std::function<PCCERT_CONTEXT(HCERTSTORE, PCCERT_CONTEXT)>;
 
-std::vector<X509_Certificate> search_cert_stores(
-   const _CRYPTOAPI_BLOB& blob,
-   const DWORD& find_type,
-   std::function<bool(const std::vector<X509_Certificate>& certs, const X509_Certificate& cert)> filter,
-   bool return_on_first_found) {
-   std::vector<X509_Certificate> certs;
-   for(const auto store_name : cert_store_names) {
-      Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
-      Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-      while(cert_context.assign(CertFindCertificateInStore(windows_cert_store.get(),
-                                                           PKCS_7_ASN_ENCODING | X509_ASN_ENCODING,
-                                                           WINCRYPT_UNUSED_PARAM,
-                                                           find_type,
-                                                           &blob,
-                                                           cert_context.get()))) {
-         X509_Certificate cert(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-         if(filter(certs, cert)) {
-            if(return_on_first_found) {
-               return {cert};
+      Cert_Enumerator(std::span<const HCERTSTORE> stores, Next_Fn fn) : m_stores(stores), m_get_next(std::move(fn)) {}
+
+      Cert_Enumerator(const Cert_Enumerator&) = delete;
+      Cert_Enumerator(Cert_Enumerator&&) = delete;
+      Cert_Enumerator& operator=(const Cert_Enumerator&) = delete;
+      Cert_Enumerator& operator=(Cert_Enumerator&&) = delete;
+      ~Cert_Enumerator() = default;
+
+      PCCERT_CONTEXT next() {
+         while(m_store_idx < m_stores.size()) {
+            if(m_ctx.assign(m_get_next(m_stores[m_store_idx], m_ctx.get()))) {
+               return m_ctx.get();
             }
-            certs.push_back(cert);
+            // The Windows API freed the previous context when it returned
+            // nullptr, so m_ctx now holds null and we can start the next
+            // store with a null prev.
+            ++m_store_idx;
          }
+         return nullptr;
       }
-   }
 
-   return certs;
-}
+   private:
+      std::span<const HCERTSTORE> m_stores;
+      Next_Fn m_get_next;
+      size_t m_store_idx = 0;
+      Cert_Context m_ctx;
+};
 
-bool already_contains_certificate(const std::vector<X509_Certificate>& certs, X509_Certificate cert) {
-   return std::any_of(certs.begin(), certs.end(), [&](const X509_Certificate& c) { return c == cert; });
-}
+/**
+ * A 20-byte SHA-1 hash of a certificate's SubjectPublicKey, suitable for use
+ * as a key in an unordered associative container.
+ */
+class Pubkey_SHA1 final {
+   public:
+      static constexpr size_t LEN = 20;
 
-std::vector<X509_Certificate> find_cert_by_dn_and_key_id(const X509_DN& subject_dn,
-                                                         const std::vector<uint8_t>& key_id,
-                                                         bool return_on_first_found) {
-   _CRYPTOAPI_BLOB blob;
-   DWORD find_type;
-   std::vector<uint8_t> dn_data;  // has to live until search completes
+      explicit Pubkey_SHA1(std::span<const uint8_t> bytes) {
+         BOTAN_ARG_CHECK(bytes.size() == LEN, "invalid SHA-1 pubkey hash length");
+         std::copy(bytes.begin(), bytes.end(), m_hash.begin());
+      }
 
-   // if key_id is available, prefer searching that, as it should be "more unique" than the subject DN
-   if(key_id.empty()) {
-      find_type = CERT_FIND_SUBJECT_NAME;
-      dn_data = subject_dn.DER_encode();
-      blob.cbData = static_cast<DWORD>(dn_data.size());
-      blob.pbData = reinterpret_cast<BYTE*>(dn_data.data());
-   } else {
-      find_type = CERT_FIND_KEY_IDENTIFIER;
-      blob.cbData = static_cast<DWORD>(key_id.size());
-      blob.pbData = const_cast<BYTE*>(key_id.data());
-   }
+      static Pubkey_SHA1 compute(HashFunction& sha1, std::span<const uint8_t> data) {
+         Pubkey_SHA1 result;
+         sha1.update(data);
+         sha1.final(result.m_hash);
+         return result;
+      }
 
-   auto filter = [&](const std::vector<X509_Certificate>& certs, const X509_Certificate& cert) {
-      return !already_contains_certificate(certs, cert) && (key_id.empty() || cert.subject_dn() == subject_dn);
-   };
+      auto operator<=>(const Pubkey_SHA1&) const = default;
 
-   return search_cert_stores(blob, find_type, filter, return_on_first_found);
-}
+      size_t hash() const noexcept {
+         size_t h = 0;
+         std::memcpy(&h, m_hash.data(), sizeof(h));
+         return h;
+      }
+
+   private:
+      Pubkey_SHA1() = default;
+      std::array<uint8_t, LEN> m_hash = {};
+};
+
+struct Pubkey_SHA1_Hasher {
+      size_t operator()(const Pubkey_SHA1& h) const noexcept { return h.hash(); }
+};
 
 }  // namespace
 
-Certificate_Store_Windows::Certificate_Store_Windows() {}
+/**
+ * Pimpl for Certificate_Store_Windows.
+ */
+class Certificate_Store_Windows_Impl final {
+   public:
+      // This cache size is arbitrary but probably is sufficient so that the vast
+      // majority of accesses hit the cache
+      static constexpr size_t SystemStore_CertCacheSize = 128;
+
+      Certificate_Store_Windows_Impl() : m_cert_cache(SystemStore_CertCacheSize) {
+         for(const auto* cert_store_name : cert_store_names) {
+            auto* store = CertOpenSystemStoreA(0, cert_store_name);
+            if(store == nullptr) {
+               const auto err = ::GetLastError();
+               close_stores();
+               throw System_Error(fmt("Failed to open Windows certificate store '{}'", cert_store_name), err);
+            }
+
+            CertControlStore(store, 0, CERT_STORE_CTRL_AUTO_RESYNC, nullptr);
+
+            m_stores.push_back(store);
+         }
+      }
+
+      ~Certificate_Store_Windows_Impl() { close_stores(); }
+
+      Certificate_Store_Windows_Impl(const Certificate_Store_Windows_Impl&) = delete;
+      Certificate_Store_Windows_Impl(Certificate_Store_Windows_Impl&&) = delete;
+      Certificate_Store_Windows_Impl& operator=(const Certificate_Store_Windows_Impl&) = delete;
+      Certificate_Store_Windows_Impl& operator=(Certificate_Store_Windows_Impl&&) = delete;
+
+      std::optional<X509_Certificate> find_cert(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) {
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         const auto certs = find_cert_by_dn_and_key_id(subject_dn, key_id, true);
+         if(certs.empty()) {
+            return std::nullopt;
+         }
+         return certs.front();
+      }
+
+      std::vector<X509_Certificate> find_all_certs(const X509_DN& subject_dn, const std::vector<uint8_t>& key_id) {
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         return find_cert_by_dn_and_key_id(subject_dn, key_id, false);
+      }
+
+      std::optional<X509_Certificate> find_cert_by_pubkey_sha1(const std::vector<uint8_t>& key_hash) {
+         if(key_hash.size() != Pubkey_SHA1::LEN) {
+            throw Invalid_Argument("Certificate_Store_Windows::find_cert_by_pubkey_sha1 invalid hash");
+         }
+
+         const Pubkey_SHA1 target(key_hash);
+
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         if(const auto hit = m_sha1_pubkey_to_cert.find(target); hit != m_sha1_pubkey_to_cert.end()) {
+            return hit->second;
+         }
+
+         // Upper bound the cache, random eviction based on the hashes
+         while(m_sha1_pubkey_to_cert.size() >= 1024) {
+            m_sha1_pubkey_to_cert.erase(m_sha1_pubkey_to_cert.begin());
+         }
+
+         auto sha1 = HashFunction::create_or_throw("SHA-1");
+
+         Cert_Enumerator enumerator(
+            m_stores, [](HCERTSTORE store, PCCERT_CONTEXT prev) { return CertEnumCertificatesInStore(store, prev); });
+
+         while(const auto* ctx = enumerator.next()) {
+            const auto pubkey_blob = ctx->pCertInfo->SubjectPublicKeyInfo.PublicKey;
+            const auto candidate =
+               Pubkey_SHA1::compute(*sha1, {static_cast<uint8_t*>(pubkey_blob.pbData), pubkey_blob.cbData});
+
+            if(candidate == target) {
+               auto result = materialize(ctx->pbCertEncoded, ctx->cbCertEncoded);
+               m_sha1_pubkey_to_cert.emplace(target, result);
+               return result;
+            }
+         }
+
+         // insert a negative query result into the cache
+         m_sha1_pubkey_to_cert.emplace(target, std::nullopt);
+         return std::nullopt;
+      }
+
+      std::optional<X509_Certificate> find_cert_by_issuer_dn_and_serial_number(const X509_DN& issuer_dn,
+                                                                               std::span<const uint8_t> serial_number) {
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         const std::vector<uint8_t> dn_data = issuer_dn.BER_encode();
+
+         const _CRYPTOAPI_BLOB blob{
+            .cbData = static_cast<DWORD>(dn_data.size()),
+            .pbData = const_cast<BYTE*>(dn_data.data()),
+         };
+
+         auto filter = [&](const X509_Certificate& cert) {
+            return std::ranges::equal(cert.serial_number(), serial_number);
+         };
+
+         const auto certs = search_cert_stores(blob, CERT_FIND_ISSUER_NAME, filter, true);
+         if(certs.empty()) {
+            return std::nullopt;
+         }
+         return certs.front();
+      }
+
+      bool contains(const X509_Certificate& cert) {
+         const auto cert_sha1 = cert.certificate_data_sha1();
+         const auto cert_sha256 = cert.certificate_data_sha256();
+
+         const CRYPT_HASH_BLOB sha1_blob{
+            .cbData = static_cast<DWORD>(cert_sha1.size()),
+            .pbData = const_cast<BYTE*>(cert_sha1.data()),
+         };
+
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         Cert_Enumerator enumerator(m_stores, [&sha1_blob](HCERTSTORE store, PCCERT_CONTEXT prev) {
+            return CertFindCertificateInStore(
+               store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0, CERT_FIND_SHA1_HASH, &sha1_blob, prev);
+         });
+
+         while(const auto* ctx = enumerator.next()) {
+            const auto found = materialize(ctx->pbCertEncoded, ctx->cbCertEncoded);
+            if(std::ranges::equal(found.certificate_data_sha256(), cert_sha256)) {
+               return true;
+            }
+         }
+
+         return false;
+      }
+
+      std::vector<X509_DN> all_subjects() {
+         const lock_guard_type<mutex_type> lock(m_mutex);
+
+         std::vector<X509_DN> subject_dns;
+
+         Cert_Enumerator enumerator(
+            m_stores, [](HCERTSTORE store, PCCERT_CONTEXT prev) { return CertEnumCertificatesInStore(store, prev); });
+
+         while(const auto* ctx = enumerator.next()) {
+            BER_Decoder dec(ctx->pCertInfo->Subject.pbData, ctx->pCertInfo->Subject.cbData);
+            X509_DN dn;
+            dn.decode_from(dec);
+            subject_dns.emplace_back(std::move(dn));
+         }
+
+         return subject_dns;
+      }
+
+   private:
+      void close_stores() {
+         for(auto* store : m_stores) {
+            CertCloseStore(store, 0);
+         }
+         m_stores.clear();
+      }
+
+      X509_Certificate materialize(const BYTE* der, DWORD len) { return m_cert_cache.find_or_insert({der, len}); }
+
+      // Caller must hold m_mutex.
+      std::vector<X509_Certificate> find_cert_by_dn_and_key_id(const X509_DN& subject_dn,
+                                                               const std::vector<uint8_t>& key_id,
+                                                               bool return_on_first_found) {
+         _CRYPTOAPI_BLOB blob{};
+         DWORD find_type = 0;
+         std::vector<uint8_t> dn_data;  // has to live until search completes
+
+         // if key_id is available, prefer searching that, as it should be "more unique" than the subject DN
+         if(key_id.empty()) {
+            find_type = CERT_FIND_SUBJECT_NAME;
+            dn_data = subject_dn.DER_encode();
+            blob.cbData = static_cast<DWORD>(dn_data.size());
+            blob.pbData = reinterpret_cast<BYTE*>(dn_data.data());
+         } else {
+            find_type = CERT_FIND_KEY_IDENTIFIER;
+            blob.cbData = static_cast<DWORD>(key_id.size());
+            blob.pbData = const_cast<BYTE*>(key_id.data());
+         }
+
+         auto filter = [&](const X509_Certificate& cert) { return key_id.empty() || cert.subject_dn() == subject_dn; };
+
+         return search_cert_stores(blob, find_type, filter, return_on_first_found);
+      }
+
+      // Caller must hold m_mutex.
+      std::vector<X509_Certificate> search_cert_stores(const _CRYPTOAPI_BLOB& blob,
+                                                       DWORD find_type,
+                                                       const std::function<bool(const X509_Certificate&)>& filter,
+                                                       bool return_on_first_found) {
+         std::vector<X509_Certificate> certs;
+         std::unordered_set<X509_Certificate::Tag, X509_Certificate::TagHash> seen;
+
+         Cert_Enumerator enumerator(m_stores, [&blob, find_type](HCERTSTORE store, PCCERT_CONTEXT prev) {
+            return CertFindCertificateInStore(
+               store, X509_ASN_ENCODING | PKCS_7_ASN_ENCODING, 0, find_type, &blob, prev);
+         });
+
+         while(const auto* ctx = enumerator.next()) {
+            auto cert = materialize(ctx->pbCertEncoded, ctx->cbCertEncoded);
+            if(!seen.insert(cert.tag()).second) {
+               continue;
+            }
+            if(filter(cert)) {
+               certs.push_back(std::move(cert));
+               if(return_on_first_found) {
+                  break;
+               }
+            }
+         }
+
+         return certs;
+      }
+
+      mutex_type m_mutex;
+      std::vector<HCERTSTORE> m_stores;
+      std::unordered_map<Pubkey_SHA1, std::optional<X509_Certificate>, Pubkey_SHA1_Hasher> m_sha1_pubkey_to_cert;
+      X509_Certificate_Cache m_cert_cache;
+};
+
+Certificate_Store_Windows::Certificate_Store_Windows() : m_impl(std::make_shared<Certificate_Store_Windows_Impl>()) {}
 
 std::vector<X509_DN> Certificate_Store_Windows::all_subjects() const {
-   std::vector<X509_DN> subject_dns;
-   for(const auto store_name : cert_store_names) {
-      Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
-      Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-
-      // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
-      // freeing the previous context.
-      while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get()))) {
-         BER_Decoder dec(cert_context->pCertInfo->Subject.pbData, cert_context->pCertInfo->Subject.cbData);
-
-         X509_DN dn;
-         dn.decode_from(dec);
-         subject_dns.emplace_back(std::move(dn));
-      }
-   }
-
-   return subject_dns;
+   return m_impl->all_subjects();
 }
 
 std::optional<X509_Certificate> Certificate_Store_Windows::find_cert(const X509_DN& subject_dn,
                                                                      const std::vector<uint8_t>& key_id) const {
-   const auto certs = find_cert_by_dn_and_key_id(subject_dn, key_id, true);
-   if(certs.empty())
-      return std::nullopt;
-   else
-      return certs.front();
+   return m_impl->find_cert(subject_dn, key_id);
 }
 
 std::vector<X509_Certificate> Certificate_Store_Windows::find_all_certs(const X509_DN& subject_dn,
                                                                         const std::vector<uint8_t>& key_id) const {
-   return find_cert_by_dn_and_key_id(subject_dn, key_id, false);
+   return m_impl->find_all_certs(subject_dn, key_id);
 }
 
 std::optional<X509_Certificate> Certificate_Store_Windows::find_cert_by_pubkey_sha1(
    const std::vector<uint8_t>& key_hash) const {
-   if(key_hash.size() != 20) {
-      throw Invalid_Argument("Certificate_Store_Windows::find_cert_by_pubkey_sha1 invalid hash");
-   }
-
-   CRYPT_HASH_BLOB blob;
-   blob.cbData = static_cast<DWORD>(key_hash.size());
-   blob.pbData = const_cast<BYTE*>(key_hash.data());
-
-   auto filter = [&](const std::vector<X509_Certificate>&, const X509_Certificate&) { return true; };
-
-   // This assumes that the to-be-found certificate adheres to RFC 3280 (Section 4.2.1.2), because
-   // the windows API does not allow to search for the SHA-1 of the certificate's public key directly.
-   // Most certificates adhere to the above mentioned convention...
-   const auto certs = search_cert_stores(blob, CERT_FIND_KEY_IDENTIFIER, filter, true);
-   if(!certs.empty())
-      return certs.front();
-
-   // ... for certificates that don't adhere to RFC 3280 (Section 4.2.1.2), we will need to use a
-   // fallback implementation that does an exhaustive search of all available certificates.
-   return find_cert_by_pubkey_sha1_via_exhaustive_search(key_hash);
+   return m_impl->find_cert_by_pubkey_sha1(key_hash);
 }
 
 std::optional<X509_Certificate> Certificate_Store_Windows::find_cert_by_raw_subject_dn_sha256(
@@ -221,22 +402,7 @@ std::optional<X509_Certificate> Certificate_Store_Windows::find_cert_by_raw_subj
 
 std::optional<X509_Certificate> Certificate_Store_Windows::find_cert_by_issuer_dn_and_serial_number(
    const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const {
-   std::vector<uint8_t> dn_data = issuer_dn.BER_encode();
-
-   _CRYPTOAPI_BLOB blob;
-   blob.cbData = static_cast<DWORD>(dn_data.size());
-   blob.pbData = reinterpret_cast<BYTE*>(dn_data.data());
-
-   auto filter = [&](const std::vector<X509_Certificate>& certs, const X509_Certificate& cert) {
-      return !already_contains_certificate(certs, cert) && std::ranges::equal(cert.serial_number(), serial_number);
-   };
-
-   const auto certs = search_cert_stores(blob, CERT_FIND_ISSUER_NAME, filter, true);
-   if(certs.empty()) {
-      return std::nullopt;
-   }
-
-   return certs.front();
+   return m_impl->find_cert_by_issuer_dn_and_serial_number(issuer_dn, serial_number);
 }
 
 std::optional<X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certificate& subject) const {
@@ -245,41 +411,8 @@ std::optional<X509_CRL> Certificate_Store_Windows::find_crl_for(const X509_Certi
    return std::nullopt;
 }
 
-std::optional<X509_Certificate> Certificate_Store_Windows::find_cert_by_pubkey_sha1_via_exhaustive_search(
-   const std::vector<uint8_t>& key_hash) const {
-   const lock_guard_type<mutex_type> lock(m_mutex);
-
-   if(const auto cache_hit = m_sha1_pubkey_to_cert.find(key_hash); cache_hit != m_sha1_pubkey_to_cert.end()) {
-      return cache_hit->second;
-   }
-
-   /*
-   * TODO: it would be possible to perform this search loop without holding the lock, and
-   * only taking the lock once right when the result was saved to the map.
-   */
-
-   auto sha1 = HashFunction::create_or_throw("SHA-1");
-   for(const auto store_name : cert_store_names) {
-      Handle_Guard<HCERTSTORE> windows_cert_store = open_cert_store(store_name);
-      Handle_Guard<PCCERT_CONTEXT> cert_context = nullptr;
-
-      // Handle_Guard::assign exchanges the underlying pointer. No RAII is needed here, because the Windows API takes care of
-      // freeing the previous context.
-      while(cert_context.assign(CertEnumCertificatesInStore(windows_cert_store.get(), cert_context.get()))) {
-         const auto pubkey_blob = cert_context->pCertInfo->SubjectPublicKeyInfo.PublicKey;
-         const auto key_hash_candidate = sha1->process(static_cast<uint8_t*>(pubkey_blob.pbData), pubkey_blob.cbData);
-
-         if(std::equal(key_hash.begin(), key_hash.end(), key_hash_candidate.begin())) {
-            X509_Certificate result(cert_context->pbCertEncoded, cert_context->cbCertEncoded);
-            m_sha1_pubkey_to_cert[key_hash] = result;
-            return result;
-         }
-      }
-   }
-
-   // insert a negative query result into the cache
-   m_sha1_pubkey_to_cert[key_hash] = std::nullopt;
-   return std::nullopt;
+bool Certificate_Store_Windows::contains(const X509_Certificate& cert) const {
+   return m_impl->contains(cert);
 }
 
 }  // namespace Botan

--- a/src/lib/x509/certstor_system_windows/certstor_windows.h
+++ b/src/lib/x509/certstor_system_windows/certstor_windows.h
@@ -11,13 +11,15 @@
 #define BOTAN_CERT_STORE_SYSTEM_WINDOWS_H_
 
 #include <botan/certstor.h>
-#include <botan/mutex.h>
-#include <map>
+#include <memory>
 
 // Use Certificate_Store_System instead
 BOTAN_FUTURE_INTERNAL_HEADER(certstor_windows.h)
 
 namespace Botan {
+
+class Certificate_Store_Windows_Impl;
+
 /**
 * Certificate Store that is backed by the system trust store on Windows.
 */
@@ -25,10 +27,10 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
    public:
       Certificate_Store_Windows();
 
-      Certificate_Store_Windows(const Certificate_Store_Windows&) = delete;
-      Certificate_Store_Windows(Certificate_Store_Windows&&) = delete;
-      Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = delete;
-      Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = delete;
+      Certificate_Store_Windows(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows(Certificate_Store_Windows&&) = default;
+      Certificate_Store_Windows& operator=(const Certificate_Store_Windows&) = default;
+      Certificate_Store_Windows& operator=(Certificate_Store_Windows&&) = default;
 
       /**
       * @return DNs for all certificates managed by the store
@@ -71,22 +73,10 @@ class BOTAN_PUBLIC_API(2, 11) Certificate_Store_Windows final : public Certifica
        */
       std::optional<X509_CRL> find_crl_for(const X509_Certificate& subject) const override;
 
-   private:
-      /**
-       * Handle certificates that do not adhere to RFC 3280 using a subject key identifier
-       * that is not equal to the SHA-1 of the public key (w/o algorithm identifier)
-       *
-       * This method lazily builds a cache of certificates found in previous queries as well
-       * as negative results for @p key_hash queries that didn't find a certificate.
-       *
-       * See here for further details: https://github.com/randombit/botan/issues/2779
-       */
-      std::optional<X509_Certificate> find_cert_by_pubkey_sha1_via_exhaustive_search(
-         const std::vector<uint8_t>& key_hash) const;
+      bool contains(const X509_Certificate& cert) const override;
 
    private:
-      mutable mutex_type m_mutex;
-      mutable std::map<std::vector<uint8_t>, std::optional<X509_Certificate>> m_sha1_pubkey_to_cert;
+      std::shared_ptr<Certificate_Store_Windows_Impl> m_impl;
 };
 
 }  // namespace Botan

--- a/src/lib/x509/info.txt
+++ b/src/lib/x509/info.txt
@@ -33,6 +33,7 @@ x509self.h
 
 <header:internal>
 x509_utils.h
+x509_cert_cache.h
 </header:internal>
 
 <os_features>

--- a/src/lib/x509/x509_cert_cache.cpp
+++ b/src/lib/x509/x509_cert_cache.cpp
@@ -44,8 +44,7 @@ X509_Certificate X509_Certificate_Cache::find_or_insert(std::span<const uint8_t>
 
    // Evict if required
    //
-   // Right now this is just an effectively random drop (lowest hash value)
-   // might make sense to add LRU here
+   // Effectively this is just a random drop, might make sense to add LRU here
    while(m_cache.size() >= m_max_entries) {
       m_cache.erase(m_cache.begin());
    }

--- a/src/lib/x509/x509_cert_cache.cpp
+++ b/src/lib/x509/x509_cert_cache.cpp
@@ -1,0 +1,58 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/x509_cert_cache.h>
+
+#include <botan/hash.h>
+
+namespace Botan {
+
+X509_Certificate_Cache::X509_Certificate_Cache(size_t max_entries) : m_max_entries(max_entries) {}
+
+X509_Certificate X509_Certificate_Cache::find_or_insert(std::span<const uint8_t> encoding) {
+   if(m_max_entries == 0) {
+      return X509_Certificate(encoding);
+   }
+
+   // Hash the DER
+   auto sha256 = HashFunction::create_or_throw("SHA-256");
+   DER_Hash hash;
+   sha256->update(encoding);
+   sha256->final(hash.m_hash);
+
+   // Check for a cache hit
+   {
+      const lock_guard_type<mutex_type> lock(m_mutex);
+      if(auto it = m_cache.find(hash); it != m_cache.end()) {
+         return it->second;
+      }
+   }
+
+   // Deserialize the certificate
+   X509_Certificate cert(encoding);
+
+   // Lock again
+   const lock_guard_type<mutex_type> lock(m_mutex);
+
+   // Check for a cache hit (possibly racing with another thread)
+   if(auto it = m_cache.find(hash); it != m_cache.end()) {
+      return it->second;
+   }
+
+   // Evict if required
+   //
+   // Right now this is just an effectively random drop (lowest hash value)
+   // might make sense to add LRU here
+   while(m_cache.size() >= m_max_entries) {
+      m_cache.erase(m_cache.begin());
+   }
+
+   // Add the newly deserialized cert to the cache
+   auto it = m_cache.emplace(hash, std::move(cert)).first;
+   return it->second;
+}
+
+}  // namespace Botan

--- a/src/lib/x509/x509_cert_cache.h
+++ b/src/lib/x509/x509_cert_cache.h
@@ -1,0 +1,87 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_X509_CERT_CACHE_H_
+#define BOTAN_X509_CERT_CACHE_H_
+
+#include <botan/x509cert.h>
+
+#include <botan/mutex.h>
+#include <array>
+#include <cstring>
+#include <span>
+#include <unordered_map>
+
+namespace Botan {
+
+class HashFunction;
+
+/**
+* A cache for X.509 certificates
+*
+* This is primarily useful for system certificate stores (Windows, macOS)
+* where repeated lookups via native APIs return raw DER bytes that must
+* be parsed each time. The cache deduplicates these by keying on the
+* SHA-256 hash of the DER encoding.
+*/
+class X509_Certificate_Cache final {
+   public:
+      /**
+      * @param max_entries maximum number of certificates to cache.
+      *        When the cache is full, an entry is evicted to make room.
+      *        If 0, caching is disabled entirely.
+      */
+      explicit X509_Certificate_Cache(size_t max_entries = 64);
+
+      /**
+      * Look up a certificate by its DER encoding, or parse and cache it.
+      *
+      * If a certificate with the same DER encoding (by SHA-256 hash) is
+      * already in the cache, returns a (cheap, shared_ptr-backed) copy.
+      * Otherwise, parses the DER encoding into an X509_Certificate,
+      * inserts it into the cache, and returns it.
+      *
+      * If the cache was constructed with max_entries == 0, always parses
+      * and never caches.
+      *
+      * @param encoding DER-encoded certificate
+      * @return the cached or newly parsed certificate
+      * @throws Decoding_Error if the encoding is not a valid certificate
+      */
+      X509_Certificate find_or_insert(std::span<const uint8_t> encoding);
+
+   private:
+      class DER_Hash final {
+         public:
+            static constexpr size_t LEN = 32;
+
+            auto operator<=>(const DER_Hash&) const = default;
+
+            size_t hash() const noexcept {
+               size_t h = 0;
+               std::memcpy(&h, m_hash.data(), sizeof(h));
+               return h;
+            }
+
+         private:
+            DER_Hash() : m_hash{} {}
+
+            friend class X509_Certificate_Cache;
+            std::array<uint8_t, LEN> m_hash;
+      };
+
+      struct DER_Hash_Fn {
+            size_t operator()(const DER_Hash& h) const noexcept { return h.hash(); }
+      };
+
+      size_t m_max_entries;
+      mutex_type m_mutex;
+      std::unordered_map<DER_Hash, X509_Certificate, DER_Hash_Fn> m_cache;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -56,7 +56,9 @@ struct X509_Certificate_Data {
 
       std::string m_fingerprint_sha1;
       std::string m_fingerprint_sha256;
-      std::array<uint8_t, 32> m_tag = {};
+
+      std::array<uint8_t, 20> m_cert_data_sha1 = {};
+      std::array<uint8_t, 32> m_cert_data_sha256 = {};
 
       AlternativeName m_subject_alt_name;
       AlternativeName m_issuer_alt_name;
@@ -303,7 +305,9 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
       data->m_subject_public_key_bitstring_sha1 = sha1->final_stdvec();
       // otherwise left as empty, and we will throw if subject_public_key_bitstring_sha1 is called
 
-      data->m_fingerprint_sha1 = create_hex_fingerprint(full_encoding, "SHA-1");
+      sha1->update(full_encoding);
+      sha1->final(data->m_cert_data_sha1);
+      data->m_fingerprint_sha1 = format_hex_fingerprint(data->m_cert_data_sha1);
    }
 
    // SHA-256 is a hard dependency of this module
@@ -315,8 +319,8 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
    data->m_subject_dn_bits_sha256 = sha256->final_stdvec();
 
    sha256->update(full_encoding);
-   sha256->final(data->m_tag);
-   data->m_fingerprint_sha256 = format_hex_fingerprint(data->m_tag);
+   sha256->final(data->m_cert_data_sha256);
+   data->m_fingerprint_sha256 = format_hex_fingerprint(data->m_cert_data_sha256);
 
    return data;
 }
@@ -416,6 +420,17 @@ const std::vector<uint8_t>& X509_Certificate::raw_issuer_dn() const {
 
 const std::vector<uint8_t>& X509_Certificate::raw_subject_dn() const {
    return data().m_subject_dn_bits;
+}
+
+std::span<const uint8_t, 20> X509_Certificate::certificate_data_sha1() const {
+   if(data().m_fingerprint_sha1.empty()) {
+      throw Not_Implemented("SHA-1 not available");
+   }
+   return data().m_cert_data_sha1;
+}
+
+std::span<const uint8_t, 32> X509_Certificate::certificate_data_sha256() const {
+   return data().m_cert_data_sha256;
 }
 
 bool X509_Certificate::is_CA_cert() const {
@@ -660,7 +675,7 @@ std::string X509_Certificate::fingerprint(std::string_view hash_name) const {
 }
 
 X509_Certificate::Tag X509_Certificate::tag() const {
-   return Tag(data().m_tag);
+   return Tag(data().m_cert_data_sha256);
 }
 
 bool X509_Certificate::matches_dns_name(std::string_view name) const {

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -85,13 +85,8 @@ X509_Certificate::X509_Certificate(DataSource& src) {
    load_data(src);
 }
 
-X509_Certificate::X509_Certificate(const std::vector<uint8_t>& vec) {
-   DataSource_Memory src(vec.data(), vec.size());
-   load_data(src);
-}
-
-X509_Certificate::X509_Certificate(const uint8_t data[], size_t len) {
-   DataSource_Memory src(data, len);
+X509_Certificate::X509_Certificate(std::span<const uint8_t> in) {
+   DataSource_Memory src(in);
    load_data(src);
 }
 

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -12,6 +12,7 @@
 #include <array>
 #include <cstring>
 #include <memory>
+#include <span>
 
 namespace Botan {
 
@@ -137,6 +138,16 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       * SHA-256 of Raw subject DN
       */
       const std::vector<uint8_t>& raw_subject_dn_sha256() const;
+
+      /**
+      * SHA-1 of the entire certificate DER encoding
+      */
+      std::span<const uint8_t, 20> certificate_data_sha1() const;
+
+      /**
+      * SHA-256 of the entire certificate DER encoding
+      */
+      std::span<const uint8_t, 32> certificate_data_sha256() const;
 
       /**
       * Get the notBefore of the certificate as X509_Time

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -446,14 +446,14 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       * Create a certificate from a buffer
       * @param in the buffer containing the DER-encoded certificate
       */
-      explicit X509_Certificate(const std::vector<uint8_t>& in);
+      explicit X509_Certificate(std::span<const uint8_t> in);
 
       /**
       * Create a certificate from a buffer
       * @param data the buffer containing the DER-encoded certificate
       * @param length length of data in bytes
       */
-      X509_Certificate(const uint8_t data[], size_t length);
+      X509_Certificate(const uint8_t data[], size_t length) : X509_Certificate(std::span{data, length}) {}
 
       /**
       * Create an uninitialized certificate object. Any attempts to

--- a/src/tests/test_certstor_system.cpp
+++ b/src/tests/test_certstor_system.cpp
@@ -162,6 +162,7 @@ Test::Result find_certs_by_subject_dn_and_key_id(Botan::Certificate_Store& certs
          auto cns = certs.front().subject_dn().get_attribute("CN");
          result.test_sz_eq("exactly one CN", cns.size(), 1);
          result.test_str_eq("CN", cns.front(), get_subject_cn());
+         result.test_is_true("returned cert is considered contained", certstore.contains(certs.front()));
       }
    } catch(std::exception& e) {
       result.test_failure(e.what());
@@ -186,6 +187,11 @@ Test::Result find_all_certs_by_subject_dn(Botan::Certificate_Store& certstore) {
          if(certs[i - 1] == certs[i]) {
             result.test_failure("find_all_certs produced duplicated result");
          }
+      }
+
+      // check all returned certs are considered contained
+      for(const auto& cert : certs) {
+         result.test_is_true("contains returns true", certstore.contains(cert));
       }
 
       if(result.test_is_true("result not empty", !certs.empty())) {
@@ -237,6 +243,7 @@ Test::Result find_cert_by_issuer_dn_and_serial_number(Botan::Certificate_Store& 
          result.test_sz_eq("exactly one CN", cns.size(), 1);
          result.test_str_eq("CN", cns.front(), get_subject_cn());
          result.test_bin_eq("serial number", cert->serial_number(), get_serial_number());
+         result.test_is_true("returned cert is considered contained", certstore.contains(cert.value()));
       }
    } catch(std::exception& e) {
       result.test_failure(e.what());
@@ -286,6 +293,11 @@ Test::Result certificate_matching_with_dn_normalization(Botan::Certificate_Store
          result.test_str_eq(
             "it is the correct cert", certs.front().subject_dn().get_first_attribute("CN"), get_subject_cn());
          result.test_str_eq("it is the correct cert", cert->subject_dn().get_first_attribute("CN"), get_subject_cn());
+      }
+
+      // check all returned certs are considered contained
+      for(const auto& ret : certs) {
+         result.test_is_true("contains returns true", certstore.contains(ret));
       }
    } catch(std::exception& e) {
       result.test_failure(e.what());


### PR DESCRIPTION
@reneme I don't know if you have any special interest re the Windows store but wanted to bring to your attention the cert cache, and the new possibility of directly implementing `contains`, both of which likely will also be beneficial for the macOS system store. I was able to do this one using MinGW+Wine but don't think there is anything similar for Mac APIs on Linux.