### PR TITLE
chore(modernize-loop-convert): Replace index-based loops with range-for

### DIFF
--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -216,9 +216,9 @@ void Streebog::compress_64(const uint64_t M[], bool last_block) {
       hN[i] ^= M[i];
    }
 
-   for(size_t i = 0; i < 12; ++i) {  // NOLINT(modernize-loop-convert)
+   for(const auto& round_constant : STREEBOG_C) {
       for(size_t j = 0; j != 8; ++j) {
-         A[j] ^= force_le(STREEBOG_C[i][7 - j]);
+         A[j] ^= force_le(round_constant[7 - j]);
       }
       lps(A);
 

--- a/src/lib/pbkdf/argon2/argon2.cpp
+++ b/src/lib/pbkdf/argon2/argon2.cpp
@@ -85,8 +85,8 @@ void extract_key(uint8_t output[], size_t output_len, const secure_vector<uint64
    if(output_len <= 64) {
       auto blake2b = HashFunction::create_or_throw(fmt("BLAKE2b({})", output_len * 8));
       blake2b->update_le(static_cast<uint32_t>(output_len));
-      for(size_t i = 0; i != 128; ++i) {  // NOLINT(modernize-loop-convert)
-         blake2b->update_le(sum[i]);
+      for(const uint64_t lane_word : sum) {
+         blake2b->update_le(lane_word);
       }
       blake2b->final(output);
    } else {
@@ -94,8 +94,8 @@ void extract_key(uint8_t output[], size_t output_len, const secure_vector<uint64
 
       auto blake2b = HashFunction::create_or_throw("BLAKE2b(512)");
       blake2b->update_le(static_cast<uint32_t>(output_len));
-      for(size_t i = 0; i != 128; ++i) {  // NOLINT(modernize-loop-convert)
-         blake2b->update_le(sum[i]);
+      for(const uint64_t lane_word : sum) {
+         blake2b->update_le(lane_word);
       }
       blake2b->final(std::span{T});
 

--- a/src/lib/permutations/keccak_perm/keccak_perm_avx512/keccak_perm_avx512.cpp
+++ b/src/lib/permutations/keccak_perm/keccak_perm_avx512/keccak_perm_avx512.cpp
@@ -140,9 +140,8 @@ void BOTAN_FN_ISA_AVX512 Keccak_Permutation::permute_avx512() {
       SIMD_5x64::load(&S[20]),
    };
 
-   // NOLINTNEXTLINE(modernize-loop-convert)
-   for(size_t i = 0; i != 24; ++i) {
-      Keccak_Permutation_round_avx512(X.data(), RC[i]);
+   for(const uint64_t round_constant : RC) {
+      Keccak_Permutation_round_avx512(X.data(), round_constant);
    }
 
    for(size_t i = 0; i != 5; ++i) {


### PR DESCRIPTION
Fixes for clang-tidy “modernize loop conversion” warnings (not include Botan4 TODOs). NOLINT suppressions were removed. 