### PR TITLE
chore(IWYU): Remove redundant <vector> includes in favor of secmem.h

### DIFF
--- a/src/lib/asn1/der_enc.h
+++ b/src/lib/asn1/der_enc.h
@@ -13,7 +13,6 @@
 #include <functional>
 #include <optional>
 #include <span>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/filters/filter.h
+++ b/src/lib/filters/filter.h
@@ -12,7 +12,6 @@
 #include <botan/secmem.h>
 #include <span>
 #include <string>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/misc/tss/tss.h
+++ b/src/lib/misc/tss/tss.h
@@ -10,7 +10,6 @@
 
 #include <botan/secmem.h>
 #include <string>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/modes/cipher_mode.h
+++ b/src/lib/modes/cipher_mode.h
@@ -15,7 +15,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/prov/pkcs11/p11.h
+++ b/src/lib/prov/pkcs11/p11.h
@@ -15,7 +15,6 @@
 
 #include <map>
 #include <string>
-#include <vector>
 
 #if defined(_MSC_VER)
    // PKCS #11 v3.2, section 2.1 - Structure packing

--- a/src/lib/prov/pkcs11/p11_object.h
+++ b/src/lib/prov/pkcs11/p11_object.h
@@ -17,7 +17,6 @@
 #include <functional>
 #include <list>
 #include <string>
-#include <vector>
 
 namespace Botan::PKCS11 {
 

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -15,7 +15,6 @@
 #include <optional>
 #include <span>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -20,7 +20,6 @@
 #include <optional>
 #include <string>
 #include <string_view>
-#include <vector>
 
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
    #include <botan/ec_point.h>

--- a/src/lib/pubkey/hss_lms/lm_ots.h
+++ b/src/lib/pubkey/hss_lms/lm_ots.h
@@ -15,7 +15,6 @@
 #include <span>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -33,7 +33,6 @@
 #endif
 
 #include <memory>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -11,7 +11,6 @@
 #include <botan/secmem.h>
 #include <botan/xmss_parameters.h>
 #include <botan/internal/xmss_address.h>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/pubkey/xmss/xmss_wots.h
+++ b/src/lib/pubkey/xmss/xmss_wots.h
@@ -12,7 +12,6 @@
 #include <botan/secmem.h>
 #include <botan/xmss_parameters.h>
 #include <botan/internal/xmss_address.h>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/stream/stream_cipher.h
+++ b/src/lib/stream/stream_cipher.h
@@ -14,7 +14,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/tls/tls12/tls_record.h
+++ b/src/lib/tls/tls12/tls_record.h
@@ -16,7 +16,6 @@
 #include <botan/tls_version.h>
 #include <functional>
 #include <memory>
-#include <vector>
 
 namespace Botan {
 

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -14,7 +14,6 @@
 #include <optional>
 #include <span>
 #include <variant>
-#include <vector>
 
 namespace Botan::TLS {
 

--- a/src/lib/tls/tls_reader.h
+++ b/src/lib/tls/tls_reader.h
@@ -14,7 +14,6 @@
 #include <botan/internal/mem_utils.h>
 #include <span>
 #include <string>
-#include <vector>
 
 namespace Botan::TLS {
 

--- a/src/lib/xof/xof.h
+++ b/src/lib/xof/xof.h
@@ -15,7 +15,6 @@
 #include <memory>
 #include <string>
 #include <string_view>
-#include <vector>
 
 namespace Botan {
 

--- a/src/tests/test_bufcomp.cpp
+++ b/src/tests/test_bufcomp.cpp
@@ -15,7 +15,6 @@
 #include <array>
 #include <cstring>
 #include <string>
-#include <vector>
 
 namespace Botan_Tests {
 

--- a/src/tests/test_strong_type.cpp
+++ b/src/tests/test_strong_type.cpp
@@ -18,7 +18,6 @@
 #include <map>
 #include <sstream>
 #include <string>
-#include <vector>
 
 namespace Botan_Tests {
 


### PR DESCRIPTION
Based on the IWYU pragma directive in the `secmem.h` file;

```cpp
#ifndef BOTAN_SECURE_MEMORY_BUFFERS_H_
#define BOTAN_SECURE_MEMORY_BUFFERS_H_

#include <botan/allocator.h>
#include <botan/types.h>  // IWYU pragma: export
#include <span>
#include <type_traits>
#include <vector>  // IWYU pragma: export
```

The `vector` includes found in the same file as `secmem.h` have been removed. **No changes were made to those included indirectly from other header files.**

Updates:
02.05.2026: Rebased the main.
24.05.2026: Rebased the main.