### PR TITLE
refactor(streebog): Replace memcpy with typecast_copy

### DIFF
--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -188,15 +188,16 @@ void Streebog::final_result(std::span<uint8_t> output) {
    compress(m_buffer.consume().data(), true);
 
    compress_64(m_S.data(), true);
-   // FIXME
-   std::memcpy(output.data(), &m_h[8 - output_length() / 8], output_length());
+
+   const size_t offset = 8 - output_length() / 8;
+   const size_t count = output_length() / sizeof(uint64_t);
+   typecast_copy(output, std::span<const uint64_t>(&m_h[offset], count));
    clear();
 }
 
 void Streebog::compress(const uint8_t input[], bool last_block) {
    uint64_t M[8];
-   std::memcpy(M, input, 64);
-
+   typecast_copy(M, std::span<const uint8_t>(input, 64));
    compress_64(M, last_block);
 }
 


### PR DESCRIPTION
This changes involve ending the use of `memcpy` for two different types in the `streebog.cpp` file and switching to `typecast_copy`, which is not deprecated (does not have a todo message). This was done to resolve the `FIXME` message. Since the message was added quite a while ago, it may be necessary to check it.

FIXME Message
```cpp
// FIXME
std::memcpy(output.data(), &m_h[8 - output_length() / 8], output_length());
clear();
```

Commit Message (https://github.com/randombit/botan/commit/432d31546eb335bb96c6b2a8c58f0168266387ec)
```bash
Avoid calling memset, memcpy within library code
Prefer using wrappers in mem_utils for this.

Current exception is where memcpy is being used to convert between
two different types, since copy_mem requires input and output
pointers have the same type. There should be a new function to
handle conversion-via-memcpy operation.
```

---
*I decided this is a hot path and that this change shouldn't be made unless it's for C++23. So I updated the text.*
~Additionally;
I noticed it while make this change. It is possible to get rid of the `reinterpret_cast` call in the `lps` function in the `streebog.cpp` file. However, this results in an extra 64 bytes being copied. (~This will disappear when C++23 `std::as_bytes` is ready for use.~) If you want, I can add it to this branch or new branch for this implementation.~

```diff
inline void lps(uint64_t block[8]) {
const uint64_t block2[8] = {block[0], block[1], block[2], block[3], block[4], block[5], block[6], block[7]};
- const std::span<const uint8_t> r{reinterpret_cast<const uint8_t*>(block2), 64};
+ const auto r = std::bit_cast<std::array<uint8_t, 64>>(block2);
```