### PR TITLE
refactor(aes_ni): Replace raw __m128i intrinsics with SIMD_4x32 in key schedules

### DIFF
--- a/src/lib/block/aes/aes_ni/aes_ni.cpp
+++ b/src/lib/block/aes/aes_ni/aes_ni.cpp
@@ -19,53 +19,50 @@ namespace {
 // NOLINTBEGIN(portability-simd-intrinsics)
 
 template <uint8_t RC>
-BOTAN_FN_ISA_AESNI inline __m128i aes_128_key_expansion(__m128i key, __m128i key_getting_rcon) {
-   __m128i key_with_rcon = _mm_aeskeygenassist_si128(key_getting_rcon, RC);
+BOTAN_FN_ISA_AESNI inline SIMD_4x32 aes_128_key_expansion(SIMD_4x32 key, SIMD_4x32 key_getting_rcon) {
+   __m128i key_with_rcon = _mm_aeskeygenassist_si128(key_getting_rcon.raw(), RC);
    key_with_rcon = _mm_shuffle_epi32(key_with_rcon, _MM_SHUFFLE(3, 3, 3, 3));
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   return _mm_xor_si128(key, key_with_rcon);
+   key ^= key.shift_elems_left<1>();
+   key ^= key.shift_elems_left<1>();
+   key ^= key.shift_elems_left<1>();
+   key ^= SIMD_4x32(key_with_rcon);
+   return key;
 }
 
 BOTAN_FN_ISA_AESNI
 void aes_192_key_expansion(
-   __m128i* K1, __m128i* K2, __m128i key2_with_rcon, secure_vector<uint32_t>& out, size_t offset) {
-   __m128i key1 = *K1;
-   __m128i key2 = *K2;
+   SIMD_4x32& K1, SIMD_4x32& K2, SIMD_4x32 key2_with_rcon, secure_vector<uint32_t>& out, size_t offset) {
+   const SIMD_4x32 rcon = SIMD_4x32(_mm_shuffle_epi32(key2_with_rcon.raw(), _MM_SHUFFLE(1, 1, 1, 1)));
+   K1 ^= K1.shift_elems_left<1>();
+   K1 ^= K1.shift_elems_left<1>();
+   K1 ^= K1.shift_elems_left<1>();
+   K1 ^= rcon;
 
-   key2_with_rcon = _mm_shuffle_epi32(key2_with_rcon, _MM_SHUFFLE(1, 1, 1, 1));
-   key1 = _mm_xor_si128(key1, _mm_slli_si128(key1, 4));
-   key1 = _mm_xor_si128(key1, _mm_slli_si128(key1, 4));
-   key1 = _mm_xor_si128(key1, _mm_slli_si128(key1, 4));
-   key1 = _mm_xor_si128(key1, key2_with_rcon);
+   K1.store_le(&out[offset]);
 
-   *K1 = key1;
-   _mm_storeu_si128(reinterpret_cast<__m128i*>(&out[offset]), key1);
-
-   if(offset == 48) {  // last key
+   if(offset == 48) {
       return;
    }
 
-   key2 = _mm_xor_si128(key2, _mm_slli_si128(key2, 4));
-   key2 = _mm_xor_si128(key2, _mm_shuffle_epi32(key1, _MM_SHUFFLE(3, 3, 3, 3)));
+   K2 ^= K2.shift_elems_left<1>();
+   K2 ^= SIMD_4x32(_mm_shuffle_epi32(K1.raw(), _MM_SHUFFLE(3, 3, 3, 3)));
 
-   *K2 = key2;
-   out[offset + 4] = _mm_cvtsi128_si32(key2);
-   out[offset + 5] = _mm_cvtsi128_si32(_mm_srli_si128(key2, 4));
+   out[offset + 4] = _mm_cvtsi128_si32(K2.raw());
+   out[offset + 5] = _mm_cvtsi128_si32(K2.shift_elems_right<1>().raw());
 }
 
 /*
 * The second half of the AES-256 key expansion (other half same as AES-128)
 */
-BOTAN_FN_ISA_AESNI __m128i aes_256_key_expansion(__m128i key, __m128i key2) {
-   __m128i key_with_rcon = _mm_aeskeygenassist_si128(key2, 0x00);
+BOTAN_FN_ISA_AESNI SIMD_4x32 aes_256_key_expansion(SIMD_4x32 key, SIMD_4x32 key2) {
+   __m128i key_with_rcon = _mm_aeskeygenassist_si128(key2.raw(), 0x00);
    key_with_rcon = _mm_shuffle_epi32(key_with_rcon, _MM_SHUFFLE(2, 2, 2, 2));
 
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   key = _mm_xor_si128(key, _mm_slli_si128(key, 4));
-   return _mm_xor_si128(key, key_with_rcon);
+   key ^= key.shift_elems_left<1>();
+   key ^= key.shift_elems_left<1>();
+   key ^= key.shift_elems_left<1>();
+   key ^= SIMD_4x32(key_with_rcon);
+   return key;
 }
 
 BOTAN_FORCE_INLINE BOTAN_FN_ISA_AESNI void keyxor(
@@ -122,6 +119,10 @@ BOTAN_FORCE_INLINE BOTAN_FN_ISA_AESNI void aesdeclast(
    B1 = SIMD_4x32(_mm_aesdeclast_si128(B1.raw(), K.raw()));
    B2 = SIMD_4x32(_mm_aesdeclast_si128(B2.raw(), K.raw()));
    B3 = SIMD_4x32(_mm_aesdeclast_si128(B3.raw(), K.raw()));
+}
+
+BOTAN_FORCE_INLINE BOTAN_FN_ISA_AESNI SIMD_4x32 aesimc(SIMD_4x32 B) {
+   return SIMD_4x32(_mm_aesimc_si128(B.raw()));
 }
 
 // NOLINTEND(portability-simd-intrinsics)
@@ -261,49 +262,42 @@ BOTAN_FN_ISA_AESNI void AES_128::aesni_key_schedule(const uint8_t key[], size_t 
    m_EK.resize(44);
    m_DK.resize(44);
 
-   // NOLINTBEGIN(portability-simd-intrinsics) TODO convert to using SIMD_4x32
+   const SIMD_4x32 K0 = SIMD_4x32::load_le(key);
+   const SIMD_4x32 K1 = aes_128_key_expansion<0x01>(K0, K0);
+   const SIMD_4x32 K2 = aes_128_key_expansion<0x02>(K1, K1);
+   const SIMD_4x32 K3 = aes_128_key_expansion<0x04>(K2, K2);
+   const SIMD_4x32 K4 = aes_128_key_expansion<0x08>(K3, K3);
+   const SIMD_4x32 K5 = aes_128_key_expansion<0x10>(K4, K4);
+   const SIMD_4x32 K6 = aes_128_key_expansion<0x20>(K5, K5);
+   const SIMD_4x32 K7 = aes_128_key_expansion<0x40>(K6, K6);
+   const SIMD_4x32 K8 = aes_128_key_expansion<0x80>(K7, K7);
+   const SIMD_4x32 K9 = aes_128_key_expansion<0x1B>(K8, K8);
+   const SIMD_4x32 K10 = aes_128_key_expansion<0x36>(K9, K9);
 
-   const __m128i K0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key));
-   const __m128i K1 = aes_128_key_expansion<0x01>(K0, K0);
-   const __m128i K2 = aes_128_key_expansion<0x02>(K1, K1);
-   const __m128i K3 = aes_128_key_expansion<0x04>(K2, K2);
-   const __m128i K4 = aes_128_key_expansion<0x08>(K3, K3);
-   const __m128i K5 = aes_128_key_expansion<0x10>(K4, K4);
-   const __m128i K6 = aes_128_key_expansion<0x20>(K5, K5);
-   const __m128i K7 = aes_128_key_expansion<0x40>(K6, K6);
-   const __m128i K8 = aes_128_key_expansion<0x80>(K7, K7);
-   const __m128i K9 = aes_128_key_expansion<0x1B>(K8, K8);
-   const __m128i K10 = aes_128_key_expansion<0x36>(K9, K9);
-
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
-   _mm_storeu_si128(EK_mm, K0);
-   _mm_storeu_si128(EK_mm + 1, K1);
-   _mm_storeu_si128(EK_mm + 2, K2);
-   _mm_storeu_si128(EK_mm + 3, K3);
-   _mm_storeu_si128(EK_mm + 4, K4);
-   _mm_storeu_si128(EK_mm + 5, K5);
-   _mm_storeu_si128(EK_mm + 6, K6);
-   _mm_storeu_si128(EK_mm + 7, K7);
-   _mm_storeu_si128(EK_mm + 8, K8);
-   _mm_storeu_si128(EK_mm + 9, K9);
-   _mm_storeu_si128(EK_mm + 10, K10);
+   K0.store_le(&m_EK[4 * 0]);
+   K1.store_le(&m_EK[4 * 1]);
+   K2.store_le(&m_EK[4 * 2]);
+   K3.store_le(&m_EK[4 * 3]);
+   K4.store_le(&m_EK[4 * 4]);
+   K5.store_le(&m_EK[4 * 5]);
+   K6.store_le(&m_EK[4 * 6]);
+   K7.store_le(&m_EK[4 * 7]);
+   K8.store_le(&m_EK[4 * 8]);
+   K9.store_le(&m_EK[4 * 9]);
+   K10.store_le(&m_EK[4 * 10]);
 
    // Now generate decryption keys
-
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
-   _mm_storeu_si128(DK_mm, K10);
-   _mm_storeu_si128(DK_mm + 1, _mm_aesimc_si128(K9));
-   _mm_storeu_si128(DK_mm + 2, _mm_aesimc_si128(K8));
-   _mm_storeu_si128(DK_mm + 3, _mm_aesimc_si128(K7));
-   _mm_storeu_si128(DK_mm + 4, _mm_aesimc_si128(K6));
-   _mm_storeu_si128(DK_mm + 5, _mm_aesimc_si128(K5));
-   _mm_storeu_si128(DK_mm + 6, _mm_aesimc_si128(K4));
-   _mm_storeu_si128(DK_mm + 7, _mm_aesimc_si128(K3));
-   _mm_storeu_si128(DK_mm + 8, _mm_aesimc_si128(K2));
-   _mm_storeu_si128(DK_mm + 9, _mm_aesimc_si128(K1));
-   _mm_storeu_si128(DK_mm + 10, K0);
-
-   // NOLINTEND(portability-simd-intrinsics)
+   K10.store_le(&m_DK[4 * 0]);
+   aesimc(K9).store_le(&m_DK[4 * 1]);
+   aesimc(K8).store_le(&m_DK[4 * 2]);
+   aesimc(K7).store_le(&m_DK[4 * 3]);
+   aesimc(K6).store_le(&m_DK[4 * 4]);
+   aesimc(K5).store_le(&m_DK[4 * 5]);
+   aesimc(K4).store_le(&m_DK[4 * 6]);
+   aesimc(K3).store_le(&m_DK[4 * 7]);
+   aesimc(K2).store_le(&m_DK[4 * 8]);
+   aesimc(K1).store_le(&m_DK[4 * 9]);
+   K0.store_le(&m_DK[4 * 10]);
 }
 
 /*
@@ -453,42 +447,34 @@ BOTAN_FN_ISA_AESNI void AES_192::aesni_key_schedule(const uint8_t key[], size_t 
    m_EK.resize(52);
    m_DK.resize(52);
 
-   // NOLINTBEGIN(portability-simd-intrinsics) TODO convert to using SIMD_4x32
-
-   __m128i K0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key));
-   __m128i K1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 8));
-   K1 = _mm_srli_si128(K1, 8);
+   SIMD_4x32 K0 = SIMD_4x32::load_le(key);
+   SIMD_4x32 K1 = SIMD_4x32::load_le(key + 8).shift_elems_right<2>();
 
    load_le(m_EK.data(), key, 6);
 
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x01), m_EK, 6);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x02), m_EK, 12);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x04), m_EK, 18);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x08), m_EK, 24);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x10), m_EK, 30);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x20), m_EK, 36);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x40), m_EK, 42);
-   aes_192_key_expansion(&K0, &K1, _mm_aeskeygenassist_si128(K1, 0x80), m_EK, 48);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x01)), m_EK, 6);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x02)), m_EK, 12);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x04)), m_EK, 18);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x08)), m_EK, 24);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x10)), m_EK, 30);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x20)), m_EK, 36);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x40)), m_EK, 42);
+   aes_192_key_expansion(K0, K1, SIMD_4x32(_mm_aeskeygenassist_si128(K1.raw(), 0x80)), m_EK, 48);
 
    // Now generate decryption keys
-   const __m128i* EK_mm = reinterpret_cast<const __m128i*>(m_EK.data());
-
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
-   _mm_storeu_si128(DK_mm, _mm_loadu_si128(EK_mm + 12));
-   _mm_storeu_si128(DK_mm + 1, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 11)));
-   _mm_storeu_si128(DK_mm + 2, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 10)));
-   _mm_storeu_si128(DK_mm + 3, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 9)));
-   _mm_storeu_si128(DK_mm + 4, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 8)));
-   _mm_storeu_si128(DK_mm + 5, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 7)));
-   _mm_storeu_si128(DK_mm + 6, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 6)));
-   _mm_storeu_si128(DK_mm + 7, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 5)));
-   _mm_storeu_si128(DK_mm + 8, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 4)));
-   _mm_storeu_si128(DK_mm + 9, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 3)));
-   _mm_storeu_si128(DK_mm + 10, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 2)));
-   _mm_storeu_si128(DK_mm + 11, _mm_aesimc_si128(_mm_loadu_si128(EK_mm + 1)));
-   _mm_storeu_si128(DK_mm + 12, _mm_loadu_si128(EK_mm + 0));
-
-   // NOLINTEND(portability-simd-intrinsics)
+   SIMD_4x32::load_le(&m_EK[4 * 12]).store_le(&m_DK[4 * 0]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 11])).store_le(&m_DK[4 * 1]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 10])).store_le(&m_DK[4 * 2]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 9])).store_le(&m_DK[4 * 3]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 8])).store_le(&m_DK[4 * 4]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 7])).store_le(&m_DK[4 * 5]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 6])).store_le(&m_DK[4 * 6]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 5])).store_le(&m_DK[4 * 7]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 4])).store_le(&m_DK[4 * 8]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 3])).store_le(&m_DK[4 * 9]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 2])).store_le(&m_DK[4 * 10]);
+   aesimc(SIMD_4x32::load_le(&m_EK[4 * 1])).store_le(&m_DK[4 * 11]);
+   SIMD_4x32::load_le(&m_EK[4 * 0]).store_le(&m_DK[4 * 12]);
 }
 
 /*
@@ -650,67 +636,60 @@ BOTAN_FN_ISA_AESNI void AES_256::aesni_key_schedule(const uint8_t key[], size_t 
    m_EK.resize(60);
    m_DK.resize(60);
 
-   // NOLINTBEGIN(portability-simd-intrinsics) TODO convert to using SIMD_4x32
+   const SIMD_4x32 K0 = SIMD_4x32::load_le(key);
+   const SIMD_4x32 K1 = SIMD_4x32::load_le(key + 16);
 
-   const __m128i K0 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key));
-   const __m128i K1 = _mm_loadu_si128(reinterpret_cast<const __m128i*>(key + 16));
+   const SIMD_4x32 K2 = aes_128_key_expansion<0x01>(K0, K1);
+   const SIMD_4x32 K3 = aes_256_key_expansion(K1, K2);
 
-   const __m128i K2 = aes_128_key_expansion<0x01>(K0, K1);
-   const __m128i K3 = aes_256_key_expansion(K1, K2);
+   const SIMD_4x32 K4 = aes_128_key_expansion<0x02>(K2, K3);
+   const SIMD_4x32 K5 = aes_256_key_expansion(K3, K4);
 
-   const __m128i K4 = aes_128_key_expansion<0x02>(K2, K3);
-   const __m128i K5 = aes_256_key_expansion(K3, K4);
+   const SIMD_4x32 K6 = aes_128_key_expansion<0x04>(K4, K5);
+   const SIMD_4x32 K7 = aes_256_key_expansion(K5, K6);
 
-   const __m128i K6 = aes_128_key_expansion<0x04>(K4, K5);
-   const __m128i K7 = aes_256_key_expansion(K5, K6);
+   const SIMD_4x32 K8 = aes_128_key_expansion<0x08>(K6, K7);
+   const SIMD_4x32 K9 = aes_256_key_expansion(K7, K8);
 
-   const __m128i K8 = aes_128_key_expansion<0x08>(K6, K7);
-   const __m128i K9 = aes_256_key_expansion(K7, K8);
+   const SIMD_4x32 K10 = aes_128_key_expansion<0x10>(K8, K9);
+   const SIMD_4x32 K11 = aes_256_key_expansion(K9, K10);
 
-   const __m128i K10 = aes_128_key_expansion<0x10>(K8, K9);
-   const __m128i K11 = aes_256_key_expansion(K9, K10);
+   const SIMD_4x32 K12 = aes_128_key_expansion<0x20>(K10, K11);
+   const SIMD_4x32 K13 = aes_256_key_expansion(K11, K12);
 
-   const __m128i K12 = aes_128_key_expansion<0x20>(K10, K11);
-   const __m128i K13 = aes_256_key_expansion(K11, K12);
+   const SIMD_4x32 K14 = aes_128_key_expansion<0x40>(K12, K13);
 
-   const __m128i K14 = aes_128_key_expansion<0x40>(K12, K13);
+   K0.store_le(&m_EK[4 * 0]);
+   K1.store_le(&m_EK[4 * 1]);
+   K2.store_le(&m_EK[4 * 2]);
+   K3.store_le(&m_EK[4 * 3]);
+   K4.store_le(&m_EK[4 * 4]);
+   K5.store_le(&m_EK[4 * 5]);
+   K6.store_le(&m_EK[4 * 6]);
+   K7.store_le(&m_EK[4 * 7]);
+   K8.store_le(&m_EK[4 * 8]);
+   K9.store_le(&m_EK[4 * 9]);
+   K10.store_le(&m_EK[4 * 10]);
+   K11.store_le(&m_EK[4 * 11]);
+   K12.store_le(&m_EK[4 * 12]);
+   K13.store_le(&m_EK[4 * 13]);
+   K14.store_le(&m_EK[4 * 14]);
 
-   __m128i* EK_mm = reinterpret_cast<__m128i*>(m_EK.data());
-   _mm_storeu_si128(EK_mm, K0);
-   _mm_storeu_si128(EK_mm + 1, K1);
-   _mm_storeu_si128(EK_mm + 2, K2);
-   _mm_storeu_si128(EK_mm + 3, K3);
-   _mm_storeu_si128(EK_mm + 4, K4);
-   _mm_storeu_si128(EK_mm + 5, K5);
-   _mm_storeu_si128(EK_mm + 6, K6);
-   _mm_storeu_si128(EK_mm + 7, K7);
-   _mm_storeu_si128(EK_mm + 8, K8);
-   _mm_storeu_si128(EK_mm + 9, K9);
-   _mm_storeu_si128(EK_mm + 10, K10);
-   _mm_storeu_si128(EK_mm + 11, K11);
-   _mm_storeu_si128(EK_mm + 12, K12);
-   _mm_storeu_si128(EK_mm + 13, K13);
-   _mm_storeu_si128(EK_mm + 14, K14);
-
-   // Now generate decryption keys
-   __m128i* DK_mm = reinterpret_cast<__m128i*>(m_DK.data());
-   _mm_storeu_si128(DK_mm, K14);
-   _mm_storeu_si128(DK_mm + 1, _mm_aesimc_si128(K13));
-   _mm_storeu_si128(DK_mm + 2, _mm_aesimc_si128(K12));
-   _mm_storeu_si128(DK_mm + 3, _mm_aesimc_si128(K11));
-   _mm_storeu_si128(DK_mm + 4, _mm_aesimc_si128(K10));
-   _mm_storeu_si128(DK_mm + 5, _mm_aesimc_si128(K9));
-   _mm_storeu_si128(DK_mm + 6, _mm_aesimc_si128(K8));
-   _mm_storeu_si128(DK_mm + 7, _mm_aesimc_si128(K7));
-   _mm_storeu_si128(DK_mm + 8, _mm_aesimc_si128(K6));
-   _mm_storeu_si128(DK_mm + 9, _mm_aesimc_si128(K5));
-   _mm_storeu_si128(DK_mm + 10, _mm_aesimc_si128(K4));
-   _mm_storeu_si128(DK_mm + 11, _mm_aesimc_si128(K3));
-   _mm_storeu_si128(DK_mm + 12, _mm_aesimc_si128(K2));
-   _mm_storeu_si128(DK_mm + 13, _mm_aesimc_si128(K1));
-   _mm_storeu_si128(DK_mm + 14, K0);
-
-   // NOLINTEND(portability-simd-intrinsics)
+   K14.store_le(&m_DK[4 * 0]);
+   aesimc(K13).store_le(&m_DK[4 * 1]);
+   aesimc(K12).store_le(&m_DK[4 * 2]);
+   aesimc(K11).store_le(&m_DK[4 * 3]);
+   aesimc(K10).store_le(&m_DK[4 * 4]);
+   aesimc(K9).store_le(&m_DK[4 * 5]);
+   aesimc(K8).store_le(&m_DK[4 * 6]);
+   aesimc(K7).store_le(&m_DK[4 * 7]);
+   aesimc(K6).store_le(&m_DK[4 * 8]);
+   aesimc(K5).store_le(&m_DK[4 * 9]);
+   aesimc(K4).store_le(&m_DK[4 * 10]);
+   aesimc(K3).store_le(&m_DK[4 * 11]);
+   aesimc(K2).store_le(&m_DK[4 * 12]);
+   aesimc(K1).store_le(&m_DK[4 * 13]);
+   K0.store_le(&m_DK[4 * 14]);
 }
 
 }  // namespace Botan


### PR DESCRIPTION
Resolves the TODO comment in `aes_ni.cpp` by converting AES-128, AES-192, and AES-256 key schedule functions to use `SIMD_4x32` instead of raw `__m128i` intrinsics.

```cpp
// NOLINTBEGIN(portability-simd-intrinsics) TODO convert to using SIMD_4x32
```

There was no performance difference compared to the `master` branch.  To be honest, I wasn’t expecting one anyway due to force inline. When I run the test multiple times, I get fairly close values. But here are the one examples;

_This Branch:_

> AES-128 [aesni] encrypt buffer size 1024 bytes: 13540.578 MiB/sec 0.19 cycles/byte (40621.75 MiB in 3000.00 ms)
> AES-128 [aesni] decrypt buffer size 1024 bytes: 13523.766 MiB/sec 0.19 cycles/byte (40571.31 MiB in 3000.00 ms)
> AES-192 [aesni] encrypt buffer size 1024 bytes: 11268.424 MiB/sec 0.23 cycles/byte (33805.31 MiB in 3000.00 ms)
> AES-192 [aesni] decrypt buffer size 1024 bytes: 11270.326 MiB/sec 0.23 cycles/byte (33811.00 MiB in 3000.00 ms)
> AES-256 [aesni] encrypt buffer size 1024 bytes: 9531.211 MiB/sec 0.27 cycles/byte (28593.69 MiB in 3000.01 ms)
> AES-256 [aesni] decrypt buffer size 1024 bytes: 9453.548 MiB/sec 0.27 cycles/byte (28360.69 MiB in 3000.00 ms)

_Master:_

> AES-128 [aesni] encrypt buffer size 1024 bytes: 13547.448 MiB/sec 0.19 cycles/byte (40642.38 MiB in 3000.00 ms)
> AES-128 [aesni] decrypt buffer size 1024 bytes: 13518.252 MiB/sec 0.19 cycles/byte (40554.81 MiB in 3000.00 ms)
> AES-192 [aesni] encrypt buffer size 1024 bytes: 11316.532 MiB/sec 0.23 cycles/byte (33949.62 MiB in 3000.00 ms)
> AES-192 [aesni] decrypt buffer size 1024 bytes: 11272.753 MiB/sec 0.23 cycles/byte (33818.31 MiB in 3000.00 ms)
> AES-256 [aesni] encrypt buffer size 1024 bytes: 9581.535 MiB/sec 0.27 cycles/byte (28744.62 MiB in 3000.00 ms)
> AES-256 [aesni] decrypt buffer size 1024 bytes: 9502.485 MiB/sec 0.27 cycles/byte (28507.50 MiB in 3000.00 ms)

---
Additional;
`SIMD` is not a I use frequently. For this reason, I wanted to treat the `TODO` messages here as an opportunity. During development, I fallowed older PRs that had been edited previously. But I am not sure full of it. I think it would be better to mark this branch draft.

With C++26, it seems like `std::simd` could be used to partially resolve future compilation complexities. https://en.cppreference.com/cpp/numeric/simd