### PR TITLE
Tighten checks on DER class tags

### DIFF
--- a/src/lib/asn1/asn1_str.cpp
+++ b/src/lib/asn1/asn1_str.cpp
@@ -88,9 +88,10 @@ void ASN1_String::encode_into(DER_Encoder& encoder) const {
 void ASN1_String::decode_from(BER_Decoder& source) {
    const BER_Object obj = source.get_next_object();
 
-   if(!is_asn1_string_type(obj.type())) {
+   if(obj.get_class() != ASN1_Class::Universal || !is_asn1_string_type(obj.type())) {
       auto typ = static_cast<uint32_t>(obj.type());
-      throw Decoding_Error(fmt("ASN1_String: Unknown string type {}", typ));
+      auto cls = static_cast<uint32_t>(obj.get_class());
+      throw Decoding_Error(fmt("ASN1_String: Unknown string type {}/{}", typ, cls));
    }
 
    m_tag = obj.type();

--- a/src/lib/asn1/asn1_time.cpp
+++ b/src/lib/asn1/asn1_time.cpp
@@ -59,6 +59,13 @@ void ASN1_Time::encode_into(DER_Encoder& der) const {
 void ASN1_Time::decode_from(BER_Decoder& source) {
    const BER_Object ber_time = source.get_next_object();
 
+   if(ber_time.get_class() != ASN1_Class::Universal ||
+      (ber_time.type() != ASN1_Type::UtcTime && ber_time.type() != ASN1_Type::GeneralizedTime)) {
+      throw Decoding_Error(fmt("ASN1_Time: Unexpected tag {}/{}",
+                               static_cast<uint32_t>(ber_time.type()),
+                               static_cast<uint32_t>(ber_time.get_class())));
+   }
+
    set_to(ASN1::to_string(ber_time), ber_time.type());
 }
 

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -123,6 +123,12 @@ void SingleResponse::decode_from(BER_Decoder& from) {
       .decode_optional(extensions, ASN1_Type(1), ASN1_Class::ContextSpecific | ASN1_Class::Constructed)
       .end_cons();
 
+   const auto cert_status_class = cert_status.get_class();
+   if(cert_status_class != ASN1_Class::ContextSpecific &&
+      cert_status_class != (ASN1_Class::ContextSpecific | ASN1_Class::Constructed)) {
+      throw Decoding_Error("OCSP::SingleResponse: certStatus has unexpected class tag");
+   }
+
    // TODO: should verify the cert_status body and decode RevokedInfo
    m_cert_status = static_cast<uint32_t>(cert_status.type());
 }

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -378,35 +378,25 @@ std::vector<uint8_t> Key_Usage::encode_inner() const {
 */
 void Key_Usage::decode_inner(const std::vector<uint8_t>& in) {
    /* RFC 5280 Section 4.2.1.3 - KeyUsage ::= BIT STRING */
-   BER_Decoder ber(in, BER_Decoder::Limits::DER());
+   std::vector<uint8_t> bits;
+   BER_Decoder(in, BER_Decoder::Limits::DER())
+      .decode(bits, ASN1_Type::BitString, ASN1_Type::BitString, ASN1_Class::Universal)
+      .verify_end();
 
-   const BER_Object obj = ber.get_next_object();
-
-   obj.assert_is_a(ASN1_Type::BitString, ASN1_Class::Universal, "usage constraint");
-
-   if(obj.length() == 2 || obj.length() == 3) {
-      uint16_t usage = 0;
-
-      const uint8_t* bits = obj.bits();
-
-      if(bits[0] >= 8) {
-         throw BER_Decoding_Error("Invalid unused bits in usage constraint");
+   const uint16_t usage = [&bits]() -> uint16_t {
+      switch(bits.size()) {
+         case 0:
+            return 0;
+         case 1:
+            return make_uint16(bits[0], 0);
+         case 2:
+            return make_uint16(bits[0], bits[1]);
+         default:
+            throw Decoding_Error("Invalid KeyUsage bitstring encoding");
       }
+   }();
 
-      const uint8_t mask = static_cast<uint8_t>(0xFF << bits[0]);
-
-      if(obj.length() == 2) {
-         usage = make_uint16(bits[1] & mask, 0);
-      } else if(obj.length() == 3) {
-         usage = make_uint16(bits[1], bits[2] & mask);
-      }
-
-      m_constraints = Key_Constraints(usage);
-   } else {
-      m_constraints = Key_Constraints(0);
-   }
-
-   ber.verify_end();
+   m_constraints = Key_Constraints(usage);
 }
 
 /*
@@ -722,19 +712,13 @@ void Authority_Information_Access::decode_inner(const std::vector<uint8_t>& in) 
       BER_Decoder info = ber.start_sequence();
 
       info.decode(oid);
+      const BER_Object name = info.get_next_object();
+      info.end_cons();
 
-      if(oid == ocsp_responder) {
-         const BER_Object name = info.get_next_object();
-
-         if(name.is_a(6, ASN1_Class::ContextSpecific)) {
-            m_ocsp_responders.push_back(ASN1::to_string(name));
-         }
-      } else if(oid == ca_issuer) {
-         const BER_Object name = info.get_next_object();
-
-         if(name.is_a(6, ASN1_Class::ContextSpecific)) {
-            m_ca_issuers.push_back(ASN1::to_string(name));
-         }
+      if(oid == ocsp_responder && name.is_a(6, ASN1_Class::ContextSpecific)) {
+         m_ocsp_responders.push_back(ASN1::to_string(name));
+      } else if(oid == ca_issuer && name.is_a(6, ASN1_Class::ContextSpecific)) {
+         m_ca_issuers.push_back(ASN1::to_string(name));
       }
    }
 
@@ -867,6 +851,10 @@ void TNAuthList::Entry::encode_into(DER_Encoder& /*to*/) const {
 
 void TNAuthList::Entry::decode_from(class BER_Decoder& ber) {
    const BER_Object obj = ber.get_next_object();
+
+   if(obj.get_class() != (ASN1_Class::ContextSpecific | ASN1_Class::Constructed)) {
+      throw Decoding_Error(fmt("Unexpected TNEntry class tag {}", static_cast<uint32_t>(obj.get_class())));
+   }
 
    const uint32_t type_tag = static_cast<Type>(obj.type_tag());
 


### PR DESCRIPTION
In various cases we were neglecting to confirm that the class tag was the expected value.