### PR TITLE
Make EC_Scalar FFI serializable

### DIFF
--- a/doc/api_ref/ffi.rst
+++ b/doc/api_ref/ffi.rst
@@ -1045,6 +1045,10 @@ EC Points and Scalars
 
    Convert from an MPI to a scalar.
 
+.. cpp:function:: int botan_ec_scalar_to_mp(botan_ec_scalar_t ec_scalar, botan_mp_t* mp)
+
+   Convert from a scalar to an MPI.
+
 .. cpp:function:: int botan_ec_point_destroy(botan_ec_point_t ec_point)
 
    Destroy an object.

--- a/src/lib/ffi/ffi.h
+++ b/src/lib/ffi/ffi.h
@@ -1461,6 +1461,13 @@ int botan_ec_scalar_random(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_gro
 BOTAN_FFI_EXPORT(3, 12)
 int botan_ec_scalar_from_mp(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_group, botan_mp_t mp);
 
+/**
+* Convert from a scalar to an MPI
+* @returns a negative number on failure, 0 on success
+*/
+BOTAN_FFI_EXPORT(3, 12)
+int botan_ec_scalar_to_mp(botan_ec_scalar_t ec_scalar, botan_mp_t* mp);
+
 BOTAN_FFI_EXPORT(3, 12) int botan_ec_point_destroy(botan_ec_point_t ec_point);
 
 /**

--- a/src/lib/ffi/ffi_ec.cpp
+++ b/src/lib/ffi/ffi_ec.cpp
@@ -216,6 +216,15 @@ int botan_ec_scalar_from_mp(botan_ec_scalar_t* ec_scalar, botan_ec_group_t ec_gr
    });
 }
 
+int botan_ec_scalar_to_mp(botan_ec_scalar_t ec_scalar, botan_mp_t* mp) {
+   if(Botan::any_null_pointers(mp)) {
+      return BOTAN_FFI_ERROR_NULL_POINTER;
+   }
+   return BOTAN_FFI_VISIT(ec_scalar, [=](const auto& sc) -> int {
+      return ffi_new_object(mp, std::make_unique<Botan::BigInt>(sc.to_bigint()));
+   });
+}
+
 // ec points
 
 int botan_ec_point_destroy(botan_ec_point_t ec_point) {

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -329,6 +329,7 @@ def _set_prototypes(dll):
     ffi_api(dll.botan_ec_scalar_destroy, [c_void_p])
     ffi_api(dll.botan_ec_scalar_random, [c_void_p, c_void_p, c_void_p])
     ffi_api(dll.botan_ec_scalar_from_mp, [c_void_p, c_void_p, c_void_p])
+    ffi_api(dll.botan_ec_scalar_to_mp, [c_void_p, c_void_p])
     ffi_api(dll.botan_ec_point_destroy, [c_void_p])
     ffi_api(dll.botan_ec_point_identity, [c_void_p, c_void_p])
     ffi_api(dll.botan_ec_point_generator, [c_void_p, c_void_p])
@@ -3071,6 +3072,12 @@ class ECScalar:
         scalar = ECScalar()
         _DLL.botan_ec_scalar_from_mp(byref(scalar.handle_()), group.handle_(), mpi.handle_())
         return scalar
+
+    def to_mpi(self) -> MPI:
+        """Convert from a scalar to an MPI."""
+        obj = c_void_p(0)
+        _DLL.botan_ec_scalar_to_mp(self.__obj, byref(obj))
+        return MPI(obj)
 
 
 class ECPoint:

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -1391,6 +1391,10 @@ iWtHjIcunpiq6+IiB8IVu7Ncu6uPKoFS/mWzTvjgdNusmgNle9p3OAbE
         group = botan.ECGroup.from_name("secp256r1")
         rng = botan.RandomNumberGenerator()
 
+        forty_two = botan.MPI(42)
+        scalar_forty_two = botan.ECScalar.from_mpi(group, forty_two)
+        self.assertEqual(forty_two, scalar_forty_two.to_mpi())
+
         identity = group.get_identity()
         generator = group.get_generator()
         one = botan.ECScalar.from_mpi(group, botan.MPI(1))

--- a/src/tests/test_ffi.cpp
+++ b/src/tests/test_ffi.cpp
@@ -5511,6 +5511,7 @@ class FFI_EC_Point_Test final : public FFI_Test {
          botan_ec_scalar_t random;
          botan_mp_t to_scalar;
          botan_ec_scalar_t from_mp;
+         botan_mp_t from_scalar;
 
          if(!Botan::EC_Group::supports_named_group("secp256r1")) {
             result.test_note("Group needed for test not supported by this build configuration.");
@@ -5523,10 +5524,13 @@ class FFI_EC_Point_Test final : public FFI_Test {
          TEST_FFI_OK(botan_ec_group_from_name, (&group, "secp256r1"));
          TEST_FFI_OK(botan_ec_scalar_random, (&random, group, rng));
          TEST_FFI_OK(botan_ec_scalar_from_mp, (&from_mp, group, to_scalar));
+         TEST_FFI_OK(botan_ec_scalar_to_mp, (from_mp, &from_scalar));
+         TEST_FFI_RC(1, botan_mp_equal, (to_scalar, from_scalar));
 
          TEST_FFI_OK(botan_ec_scalar_destroy, (random));
          TEST_FFI_OK(botan_ec_scalar_destroy, (from_mp));
          TEST_FFI_OK(botan_mp_destroy, (to_scalar));
+         TEST_FFI_OK(botan_mp_destroy, (from_scalar));
 
          botan_ec_point_t identity;
          botan_ec_point_t generator;


### PR DESCRIPTION
After #5404 added `botan_ec_privkey_get_private_key(key, &scalar)`, there is no way to actually get that private value to e.g. serialize it :sweat_smile: 