### PR TITLE
Prohibit a DH public key of p-1

### DIFF
--- a/src/lib/pubkey/dh/dh.cpp
+++ b/src/lib/pubkey/dh/dh.cpp
@@ -132,7 +132,7 @@ class DH_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
 secure_vector<uint8_t> DH_KA_Operation::raw_agree(const uint8_t w[], size_t w_len) {
    BigInt v = BigInt::from_bytes(std::span{w, w_len});
 
-   if(v <= 1 || v >= group().get_p()) {
+   if(v <= 1 || v >= group().get_p() - 1) {
       throw Invalid_Argument("DH agreement - invalid key provided");
    }
 

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -418,7 +418,7 @@ bool DL_Group::verify_public_element(const BigInt& y) const {
    const BigInt& p = get_p();
    const BigInt& q = get_q();
 
-   if(y <= 1 || y >= p) {
+   if(y <= 1 || y >= p - 1) {
       return false;
    }
 

--- a/src/tests/test_dh.cpp
+++ b/src/tests/test_dh.cpp
@@ -73,13 +73,21 @@ class Diffie_Hellman_KAT_Tests final : public PK_Key_Agreement_Test {
 
          auto kas = std::make_unique<Botan::PK_Key_Agreement>(*privkey, this->rng(), "Raw");
 
-         result.test_throws("agreement input too big", "DH agreement - invalid key provided", [&kas]() {
-            const BigInt too_big("584580020955360946586837552585233629614212007514394561597561641914945762794672");
-            kas->derive_key(16, too_big.serialize());
+         result.test_throws("agreement input == p", "DH agreement - invalid key provided", [&kas, &p]() {
+            kas->derive_key(16, p.serialize());
          });
 
-         result.test_throws("agreement input too small", "DH agreement - invalid key provided", [&kas]() {
-            const BigInt too_small("1");
+         result.test_throws("agreement input == p - 1", "DH agreement - invalid key provided", [&kas, &p]() {
+            kas->derive_key(16, (p - 1).serialize());
+         });
+
+         result.test_throws("agreement input == 1", "DH agreement - invalid key provided", [&kas]() {
+            const BigInt too_small(1);
+            kas->derive_key(16, too_small.serialize());
+         });
+
+         result.test_throws("agreement input == 0", "DH agreement - invalid key provided", [&kas]() {
+            const BigInt too_small(0);
             kas->derive_key(16, too_small.serialize());
          });
 


### PR DESCRIPTION
Within TLS this was already caught and rejected but the same tighter check should apply to all uses of DH.