### PR TITLE
Avoid possible integer overflow in BigInt left shift.

### DIFF
--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -251,6 +251,10 @@ word BigInt::operator%=(word mod) {
 * Left Shift Operator
 */
 BigInt& BigInt::operator<<=(size_t shift) {
+   if(shift >= 65536) {
+      throw Invalid_Argument("BigInt left shift count too large");
+   }
+
    const size_t sw = sig_words();
    const size_t new_size = sw + (shift + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
 

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -186,15 +186,19 @@ word operator%(const BigInt& n, word mod) {
 * Left Shift Operator
 */
 BigInt operator<<(const BigInt& x, size_t shift) {
+   if(shift >= 65536) {
+      throw Invalid_Argument("BigInt left shift count too large");
+   }
+
    if(x.is_zero()) {
       return BigInt::zero();
    }
 
    const size_t x_sw = x.sig_words();
 
-   const size_t new_size = x_sw + (shift + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
+   const size_t new_size = x_sw + shift / WordInfo<word>::bits + 1;
    BigInt y = BigInt::with_capacity(new_size);
-   bigint_shl2(y.mutable_data(), x._data(), x_sw, shift);
+   bigint_shl2(y.mutable_data(), new_size, x._data(), x_sw, shift);
    y.set_sign(x.sign());
    return y;
 }
@@ -210,8 +214,9 @@ BigInt operator>>(const BigInt& x, size_t shift) {
       return BigInt::zero();
    }
 
-   BigInt y = BigInt::with_capacity(x_sw - shift_words);
-   bigint_shr2(y.mutable_data(), x._data(), x_sw, shift);
+   const size_t new_size = x_sw - shift_words;
+   BigInt y = BigInt::with_capacity(new_size);
+   bigint_shr2(y.mutable_data(), new_size, x._data(), x_sw, shift);
 
    if(x.signum() < 0 && y.is_zero()) {
       y.set_sign(BigInt::Positive);

--- a/src/lib/math/bigint/bigint.cpp
+++ b/src/lib/math/bigint/bigint.cpp
@@ -487,7 +487,7 @@ void BigInt::ct_shift_left(size_t shift) {
    // shift results only when they are within the shift range.
    for(size_t i = 0; i < iterations; ++i) {
       // Shift left by 1 bit, dropping overflow
-      bigint_shl2(ws.data(), _data(), n, 1);
+      bigint_shl2(ws.data(), n + 1, _data(), n, 1);
       ws[n] = 0;
 
       // Conditionally assign the bit-shift result
@@ -497,7 +497,7 @@ void BigInt::ct_shift_left(size_t shift) {
       }
 
       // Shift left by 1 word, dropping the most significant word
-      bigint_shl2(ws.data(), _data(), n - 1 /* ignore msw */, WordInfo<word>::bits);
+      bigint_shl2(ws.data(), n + 1, _data(), n - 1 /* ignore msw */, WordInfo<word>::bits);
       ws[0] = 0;
 
       // Conditionally assign the word-shift result

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -303,10 +303,15 @@ inline constexpr auto bigint_sub_abs(W z[], const W x[], const W y[], size_t N, 
 /*
 * Shift Operations
 */
+
+// Caller must ensure x[x_words..x_size-1] is zeroed.
 template <WordType W>
 inline constexpr void bigint_shl1(W x[], size_t x_size, size_t x_words, size_t shift) {
    const size_t word_shift = shift / WordInfo<W>::bits;
    const size_t bit_shift = shift % WordInfo<W>::bits;
+
+   BOTAN_ASSERT_NOMSG(word_shift <= x_size);
+   BOTAN_ASSERT_NOMSG(x_words <= x_size - word_shift);
 
    unchecked_copy_memory(x + word_shift, x, x_words);
    zeroize_buffer(x, word_shift);
@@ -347,11 +352,16 @@ inline constexpr void bigint_shr1(W x[], size_t x_size, size_t shift) {
 }
 
 template <WordType W>
-inline constexpr void bigint_shl2(W y[], const W x[], size_t x_size, size_t shift) {
+inline constexpr void bigint_shl2(W y[], size_t y_size, const W x[], size_t x_size, size_t shift) {
    const size_t word_shift = shift / WordInfo<W>::bits;
    const size_t bit_shift = shift % WordInfo<W>::bits;
 
+   BOTAN_ASSERT_NOMSG(word_shift <= y_size);
+   BOTAN_ASSERT_NOMSG(x_size < y_size - word_shift);
+
    unchecked_copy_memory(y + word_shift, x, x_size);
+   zeroize_buffer(y, word_shift);
+   zeroize_buffer(y + word_shift + x_size, y_size - word_shift - x_size);
 
    const auto carry_mask = CT::Mask<W>::expand(bit_shift);
    const W carry_shift = carry_mask.if_set_return(WordInfo<W>::bits - bit_shift);
@@ -365,14 +375,17 @@ inline constexpr void bigint_shl2(W y[], const W x[], size_t x_size, size_t shif
 }
 
 template <WordType W>
-inline constexpr void bigint_shr2(W y[], const W x[], size_t x_size, size_t shift) {
+inline constexpr void bigint_shr2(W y[], size_t y_size, const W x[], size_t x_size, size_t shift) {
    const size_t word_shift = shift / WordInfo<W>::bits;
    const size_t bit_shift = shift % WordInfo<W>::bits;
    const size_t new_size = x_size < word_shift ? 0 : (x_size - word_shift);
 
+   BOTAN_ASSERT_NOMSG(new_size <= y_size);
+
    if(new_size > 0) {
       unchecked_copy_memory(y, x + word_shift, new_size);
    }
+   zeroize_buffer(y + new_size, y_size - new_size);
 
    const auto carry_mask = CT::Mask<W>::expand(bit_shift);
    const W carry_shift = carry_mask.if_set_return(WordInfo<W>::bits - bit_shift);

--- a/src/lib/math/numbertheory/numthry.cpp
+++ b/src/lib/math/numbertheory/numthry.cpp
@@ -265,11 +265,11 @@ BigInt gcd(const BigInt& a, const BigInt& b) {
       factors_of_two += (u_is_even & v_is_even).if_set_return(1);
 
       // remove one factor of 2, if u is even
-      bigint_shr2(tmp.mutable_data(), u._data(), sz, 1);
+      bigint_shr2(tmp.mutable_data(), sz, u._data(), sz, 1);
       u.ct_cond_assign(u_is_even.as_bool(), tmp);
 
       // remove one factor of 2, if v is even
-      bigint_shr2(tmp.mutable_data(), v._data(), sz, 1);
+      bigint_shr2(tmp.mutable_data(), sz, v._data(), sz, 1);
       v.ct_cond_assign(v_is_even.as_bool(), tmp);
    }
 

--- a/src/lib/pubkey/curve448/curve448_scalar.cpp
+++ b/src/lib/pubkey/curve448/curve448_scalar.cpp
@@ -30,7 +30,7 @@ auto div_mod_2_446(std::span<const word, S> x) {
       r[Scalar448::WORDS - 1] &= ~(word(0b11) << (sizeof(word) * 8 - 2));
 
       std::array<word, S - Scalar448::WORDS + 1> q;  // NOLINT(*-member-init)
-      bigint_shr2(q.data(), x.data(), x.size(), 446);
+      bigint_shr2(q.data(), q.size(), x.data(), x.size(), 446);
 
       return std::make_pair(q, r);
    }


### PR DESCRIPTION
For very large (~SIZE_MAX) shifts this could result in an integer overflow. Avoid any possible overflows, but also bound the shifts to 64K, which itself is probably at least 1024 times larger than practically required.