### PR TITLE
Improve verification of EC group generators

### DIFF
--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -9,6 +9,7 @@
 #include <botan/bigint.h>
 #include <botan/exceptn.h>
 #include <botan/rng.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
@@ -1731,6 +1732,14 @@ std::shared_ptr<const PrimeOrderCurve> PCurveInstance::from_params(
 
    // The bit length of the field and order being the same simplifies things
    if(p_bits != order.bits()) {
+      return {};
+   }
+
+   // Check that the (x,y) generator point is on the curve
+   auto mod_p = Barrett_Reduction::for_public_modulus(p);
+   const BigInt y2 = mod_p.square(base_y);
+   const BigInt x3_ax_b = mod_p.reduce(mod_p.cube(base_x) + mod_p.multiply(a, base_x) + b);
+   if(y2 != x3_ax_b) {
       return {};
    }
 

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -830,18 +830,34 @@ bool EC_Group::verify_group(RandomNumberGenerator& rng, bool strong) const {
       return false;
    }
 
+   // Check that the generator (g_x, g_y) is on the curve: y^2 == x^3 + a*x + b
+   const BigInt& g_x = get_g_x();
+   const BigInt& g_y = get_g_y();
+   const BigInt y2 = mod_p.square(g_y);
+   const BigInt x3_ax_b = mod_p.reduce(mod_p.cube(g_x) + mod_p.multiply(a, g_x) + b);
+   if(y2 != x3_ax_b) {
+      return false;
+   }
+
+   // Check that the generator has the claimed order: [order]G == identity,
+   auto g_pt = EC_AffinePoint::from_bigint_xy(*this, get_g_x(), get_g_y());
+   if(!g_pt) {
+      return false;
+   }
+   const auto neg_one = EC_Scalar::one(*this).negate();
+   const auto n_minus_one_g = EC_AffinePoint::g_mul(neg_one, rng);
+   if(n_minus_one_g != g_pt->negate()) {
+      return false;
+   }
+
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
-   const EC_Point& base_point = get_base_point();
-   //check if the base point is on the curve
-   if(!base_point.on_the_curve()) {
-      return false;
-   }
-   if((base_point * get_cofactor()).is_zero()) {
-      return false;
-   }
-   //check if order of the base point is correct
-   if(!(base_point * order).is_zero()) {
-      return false;
+   // Reject if [cofactor]G is the identity. pcurves does not support cofactor != 1
+   // so this can only matter when the legacy backend is in use.
+   if(has_cofactor()) {
+      const EC_Point& base_point = get_base_point();
+      if((base_point * get_cofactor()).is_zero()) {
+         return false;
+      }
    }
 #endif
 

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -521,6 +521,27 @@ EC_Group::EC_Group(const BigInt& p,
                    const BigInt& order,
                    const BigInt& cofactor,
                    const OID& oid) {
+   BOTAN_ARG_CHECK(a >= 0 && a < p, "EC_Group a is invalid");
+   BOTAN_ARG_CHECK(b > 0 && b < p, "EC_Group b is invalid");
+   BOTAN_ARG_CHECK(base_x >= 0 && base_x < p, "EC_Group base_x is invalid");
+   BOTAN_ARG_CHECK(base_y >= 0 && base_y < p, "EC_Group base_y is invalid");
+
+   auto mod_p = Barrett_Reduction::for_public_modulus(p);
+   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(p, mod_p), "EC_Group p is not prime");
+
+   auto mod_order = Barrett_Reduction::for_public_modulus(order);
+   BOTAN_ARG_CHECK(is_bailie_psw_probable_prime(order, mod_order), "EC_Group order is not prime");
+
+   // Check that 4*a^3 + 27*b^2 != 0
+   const auto discriminant = mod_p.reduce(mod_p.multiply(BigInt::from_s32(4), mod_p.cube(a)) +
+                                          mod_p.multiply(BigInt::from_s32(27), mod_p.square(b)));
+   BOTAN_ARG_CHECK(discriminant != 0, "EC_Group discriminant is invalid");
+
+   // Check that the generator (base_x,base_y) is on the curve; y^2 = x^3 + a*x + b
+   auto y2 = mod_p.square(base_y);
+   auto x3_ax_b = mod_p.reduce(mod_p.cube(base_x) + mod_p.multiply(a, base_x) + b);
+   BOTAN_ARG_CHECK(y2 == x3_ax_b, "EC_Group generator is not on the curve");
+
    if(oid.has_value()) {
       m_data = ec_group_data().lookup_or_create(
          p, a, b, base_x, base_y, order, cofactor, oid, EC_Group_Source::ExternalSource);

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -7,6 +7,7 @@
 #include <botan/internal/ec_inner_data.h>
 
 #include <botan/der_enc.h>
+#include <botan/internal/barrett.h>
 #include <botan/internal/ec_inner_pc.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/pcurves.h>
@@ -57,6 +58,14 @@ EC_Group_Data::EC_Group_Data(const BigInt& p,
       m_has_cofactor(m_cofactor != 1),
       m_order_is_less_than_p(m_order < p),
       m_source(source) {
+   // Verify the generator (x, y) satisfies y^2 = x^3 + a*x + b (mod p)
+   auto mod_p = Barrett_Reduction::for_public_modulus(p);
+   const BigInt y2 = mod_p.square(g_y);
+   const BigInt x3_ax_b = mod_p.reduce(mod_p.cube(g_x) + mod_p.multiply(a, g_x) + b);
+   if(y2 != x3_ax_b) {
+      throw Invalid_Argument("EC_Group generator is not on the curve");
+   }
+
    // TODO(Botan4) we can assume/assert the OID is set
    if(!m_oid.empty()) {
       DER_Encoder der(m_der_named_curve);

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -438,6 +438,7 @@ class EC_Group_Registration_Tests final : public Test {
             results.push_back(test_ecc_registration());
             results.push_back(test_ec_group_from_params());
             results.push_back(test_ec_group_bad_registration());
+            results.push_back(test_ec_group_off_curve_generator());
             results.push_back(test_ec_group_duplicate_orders());
             results.push_back(test_ec_group_registration_with_custom_oid());
             results.push_back(test_ec_group_unregistration());
@@ -521,6 +522,32 @@ class EC_Group_Registration_Tests final : public Test {
          } catch(Botan::Invalid_Argument&) {
             result.test_success("Got expected exception");
          }
+
+         return result;
+      }
+
+      Test::Result test_ec_group_off_curve_generator() {
+         Test::Result result("EC_Group rejects off-curve generator");
+
+         Botan::EC_Group::clear_registered_curve_data();
+
+         // secp256r1 params, but g_y has its low bit flipped so (g_x, g_y) is not on the curve
+         const Botan::BigInt p("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFF");
+         const Botan::BigInt a("0xFFFFFFFF00000001000000000000000000000000FFFFFFFFFFFFFFFFFFFFFFFC");
+         const Botan::BigInt b("0x5AC635D8AA3A93E7B3EBBD55769886BC651D06B0CC53B0F63BCE3C3E27D2604B");
+
+         const Botan::BigInt g_x("0x6B17D1F2E12C4247F8BCE6E563A440F277037D812DEB33A0F4A13945D898C296");
+         const Botan::BigInt bad_g_y("0x4FE342E2FE1A7F9B8EE7EB4A7C0F9E162BCE33576B315ECECBB6406837BF51F4");
+         const Botan::BigInt order("0xFFFFFFFF00000000FFFFFFFFFFFFFFFFBCE6FAADA7179E84F3B9CAC2FC632551");
+
+         result.test_throws("Deprecated EC_Group constructor rejects off-curve generator",
+                            "EC_Group generator is not on the curve",
+                            [&]() { const Botan::EC_Group g(p, a, b, g_x, bad_g_y, order, 1); });
+
+         const Botan::OID custom_oid("1.3.6.1.4.1.25258.100.42");
+         result.test_throws("Deprecated EC_Group constructor with custom OID rejects off-curve generator",
+                            "EC_Group generator is not on the curve",
+                            [&]() { const Botan::EC_Group g(p, a, b, g_x, bad_g_y, order, 1, custom_oid); });
 
          return result;
       }

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -163,11 +163,16 @@ bool Test::Result::ThrowExpectations::check(std::string_view test_name, Test::Re
       if(m_expected_exception_check_fn && !m_expected_exception_check_fn(std::current_exception())) {
          return result.test_failure(Botan::fmt("{} threw unexpected exception: {}", test_name, ex.what()));
       }
-      if(m_expected_message.has_value() && m_expected_message.value() != ex.what()) {
-         return result.test_failure(Botan::fmt("{} threw exception with unexpected message (expected {} got {})",
-                                               test_name,
-                                               m_expected_message.value(),
-                                               ex.what()));
+      if(m_expected_message.has_value()) {
+         const std::string ex_msg = std::string(ex.what());
+
+         // TODO(C++23) std::string::contains
+         if(ex_msg.find(m_expected_message.value()) == std::string::npos) {
+            return result.test_failure(Botan::fmt("{} threw exception with unexpected message (expected {} got {})",
+                                                  test_name,
+                                                  m_expected_message.value(),
+                                                  ex_msg));
+         }
       }
    } catch(...) {
       if(m_expect_success || m_expected_exception_check_fn || m_expected_message.has_value()) {


### PR DESCRIPTION
Consistently check that x,y is on the curve and of the correct order, even if the old BigInt-based implementation is not being used.