### PR TITLE
Temporarily revert the check on RSA signature sizes

### DIFF
--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -774,7 +774,11 @@ class RSA_Verify_Operation final : public PK_Ops::Verification,
          // RFC 8017 8.1.2 and 8.2.2 state
          //    If the length of the signature S is not k octets,
          //    output "invalid signature" and stop.
-         if(input_len != public_modulus_bytes()) {
+         //
+         // However right now TLS-Anvil has a bug which causes it to occasionally send
+         // short signatures, so accept this for now.
+         // TODO(Botan4) if this check hasn't been addressed by now, do so for Botan4
+         if(input_len > public_modulus_bytes()) {
             throw Decoding_Error("RSA signature is an incorrect size for this public key");
          }
          const BigInt input_bn(input, input_len);


### PR DESCRIPTION
TLS-Anvil has a bug (https://github.com/tls-attacker/TLS-Anvil/issues/63) which causes it to send unpadded RSA signatures. Temporarily accept this until the bug is resolved.