### PR TITLE
Add timeout to running apt-get update on Github Actions

### DIFF
--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -33,7 +33,9 @@ if type -p "apt-get"; then
 
     sudo rm -f /var/lib/man-db/auto-update
 
-    sudo apt-get -qq update
+    # On GH Actions, occasionally apt-get seems to hang forever, run update with a timeout
+    # so the job stops after a reasonable interval
+    timeout 3m sudo apt-get -qq update
     # shellcheck disable=SC2046
     sudo apt-get -qq install $("${SCRIPT_LOCATION}"/gha_linux_packages.py "$TARGET" "$COMPILER")
 


### PR DESCRIPTION
Every once in a while this operation seems to hang, for unclear reasons. Just timeout after a few minutes so the job fails quickly, rather than consuming a CI runner slot for hours.