### PR TITLE
Move the cli test TCP/UDP port range downward

### DIFF
--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -69,10 +69,7 @@ def setup_logging(options):
     logging.getLogger().setLevel(log_level)
 
 def port_for(service):
-    # use ports in range 63000-63100 for tests, which will hopefully
-    # avoid conflicts with local services
-
-    base_port = 63000
+    base_port = 47890
 
     port_assignments = {
         'tls_server': 0,


### PR DESCRIPTION
Windows defines 49152 and up as "ephemeral ports", which is fine.  However it also has the notion of "excluded port ranges" within the ephemeral range, where systems like HyperV can reserve some range of ports, which will cause our socket binds to fail.

This binding restriction may be the cause of the sporadic failures seen in the CLI tests on Windows. Move the base port downward, well below 49152; hopefully this resolves our flaky CI.