### PR TITLE
OCSP optimizations and policy changes

### DIFF
--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -44,23 +44,33 @@ bool CertID::is_id_for(const X509_Certificate& issuer, const X509_Certificate& s
 
       const std::string hash_algo = m_hash_id.oid().to_formatted_string();
 
-      if(hash_algo != "SHA-1" && hash_algo != "SHA-256") {
-         return false;
-      }
-
-      auto hash = HashFunction::create_or_throw(hash_algo);
-
       /*
       RFC 6960 4.1.1
          issuerNameHash is the hash of the issuer's distinguished name (DN).
          The hash shall be calculated over the DER encoding of the issuer's name
          field in the certificate being checked.
-      */
-      if(m_issuer_dn_hash != hash->process<std::vector<uint8_t>>(subject.raw_issuer_dn())) {
-         return false;
-      }
 
-      if(m_issuer_key_hash != hash->process<std::vector<uint8_t>>(issuer.subject_public_key_bitstring())) {
+         issuerKeyHash is the hash of the issuer's public key. The hash shall be
+         calculated over the value (excluding tag and length) of the subject public key
+         field in the issuer's certificate.
+      */
+
+      if(hash_algo == "SHA-1") {
+         if(!std::ranges::equal(m_issuer_dn_hash, subject.raw_issuer_dn_sha1())) {
+            return false;
+         }
+         if(!std::ranges::equal(m_issuer_key_hash, issuer.subject_public_key_bitstring_sha1())) {
+            return false;
+         }
+      } else if(hash_algo == "SHA-256") {
+         if(!std::ranges::equal(m_issuer_dn_hash, subject.raw_issuer_dn_sha256())) {
+            return false;
+         }
+         if(!std::ranges::equal(m_issuer_key_hash, issuer.subject_public_key_bitstring_sha256())) {
+            return false;
+         }
+      } else {
+         // Exotic hashes are unlikely to occur in OCSP
          return false;
       }
    } catch(...) {

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -35,8 +35,11 @@ class X509_Certificate_Data final {
       std::vector<uint8_t> m_subject_public_key_bits;
       std::vector<uint8_t> m_subject_public_key_bits_seq;
       std::vector<uint8_t> m_subject_public_key_bitstring;
-      std::vector<uint8_t> m_subject_public_key_bitstring_sha1;
       AlgorithmIdentifier m_subject_public_key_algid;
+
+      // TODO(Botan4) change this to std::array<uint8_t, 20> and getter to span
+      std::vector<uint8_t> m_subject_public_key_bitstring_sha1;
+      std::array<uint8_t, 32> m_subject_public_key_bitstring_sha256 = {};
 
       std::vector<uint8_t> m_v2_issuer_key_id;
       std::vector<uint8_t> m_v2_subject_key_id;
@@ -51,8 +54,12 @@ class X509_Certificate_Data final {
       std::vector<URI> m_ocsp_responders;
       std::vector<URI> m_ca_issuers;
 
+      // TODO(Botan4) change this to std::array<uint8_t, 32> and getter to span
       std::vector<uint8_t> m_issuer_dn_bits_sha256;
+      // TODO(Botan4) change this to std::array<uint8_t, 32> and getter to span
       std::vector<uint8_t> m_subject_dn_bits_sha256;
+      std::array<uint8_t, 20> m_issuer_dn_bits_sha1 = {};
+      std::array<uint8_t, 20> m_subject_dn_bits_sha1 = {};
 
       std::string m_fingerprint_sha1;
       std::string m_fingerprint_sha256;
@@ -315,6 +322,12 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
       sha1->update(full_encoding);
       sha1->final(data->m_cert_data_sha1);
       data->m_fingerprint_sha1 = format_hex_fingerprint(data->m_cert_data_sha1);
+
+      sha1->update(data->m_issuer_dn_bits);
+      sha1->final(data->m_issuer_dn_bits_sha1);
+
+      sha1->update(data->m_subject_dn_bits);
+      sha1->final(data->m_subject_dn_bits_sha1);
    }
 
    // SHA-256 is a hard dependency of this module
@@ -328,6 +341,9 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
    sha256->update(full_encoding);
    sha256->final(data->m_cert_data_sha256);
    data->m_fingerprint_sha256 = format_hex_fingerprint(data->m_cert_data_sha256);
+
+   sha256->update(data->m_subject_public_key_bitstring);
+   sha256->final(data->m_subject_public_key_bitstring_sha256);
 
    return data;
 }
@@ -395,6 +411,10 @@ const std::vector<uint8_t>& X509_Certificate::subject_public_key_bitstring_sha1(
    }
 
    return data().m_subject_public_key_bitstring_sha1;
+}
+
+std::span<const uint8_t, 32> X509_Certificate::subject_public_key_bitstring_sha256() const {
+   return data().m_subject_public_key_bitstring_sha256;
 }
 
 const std::vector<uint8_t>& X509_Certificate::authority_key_id() const {
@@ -739,6 +759,14 @@ const std::vector<uint8_t>& X509_Certificate::raw_subject_dn_sha256() const {
       throw Encoding_Error("X509_Certificate::raw_subject_dn_sha256 called but SHA-256 disabled in build");
    }
    return data().m_subject_dn_bits_sha256;
+}
+
+std::span<const uint8_t, 20> X509_Certificate::raw_issuer_dn_sha1() const {
+   return data().m_issuer_dn_bits_sha1;
+}
+
+std::span<const uint8_t, 20> X509_Certificate::raw_subject_dn_sha1() const {
+   return data().m_subject_dn_bits_sha1;
 }
 
 std::string X509_Certificate::fingerprint(std::string_view hash_name) const {

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -92,6 +92,13 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       const std::vector<uint8_t>& subject_public_key_bitstring_sha1() const;
 
       /**
+      * Get the SHA-256 bit string of the public key associated with this certificate.
+      * This is used for OCSP among other protocols.
+      * @return hash of subject public key of this certificate
+      */
+      std::span<const uint8_t, 32> subject_public_key_bitstring_sha256() const;
+
+      /**
       * Get the certificate's issuer distinguished name (DN).
       * @return issuer DN of this certificate
       */
@@ -125,6 +132,11 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       const std::vector<uint8_t>& raw_issuer_dn() const;
 
       /**
+      * SHA-1 of Raw issuer DN
+      */
+      std::span<const uint8_t, 20> raw_issuer_dn_sha1() const;
+
+      /**
       * SHA-256 of Raw issuer DN
       */
       const std::vector<uint8_t>& raw_issuer_dn_sha256() const;
@@ -133,6 +145,11 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       * Raw subject DN
       */
       const std::vector<uint8_t>& raw_subject_dn() const;
+
+      /**
+      * SHA-1 of Raw subject DN
+      */
+      std::span<const uint8_t, 20> raw_subject_dn_sha1() const;
 
       /**
       * SHA-256 of Raw subject DN

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -551,7 +551,11 @@ Certificate_Status_Code verify_ocsp_signing_cert(const X509_Certificate& signing
       Path_Validation_Restrictions(false /* do not enforce revocation data */,
                                    restrictions.minimum_key_strength(),
                                    false /* OCSP is not available, so don't try for intermediates */,
-                                   restrictions.trusted_hashes());
+                                   restrictions.trusted_hashes(),
+                                   /* max_ocsp_age */ std::chrono::seconds(0),
+                                   /* trusted_responders */ {},
+                                   restrictions.ignore_trusted_root_time_range(),
+                                   restrictions.require_self_signed_trust_anchors());
 
    const auto validation_result = x509_path_validate(concat(std::vector{signing_cert}, extra_certs),
                                                      relaxed_restrictions,

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -59,7 +59,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
          bool require_rev = false,
          size_t minimum_key_strength = 110,
          bool ocsp_all_intermediates = false,
-         std::chrono::seconds max_ocsp_age = std::chrono::seconds::zero(),
+         std::chrono::seconds max_ocsp_age = std::chrono::hours(24 * 7),
          std::unique_ptr<Certificate_Store> trusted_ocsp_responders = std::make_unique<Certificate_Store_In_Memory>(),
          bool ignore_trusted_root_time_range = false,
          bool require_self_signed_trust_anchors = true);
@@ -89,7 +89,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
          size_t minimum_key_strength,
          bool ocsp_all_intermediates,
          const std::set<std::string>& trusted_hashes,
-         std::chrono::seconds max_ocsp_age = std::chrono::seconds::zero(),
+         std::chrono::seconds max_ocsp_age = std::chrono::hours(24 * 7),
          std::unique_ptr<Certificate_Store> trusted_ocsp_responders = std::make_unique<Certificate_Store_In_Memory>(),
          bool ignore_trusted_root_time_range = false,
          bool require_self_signed_trust_anchors = true) :

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -1220,7 +1220,7 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          std::optional<const Botan::OCSP::Response> ocsp = load_test_OCSP_resp("x509/ocsp/randombit_ocsp.der");
 
          auto check_path = [&](const std::chrono::system_clock::time_point valid_time,
-                               const Botan::Certificate_Status_Code expected) {
+                               const Botan::Certificate_Status_Code expected_status) {
             const auto path_result = Botan::x509_path_validate(cert_path,
                                                                restrictions,
                                                                trusted,
@@ -1230,9 +1230,8 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                                                                std::chrono::milliseconds(0),
                                                                {ocsp});
 
-            return result.test_is_true(std::string("Status: '") + Botan::to_string(expected) + "' should match '" +
-                                          Botan::to_string(path_result.result()) + "'",
-                                       path_result.result() == expected);
+            return result.test_str_eq(
+               "Expected status", path_result.result_string(), Botan::to_string(expected_status));
          };
 
          check_path(Botan::calendar_point(2016, 11, 11, 12, 30, 0).to_std_timepoint(),
@@ -1294,7 +1293,8 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          Test::Result result("path check with ocsp w/o next_update w/o max_age");
          Botan::Certificate_Store_In_Memory trusted;
 
-         auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false);
+         // max_age=0 means unbounded (the default is now finite)
+         auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false, std::chrono::seconds(0));
 
          auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
          auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
@@ -1327,6 +1327,49 @@ class Path_Validation_With_OCSP_Tests final : public Test {
          check_path(Botan::calendar_point(2019, 5, 28, 7, 30, 0).to_std_timepoint(),
                     Botan::Certificate_Status_Code::OK);
          check_path(Botan::calendar_point(2019, 5, 28, 8, 0, 0).to_std_timepoint(), Botan::Certificate_Status_Code::OK);
+         // Well past 7 days: unbounded, so still OK
+         check_path(Botan::calendar_point(2019, 6, 10, 7, 30, 0).to_std_timepoint(),
+                    Botan::Certificate_Status_Code::OK);
+
+         return result;
+      }
+
+      static Test::Result validate_with_ocsp_without_next_update_default_restrictions() {
+         Test::Result result("path check with ocsp w/o next_update under default max_age");
+         Botan::Certificate_Store_In_Memory trusted;
+
+         auto restrictions = Botan::Path_Validation_Restrictions(false, 110, false);
+
+         auto ee = load_test_X509_cert("x509/ocsp/patrickschmidt.pem");
+         auto ca = load_test_X509_cert("x509/ocsp/bdrive_encryption.pem");
+         auto trust_root = load_test_X509_cert("x509/ocsp/bdrive_root.pem");
+
+         trusted.add_certificate(trust_root);
+
+         const std::vector<Botan::X509_Certificate> cert_path = {ee, ca, trust_root};
+
+         auto ocsp = load_test_OCSP_resp("x509/ocsp/patrickschmidt_ocsp.der");
+
+         auto check_path = [&](const std::chrono::system_clock::time_point valid_time,
+                               const Botan::Certificate_Status_Code expected) {
+            const auto path_result = Botan::x509_path_validate(cert_path,
+                                                               restrictions,
+                                                               trusted,
+                                                               "",
+                                                               Botan::Usage_Type::UNSPECIFIED,
+                                                               valid_time,
+                                                               std::chrono::milliseconds(0),
+                                                               {ocsp});
+
+            return result.test_is_true(std::string("Status: '") + Botan::to_string(expected) + "' should match '" +
+                                          Botan::to_string(path_result.result()) + "'",
+                                       path_result.result() == expected);
+         };
+
+         check_path(Botan::calendar_point(2019, 5, 28, 7, 30, 0).to_std_timepoint(),
+                    Botan::Certificate_Status_Code::OK);
+         check_path(Botan::calendar_point(2019, 6, 10, 7, 30, 0).to_std_timepoint(),
+                    Botan::Certificate_Status_Code::OCSP_IS_TOO_OLD);
 
          return result;
       }
@@ -1572,6 +1615,7 @@ class Path_Validation_With_OCSP_Tests final : public Test {
                  validate_with_ocsp_with_next_update_with_max_age(),
                  validate_with_ocsp_without_next_update_without_max_age(),
                  validate_with_ocsp_without_next_update_with_max_age(),
+                 validate_with_ocsp_without_next_update_default_restrictions(),
                  validate_with_ocsp_with_authorized_responder(),
                  validate_with_ocsp_with_authorized_responder_without_keyusage(),
                  validate_with_forged_ocsp_using_self_signed_cert(),


### PR DESCRIPTION
Prehash values in X509 certificate such that `CertId::is_id_for` doesn't have to hash on each look. Likely also useful in other contexts.

Changes `max_ocsp_age` from 0 (disabled/any age allowed as long as it is before `nextUpdate`) to 7 days.

For verification of OCSP signer certificates, pass along the same trust root options (allow expired + allow non-self-signed) since OCSP requires that the signer of the response by signed by the same CA that signed the subscriber certificate, so if these options are necessary in order to verify the leaf they would also be required to verify the OCSP signer's certificate.