### PR TITLE
chore(test): Resolve TODO in Roughtime_Request test

### DIFF
--- a/src/tests/test_roughtime.cpp
+++ b/src/tests/test_roughtime.cpp
@@ -36,11 +36,10 @@ class Roughtime_Request_Tests final : public Text_Based_Test {
 
          const auto request = Botan::Roughtime::encode_request(nonce);
 
-         // TODO should use byte comparison function
          if(type == "Valid") {
-            result.test_is_true("encode", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
+            result.test_bin_eq("encode", request, request_v);
          } else {
-            result.test_is_true("encode", request != Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
+            result.test_bin_ne("encode", request, request_v);
          }
 
          return result;


### PR DESCRIPTION
Following the `// TODO should use byte comparison function` message, I updated the `test_is_true/false` calls to `test_bin_eq/ne`. 

However, after reviewing the commit where this message was added, I’m not entirely sure this is exactly what was intended. This change could have been implemented in commit 505d93a. 

```cpp
// Before
result.test_eq("encode", type == "Valid", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));


// After
// TODO should use byte comparison function
if(type == "Valid") {
    result.test_is_true("encode", request == Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
} else {
    result.test_is_true("encode", request != Botan::typecast_copy<std::array<uint8_t, 1024>>(request_v.data()));
}
```

Is `test_bin_eq` / `test_bin_ne` the intended direction here, or should the behavior be preserved differently? For example, should the `request_v` span be taken as a fixed size of `1024`? The test vectors in the `src/tests/data/roughtime/` directory are always 1024 bytes long, so I believe they can be compared directly. Additionally, if this were not the case, `typecast_copy` would result in an undefined behavior in cases where the length is less than 1024.