### PR TITLE
Systematically eliminate any possible integer overflows

### DIFF
--- a/src/cli/zfec.cpp
+++ b/src/cli/zfec.cpp
@@ -10,6 +10,7 @@
    #include <botan/hash.h>
    #include <botan/mem_ops.h>
    #include <botan/zfec.h>
+   #include <botan/internal/int_utils.h>
    #include <botan/internal/loadstor.h>
    #include <fstream>
    #include <sstream>
@@ -238,7 +239,18 @@ class FEC_Decode final : public Command {
 
          const Botan::ZFEC fec(k, n);
 
-         std::vector<uint8_t> decoded(share_size * k);
+         const auto decoded_size = Botan::checked_mul(share_size, k);
+         if(!decoded_size.has_value()) {
+            throw CLI_Error("Share size and count are too large to decode");
+         }
+
+         const size_t decoded_len = decoded_size.value();
+         const size_t trailer_len = Botan::add_or_throw(hash_len, padding, "FEC share padding is too large");
+         if(decoded_len < trailer_len) {
+            throw CLI_Error("Recovered data is too short to be valid");
+         }
+
+         std::vector<uint8_t> decoded(decoded_len);
 
          auto decoder_fn = [&](size_t share, const uint8_t bits[], size_t len) {
             std::memcpy(&decoded[share * share_size], bits, len);
@@ -252,20 +264,20 @@ class FEC_Decode final : public Command {
 
          fec.decode_shares(share_ptrs, share_size, decoder_fn);
 
-         auto decoded_digest = hash->process(decoded.data(), decoded.size() - (hash_len + padding));
+         const size_t output_len = decoded_len - trailer_len;
+         auto decoded_digest = hash->process(decoded.data(), output_len);
 
-         if(!Botan::constant_time_compare(
-               decoded_digest.data(), &decoded[decoded.size() - (hash_len + padding)], hash_len)) {
+         if(!Botan::constant_time_compare(decoded_digest.data(), &decoded[output_len], hash_len)) {
             throw CLI_Error("Recovered data failed digest check");
          }
 
          for(size_t i = 0; i != padding; ++i) {
-            if(decoded[decoded.size() - padding + i] != 0) {
+            if(decoded[decoded_len - padding + i] != 0) {
                throw CLI_Error("Recovered data had non-zero padding bytes");
             }
          }
 
-         output_binary().write(reinterpret_cast<const char*>(decoded.data()), decoded.size() - (hash_len + padding));
+         output_binary().write(reinterpret_cast<const char*>(decoded.data()), output_len);
       }
 };
 

--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -37,11 +37,13 @@ class Base32 final {
       static constexpr size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
 
       static constexpr size_t encode_max_output(size_t input_length) {
-         return (round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in) * m_encoding_bytes_out;
+         const size_t encoding_blocks = round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in;
+         return mul_or_throw(encoding_blocks, m_encoding_bytes_out, "Input too large to base32 encode");
       }
 
       static constexpr size_t decode_max_output(size_t input_length) {
-         return (round_up(input_length, m_encoding_bytes_out) * m_encoding_bytes_in) / m_encoding_bytes_out;
+         // Divide before multiply to avoid overflow; round_up makes the division exact.
+         return (round_up(input_length, m_encoding_bytes_out) / m_encoding_bytes_out) * m_encoding_bytes_in;
       }
 
       static void encode(char out[8], const uint8_t in[5]) noexcept;

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -36,11 +36,13 @@ class Base64 final {
       static constexpr size_t remaining_bits_before_padding() noexcept { return m_remaining_bits_before_padding; }
 
       static constexpr size_t encode_max_output(size_t input_length) {
-         return (round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in) * m_encoding_bytes_out;
+         const size_t encoding_blocks = round_up(input_length, m_encoding_bytes_in) / m_encoding_bytes_in;
+         return mul_or_throw(encoding_blocks, m_encoding_bytes_out, "Input too large to base64 encode");
       }
 
       static constexpr size_t decode_max_output(size_t input_length) {
-         return (round_up(input_length, m_encoding_bytes_out) * m_encoding_bytes_in) / m_encoding_bytes_out;
+         // Divide before multiply to avoid overflow; round_up makes the division exact.
+         return (round_up(input_length, m_encoding_bytes_out) / m_encoding_bytes_out) * m_encoding_bytes_in;
       }
 
       static void encode(char out[4], const uint8_t in[3]) noexcept;

--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -40,7 +40,8 @@ void hex_encode(char output[], const uint8_t input[], size_t input_length, bool 
 }
 
 std::string hex_encode(const uint8_t input[], size_t input_length, bool uppercase) {
-   std::string output(2 * input_length, 0);
+   const size_t output_length = mul_or_throw<size_t>(2, input_length, "Input too large to hex encode");
+   std::string output(output_length, 0);
 
    if(input_length > 0) {
       hex_encode(&output.front(), input, input_length, uppercase);

--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -73,8 +73,9 @@ void Stream_Compression::process(secure_vector<uint8_t>& buf, size_t offset, uin
       return;
    }
 
-   if(m_buffer.size() < buf.size() + offset) {
-      m_buffer.resize(buf.size() + offset);
+   const size_t buffer_needed = add_or_throw(buf.size(), offset, "Compression input too large");
+   if(m_buffer.size() < buffer_needed) {
+      m_buffer.resize(buffer_needed);
    }
 
    // If the output buffer has zero length, .data() might return nullptr. This would
@@ -97,8 +98,9 @@ void Stream_Compression::process(secure_vector<uint8_t>& buf, size_t offset, uin
          m_buffer.resize(m_buffer.size() - m_stream->avail_out());
          break;
       } else if(m_stream->avail_out() == 0) {
-         const size_t added = 8 + m_buffer.size();
-         m_buffer.resize(m_buffer.size() + added);
+         const size_t added = add_or_throw<size_t>(m_buffer.size(), 8, "Compression output too large");
+         const size_t new_size = add_or_throw(m_buffer.size(), added, "Compression output too large");
+         m_buffer.resize(new_size);
          m_stream->next_out(m_buffer.data() + m_buffer.size() - added, added);
       } else if(m_stream->avail_in() == 0) {
          m_buffer.resize(m_buffer.size() - m_stream->avail_out());
@@ -133,8 +135,9 @@ void Stream_Decompression::process(secure_vector<uint8_t>& buf, size_t offset, u
    BOTAN_ASSERT(m_stream, "Initialized");
    BOTAN_ASSERT(buf.size() >= offset, "Offset is sane");
 
-   if(m_buffer.size() < buf.size() + offset) {
-      m_buffer.resize(buf.size() + offset);
+   const size_t buffer_needed = add_or_throw(buf.size(), offset, "Compression input too large");
+   if(m_buffer.size() < buffer_needed) {
+      m_buffer.resize(buffer_needed);
    }
 
    m_stream->next_in(buf.data() + offset, buf.size() - offset);
@@ -161,8 +164,9 @@ void Stream_Decompression::process(secure_vector<uint8_t>& buf, size_t offset, u
       }
 
       if(m_stream->avail_out() == 0) {
-         const size_t added = 8 + m_buffer.size();
-         m_buffer.resize(m_buffer.size() + added);
+         const size_t added = add_or_throw<size_t>(m_buffer.size(), 8, "Compression output too large");
+         const size_t new_size = add_or_throw(m_buffer.size(), added, "Compression output too large");
+         m_buffer.resize(new_size);
          m_stream->next_out(m_buffer.data() + m_buffer.size() - added, added);
       } else if(m_stream->avail_in() == 0) {
          m_buffer.resize(m_buffer.size() - m_stream->avail_out());

--- a/src/lib/filters/b64_filt.cpp
+++ b/src/lib/filters/b64_filt.cpp
@@ -10,6 +10,7 @@
 #include <botan/base64.h>
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
+#include <botan/internal/int_utils.h>
 #include <algorithm>
 
 namespace Botan {
@@ -111,8 +112,8 @@ void Base64_Decoder::write(const uint8_t input[], size_t length) {
    while(length > 0) {
       const size_t to_copy = std::min<size_t>(length, m_in.size() - m_position);
       if(to_copy == 0) {
-         m_in.resize(m_in.size() * 2);
-         m_out.resize(m_out.size() * 2);
+         m_in.resize(mul_or_throw<size_t>(2, m_in.size(), "Base64_Decoder input too large"));
+         m_out.resize(mul_or_throw<size_t>(2, m_out.size(), "Base64_Decoder input too large"));
       }
       copy_mem(&m_in[m_position], input, to_copy);
       m_position += to_copy;

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -179,6 +179,11 @@ bool is_miller_rabin_probable_prime(const BigInt& n,
 }
 
 size_t miller_rabin_test_iterations(size_t n_bits, size_t prob, bool random) {
+   // Cap prob at 512 bits as _way_ more than enough; a random fault causing
+   // false accept is much more likely to occur than an actual 2^-512 event is.
+
+   prob = std::min<size_t>(512, prob);
+
    const size_t base = (prob + 2) / 2;  // worst case 4^-t error rate
 
    /*

--- a/src/lib/misc/cryptobox/cryptobox.cpp
+++ b/src/lib/misc/cryptobox/cryptobox.cpp
@@ -15,6 +15,7 @@
 #include <botan/pwdhash.h>
 #include <botan/rng.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/mem_utils.h>
 
@@ -48,7 +49,8 @@ std::string encrypt(const uint8_t input[], size_t input_len, std::string_view pa
       mac (20 bytes)
       ciphertext
    */
-   secure_vector<uint8_t> out_buf(CRYPTOBOX_HEADER_LEN + input_len);
+   const size_t out_len = add_or_throw(CRYPTOBOX_HEADER_LEN, input_len, "CryptoBox input too large");
+   secure_vector<uint8_t> out_buf(out_len);
    store_be(CRYPTOBOX_VERSION_CODE, out_buf.data());
    rng.randomize(&out_buf[VERSION_CODE_LEN], PBKDF_SALT_LEN);
    // space left for MAC here

--- a/src/lib/misc/nist_keywrap/nist_keywrap.cpp
+++ b/src/lib/misc/nist_keywrap/nist_keywrap.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/block_cipher.h>
 #include <botan/exceptn.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {
@@ -15,9 +16,9 @@ namespace Botan {
 namespace {
 
 std::vector<uint8_t> raw_nist_key_wrap(const uint8_t input[], size_t input_len, const BlockCipher& bc, uint64_t ICV) {
-   const size_t n = (input_len + 7) / 8;
+   const size_t n = input_len / 8 + (input_len % 8 != 0 ? 1 : 0);
 
-   secure_vector<uint8_t> R((n + 1) * 8);
+   secure_vector<uint8_t> R(mul_or_throw<size_t>(8, n + 1, "NIST key wrap input too large"));
    secure_vector<uint8_t> A(16);
 
    store_be(ICV, A.data());
@@ -197,6 +198,8 @@ secure_vector<uint8_t> nist_key_unwrap_padded(const uint8_t input[], size_t inpu
    length, which is R.size() minus 0 to 7 bytes of padding. Compute
    the ICV we'd expect for the zero-padding case and subtract ICV_out;
    for a valid unwrap the difference is at most 7, and equals the padding.
+   For an invalid unwrap the unsigned subtraction wraps to a value > 7
+   (checked below), so the modular arithmetic here is intentional.
    */
    const uint64_t expected_ICV_max = 0xA65959A600000000 | static_cast<uint32_t>(R.size());
    const uint64_t padding = expected_ICV_max - ICV_out;

--- a/src/lib/misc/roughtime/roughtime.cpp
+++ b/src/lib/misc/roughtime/roughtime.cpp
@@ -13,6 +13,7 @@
 #include <botan/pubkey.h>
 #include <botan/rng.h>
 #include <botan/internal/buffer_slicer.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/socket_udp.h>
 
 #include <map>
@@ -72,8 +73,14 @@ std::map<std::string, std::vector<uint8_t>> unpack_roughtime_packet(T bytes) {
    uint32_t start = start_content;
    std::map<std::string, std::vector<uint8_t>> tags;
    for(uint32_t i = 0; i < num_tags; ++i) {
-      const size_t end =
-         ((i + 1) == num_tags) ? bytes.size() : start_content + from_little_endian<uint32_t>(buf + 4 + i * 4);
+      size_t end = bytes.size();
+      if((i + 1) != num_tags) {
+         const auto tag_end = checked_add(start_content, from_little_endian<uint32_t>(buf + 4 + i * 4));
+         if(!tag_end.has_value()) {
+            throw Roughtime::Roughtime_Error("Tag end index out of bounds");
+         }
+         end = tag_end.value();
+      }
       if(end > bytes.size()) {
          throw Roughtime::Roughtime_Error("Tag end index out of bounds");
       }

--- a/src/lib/modes/aead/ascon_aead128/ascon_aead128.cpp
+++ b/src/lib/modes/aead/ascon_aead128/ascon_aead128.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/concat_util.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {
@@ -110,6 +111,10 @@ std::array<uint8_t, 16> Ascon_AEAD128_Mode::calculate_tag_and_finish() {
    return tag;
 }
 
+size_t Ascon_AEAD128_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "Ascon-AEAD128 input too large");
+}
+
 size_t Ascon_AEAD128_Encryption::process_msg(uint8_t buf[], size_t size) {
    BOTAN_STATE_CHECK(has_keying_material());
    BOTAN_STATE_CHECK(m_has_nonce);
@@ -127,6 +132,11 @@ void Ascon_AEAD128_Encryption::finish_msg(secure_vector<uint8_t>& final_block, s
    process_msg(final_block_at_offset.data(), final_block_at_offset.size());
    const auto tag = calculate_tag_and_finish();
    final_block.insert(final_block.end(), tag.begin(), tag.end());
+}
+
+size_t Ascon_AEAD128_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 size_t Ascon_AEAD128_Decryption::process_msg(uint8_t buf[], size_t size) {

--- a/src/lib/modes/aead/ascon_aead128/ascon_aead128.h
+++ b/src/lib/modes/aead/ascon_aead128/ascon_aead128.h
@@ -68,7 +68,7 @@ class Ascon_AEAD128_Mode : public AEAD_Mode {
 */
 class Ascon_AEAD128_Encryption final : public Ascon_AEAD128_Mode {
    public:
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -82,10 +82,7 @@ class Ascon_AEAD128_Encryption final : public Ascon_AEAD128_Mode {
 */
 class Ascon_AEAD128_Decryption final : public Ascon_AEAD128_Mode {
    public:
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/ccm/ccm.cpp
+++ b/src/lib/modes/aead/ccm/ccm.cpp
@@ -12,6 +12,7 @@
 #include <botan/mem_ops.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {
@@ -187,6 +188,10 @@ secure_vector<uint8_t> CCM_Mode::format_c0() {
    return C;
 }
 
+size_t CCM_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "CCM input too large");
+}
+
 void CCM_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
@@ -235,6 +240,11 @@ void CCM_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    buffer += std::make_pair(T.data(), tag_size());
 
    reset();
+}
+
+size_t CCM_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 void CCM_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {

--- a/src/lib/modes/aead/ccm/ccm.h
+++ b/src/lib/modes/aead/ccm/ccm.h
@@ -94,7 +94,7 @@ class CCM_Encryption final : public CCM_Mode {
       explicit CCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
             CCM_Mode(std::move(cipher), tag_size, L) {}
 
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -117,10 +117,7 @@ class CCM_Decryption final : public CCM_Mode {
       explicit CCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16, size_t L = 3) :
             CCM_Mode(std::move(cipher), tag_size, L) {}
 
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan {
@@ -102,6 +103,10 @@ void ChaCha20Poly1305_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
    }
 }
 
+size_t ChaCha20Poly1305_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "ChaCha20Poly1305 input too large");
+}
+
 size_t ChaCha20Poly1305_Encryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(m_nonce_len > 0);
    m_chacha->cipher1(buf, sz);
@@ -131,10 +136,19 @@ void ChaCha20Poly1305_Encryption::finish_msg(secure_vector<uint8_t>& buffer, siz
    }
    update_len(m_ctext_len);
 
-   buffer.resize(buffer.size() + tag_size());
+   const auto new_size = checked_add(buffer.size(), tag_size());
+   if(!new_size.has_value()) {
+      throw Invalid_State("ChaCha20Poly1305 message length limit exceeded");
+   }
+   buffer.resize(new_size.value());
    m_poly1305->final(&buffer[buffer.size() - tag_size()]);
    m_ctext_len = 0;
    m_nonce_len = 0;
+}
+
+size_t ChaCha20Poly1305_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 size_t ChaCha20Poly1305_Decryption::process_msg(uint8_t buf[], size_t sz) {

--- a/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
+++ b/src/lib/modes/aead/chacha20poly1305/chacha20poly1305.h
@@ -73,7 +73,7 @@ class ChaCha20Poly1305_Mode : public AEAD_Mode {
 */
 class ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode {
    public:
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -87,10 +87,7 @@ class ChaCha20Poly1305_Encryption final : public ChaCha20Poly1305_Mode {
 */
 class ChaCha20Poly1305_Decryption final : public ChaCha20Poly1305_Mode {
    public:
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/eax/eax.cpp
+++ b/src/lib/modes/aead/eax/eax.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ctr.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 
 namespace Botan {
 
@@ -131,6 +132,10 @@ void EAX_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
    m_cmac->update(2);
 }
 
+size_t EAX_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "EAX input too large");
+}
+
 size_t EAX_Encryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(!m_nonce_mac.empty());
    m_ctr->cipher(buf, buf, sz);
@@ -155,6 +160,11 @@ void EAX_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    buffer += std::make_pair(data_mac.data(), tag_size());
 
    m_nonce_mac.clear();
+}
+
+size_t EAX_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 size_t EAX_Decryption::process_msg(uint8_t buf[], size_t sz) {

--- a/src/lib/modes/aead/eax/eax.h
+++ b/src/lib/modes/aead/eax/eax.h
@@ -81,7 +81,7 @@ class EAX_Encryption final : public EAX_Mode {
       explicit EAX_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
             EAX_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -102,10 +102,7 @@ class EAX_Decryption final : public EAX_Mode {
       explicit EAX_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 0) :
             EAX_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/gcm/gcm.cpp
+++ b/src/lib/modes/aead/gcm/gcm.cpp
@@ -15,6 +15,7 @@
 #include <botan/internal/ctr.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/ghash.h>
+#include <botan/internal/int_utils.h>
 #include <array>
 
 namespace Botan {
@@ -123,6 +124,10 @@ void GCM_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
    m_in_msg = true;
 }
 
+size_t GCM_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "GCM input too large");
+}
+
 size_t GCM_Encryption::process_msg(uint8_t buf[], size_t sz) {
    BOTAN_STATE_CHECK(m_in_msg);
    BOTAN_ARG_CHECK(sz % update_granularity() == 0, "Invalid buffer size");
@@ -144,6 +149,11 @@ void GCM_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    m_ghash->final(std::span(mac).first(tag_size()));
    buffer += std::make_pair(mac.data(), tag_size());
    m_in_msg = false;
+}
+
+size_t GCM_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 size_t GCM_Decryption::process_msg(uint8_t buf[], size_t sz) {

--- a/src/lib/modes/aead/gcm/gcm.h
+++ b/src/lib/modes/aead/gcm/gcm.h
@@ -79,7 +79,7 @@ class GCM_Encryption final : public GCM_Mode {
       explicit GCM_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             GCM_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -100,10 +100,7 @@ class GCM_Decryption final : public GCM_Mode {
       explicit GCM_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             GCM_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ARG_CHECK(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/ocb/ocb.cpp
+++ b/src/lib/modes/aead/ocb/ocb.cpp
@@ -13,6 +13,7 @@
 #include <botan/mem_ops.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/poly_dbl.h>
 
 namespace Botan {
@@ -352,6 +353,10 @@ void OCB_Mode::start_msg(const uint8_t nonce[], size_t nonce_len) {
    m_block_index = 0;
 }
 
+size_t OCB_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "OCB input too large");
+}
+
 void OCB_Encryption::encrypt(uint8_t buffer[], size_t blocks) {
    assert_key_material_set();
    BOTAN_STATE_CHECK(m_L->initialized());
@@ -433,6 +438,11 @@ void OCB_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    buffer += std::make_pair(mac.data(), tag_size());
 
    reset();
+}
+
+size_t OCB_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 void OCB_Decryption::decrypt(uint8_t buffer[], size_t blocks) {

--- a/src/lib/modes/aead/ocb/ocb.h
+++ b/src/lib/modes/aead/ocb/ocb.h
@@ -101,7 +101,7 @@ class BOTAN_TEST_API OCB_Encryption final : public OCB_Mode {
       explicit OCB_Encryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             OCB_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -120,10 +120,7 @@ class BOTAN_TEST_API OCB_Decryption final : public OCB_Mode {
       explicit OCB_Decryption(std::unique_ptr<BlockCipher> cipher, size_t tag_size = 16) :
             OCB_Mode(std::move(cipher), tag_size) {}
 
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/cmac.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/ctr.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/poly_dbl.h>
 
 namespace Botan {
@@ -161,6 +162,10 @@ void SIV_Mode::set_ctr_iv(secure_vector<uint8_t> V) {
    ctr().set_iv(V.data(), V.size());
 }
 
+size_t SIV_Encryption::output_length(size_t input_length) const {
+   return add_or_throw(input_length, tag_size(), "SIV input too large");
+}
+
 void SIV_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    BOTAN_ARG_CHECK(buffer.size() >= offset, "Offset is out of range");
 
@@ -180,6 +185,11 @@ void SIV_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    // intervening start_msg() silently re-use the prior nonce instead of
    // running nonce-less SIV.
    reset();
+}
+
+size_t SIV_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
+   return input_length - tag_size();
 }
 
 void SIV_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {

--- a/src/lib/modes/aead/siv/siv.h
+++ b/src/lib/modes/aead/siv/siv.h
@@ -94,7 +94,7 @@ class BOTAN_TEST_API SIV_Encryption final : public SIV_Mode {
       */
       explicit SIV_Encryption(std::unique_ptr<BlockCipher> cipher) : SIV_Mode(std::move(cipher)) {}
 
-      size_t output_length(size_t input_length) const override { return input_length + tag_size(); }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return 0; }
 
@@ -112,10 +112,7 @@ class BOTAN_TEST_API SIV_Decryption final : public SIV_Mode {
       */
       explicit SIV_Decryption(std::unique_ptr<BlockCipher> cipher) : SIV_Mode(std::move(cipher)) {}
 
-      size_t output_length(size_t input_length) const override {
-         BOTAN_ASSERT(input_length >= tag_size(), "Sufficient input");
-         return input_length - tag_size();
-      }
+      size_t output_length(size_t input_length) const override;
 
       size_t minimum_final_size() const override { return tag_size(); }
 

--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -12,6 +12,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/mode_pad.h>
 
 namespace Botan {
@@ -123,7 +124,8 @@ void CBC_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
 
    const size_t BS = block_size();
 
-   const size_t output_bytes = offset + padding().output_length(buffer.size() - offset, BS);
+   const size_t output_bytes =
+      add_or_throw(offset, padding().output_length(buffer.size() - offset, BS), "CBC input too large");
    const size_t bytes_in_final_block = (buffer.size() - offset) % BS;
    buffer.resize(output_bytes);
    padding().add_padding(std::span(buffer).subspan(offset), bytes_in_final_block, BS);

--- a/src/lib/modes/mode_pad/mode_pad.cpp
+++ b/src/lib/modes/mode_pad/mode_pad.cpp
@@ -10,8 +10,15 @@
 #include <botan/internal/mode_pad.h>
 
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 
 namespace Botan {
+
+size_t BlockCipherModePaddingMethod::output_length(size_t input_length, size_t block_size) const {
+   // Round input_length down to a multiple of block_size then add a full block
+   const size_t full_blocks = input_length - (input_length % block_size);
+   return add_or_throw(full_blocks, block_size, "Input too large to pad");
+}
 
 /**
 * Get a block cipher padding method by name

--- a/src/lib/modes/mode_pad/mode_pad.h
+++ b/src/lib/modes/mode_pad/mode_pad.h
@@ -63,9 +63,7 @@ class BOTAN_TEST_API BlockCipherModePaddingMethod /* NOLINT(*-special-member-fun
       * @param block_size   size of each block in bytes
       * @return the total number of output bytes (including the padding)
       */
-      virtual size_t output_length(size_t input_length, size_t block_size) const {
-         return ((input_length + block_size) / block_size) * block_size;
-      }
+      virtual size_t output_length(size_t input_length, size_t block_size) const;
 
       /**
       * @return name of the mode

--- a/src/lib/passhash/bcrypt/bcrypt.cpp
+++ b/src/lib/passhash/bcrypt/bcrypt.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/blowfish.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/mem_utils.h>
 #include <botan/internal/parsing.h>
 
@@ -116,7 +117,8 @@ std::string make_bcrypt(std::string_view pass, std::span<const uint8_t> salt, ui
 
    // Bcrypt is defined with the key including the trailing NULL so we must copy it to a local
    // variable since std::string_view is not necessarily NULL terminated.
-   secure_vector<uint8_t> pass_w_null(pass.size() + 1);
+   const size_t pass_w_null_len = add_or_throw<size_t>(pass.size(), 1, "bcrypt password is too long");
+   secure_vector<uint8_t> pass_w_null(pass_w_null_len);
    copy_mem(std::span{pass_w_null}.first(pass.size()), as_span_of_bytes(pass));
 
    blowfish.salted_set_key(pass_w_null.data(), pass_w_null.size(), salt.data(), salt.size(), work_factor);

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -11,6 +11,7 @@
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/mem_utils.h>
 #include <botan/internal/time_utils.h>
 #include <algorithm>
@@ -31,7 +32,8 @@ void pgp_s2k(HashFunction& hash,
       throw Invalid_Argument("OpenPGP S2K requires a salt in iterated mode");
    }
 
-   secure_vector<uint8_t> input_buf(salt_len + password_size);
+   const size_t input_len = add_or_throw(salt_len, password_size, "OpenPGP S2K salt and password are too large");
+   secure_vector<uint8_t> input_buf(input_len);
    if(salt_len > 0) {
       copy_mem(input_buf.data(), salt, salt_len);
    }
@@ -104,7 +106,7 @@ std::unique_ptr<PasswordHash> RFC4880_S2K_Family::tune_params(size_t output_len,
    const uint64_t desired_nsec = desired_msec * 1000000;
 
    const size_t hash_size = m_hash->output_length();
-   const size_t blocks_required = (output_len <= hash_size ? 1 : (output_len + hash_size - 1) / hash_size);
+   const size_t blocks_required = std::max<size_t>(1, (output_len / hash_size) + (output_len % hash_size != 0 ? 1 : 0));
 
    const double bytes_to_be_hashed = (hash_bytes_per_second * (desired_nsec / 1000000000.0)) / blocks_required;
    const size_t iterations = RFC4880_round_iterations(static_cast<size_t>(bytes_to_be_hashed));

--- a/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.cpp
+++ b/src/lib/pbkdf/pkcs12_kdf/pkcs12_kdf.cpp
@@ -13,6 +13,7 @@
 #include <botan/mem_ops.h>
 #include <botan/internal/charset.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/time_utils.h>
 #include <algorithm>
 #include <array>
@@ -94,10 +95,20 @@ void pkcs12_kdf_with_hash(std::span<uint8_t> out,
    const size_t pwd_len = pwd_bytes.size();
    const size_t salt_len = salt.size();
 
+   // Round len up to a multiple of v, checking for overflow. Dividing before
+   // the multiply avoids overflow when computing the number of blocks.
+   auto round_up_to_v = [v](size_t len) -> size_t {
+      if(len == 0) {
+         return 0;
+      }
+      const size_t blocks = (len / v) + (len % v != 0 ? 1 : 0);
+      return mul_or_throw(blocks, v, "PKCS12-KDF: input too large");
+   };
+
    // Calculate sizes (must be multiple of v)
-   const size_t S_len = salt_len > 0 ? v * ((salt_len + v - 1) / v) : 0;
-   const size_t P_len = pwd_len > 0 ? v * ((pwd_len + v - 1) / v) : 0;
-   const size_t I_len = S_len + P_len;
+   const size_t S_len = round_up_to_v(salt_len);
+   const size_t P_len = round_up_to_v(pwd_len);
+   const size_t I_len = add_or_throw(S_len, P_len, "PKCS12-KDF: input too large");
 
    // Create D (diversifier): v bytes of id
    secure_vector<uint8_t> D(v, id);

--- a/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
+++ b/src/lib/tls/tls12/tls_cbc/tls_cbc.cpp
@@ -17,6 +17,7 @@
 #include <botan/tls_version.h>
 #include <botan/internal/cbc.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rounding.h>
 
@@ -171,7 +172,8 @@ void TLS_CBC_HMAC_AEAD_Encryption::cbc_encrypt_record(secure_vector<uint8_t>& bu
    // We always do short padding:
    BOTAN_ASSERT_NOMSG(padding_length <= 16);
 
-   buffer.resize(buffer.size() + padding_length);
+   const size_t buf_with_padding = add_or_throw(buffer.size(), padding_length, "TLS CBC input too large");
+   buffer.resize(buf_with_padding);
 
    const uint8_t padding_val = static_cast<uint8_t>(padding_length - 1);
 
@@ -197,8 +199,14 @@ void TLS_CBC_HMAC_AEAD_Encryption::cbc_encrypt_record(secure_vector<uint8_t>& bu
 }
 
 size_t TLS_CBC_HMAC_AEAD_Encryption::output_length(size_t input_length) const {
-   return round_up(input_length + 1 + (use_encrypt_then_mac() ? 0 : tag_size()), block_size()) +
-          (use_encrypt_then_mac() ? tag_size() : 0);
+   const size_t mac_in_plaintext = use_encrypt_then_mac() ? 0 : tag_size();
+   const size_t mac_appended = use_encrypt_then_mac() ? tag_size() : 0;
+
+   // round_up() checks its own addition for overflow, but the addition feeding
+   // it and the trailing MAC must be checked separately. mac_in_plaintext + 1
+   // cannot overflow as the MAC length is small.
+   const size_t input_size = add_or_throw(input_length, mac_in_plaintext + 1, "TLS CBC input too large");
+   return add_or_throw(round_up(input_size, block_size()), mac_appended, "TLS CBC input too large");
 }
 
 void TLS_CBC_HMAC_AEAD_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
@@ -206,15 +214,17 @@ void TLS_CBC_HMAC_AEAD_Encryption::finish_msg(secure_vector<uint8_t>& buffer, si
 
    const size_t msg_size = msg().size();
 
-   const size_t input_size = msg_size + 1 + (use_encrypt_then_mac() ? 0 : tag_size());
+   const size_t input_size =
+      add_or_throw(msg_size, (use_encrypt_then_mac() ? 0 : tag_size()) + 1, "TLS CBC input too large");
    const size_t enc_size = round_up(input_size, block_size());
    BOTAN_DEBUG_ASSERT(enc_size % block_size() == 0);
 
    const uint8_t padding_val = static_cast<uint8_t>(enc_size - input_size);
    const size_t padding_length = static_cast<size_t>(padding_val) + 1;
 
-   buffer.reserve(offset + msg_size + padding_length + tag_size());
-   buffer.resize(offset + msg_size);
+   const size_t output_size = add_or_throw(offset, msg_size, "TLS CBC input too large");
+   buffer.reserve(add_or_throw(output_size, padding_length + tag_size(), "TLS CBC input too large"));
+   buffer.resize(output_size);
    if(msg_size > 0) {
       copy_mem(&buffer[offset], msg().data(), msg_size);
    }
@@ -228,13 +238,13 @@ void TLS_CBC_HMAC_AEAD_Encryption::finish_msg(secure_vector<uint8_t>& buffer, si
 
       cbc_encrypt_record(buffer, offset, padding_length);
       mac().update(&buffer[offset], enc_size);
-      buffer.resize(buffer.size() + tag_size());
+      buffer.resize(add_or_throw(buffer.size(), tag_size(), "TLS CBC input too large"));
       mac().final(&buffer[buffer.size() - tag_size()]);
    } else {
       if(msg_size > 0) {
          mac().update(&buffer[offset], msg_size);
       }
-      buffer.resize(buffer.size() + tag_size());
+      buffer.resize(add_or_throw(buffer.size(), tag_size(), "TLS CBC input too large"));
       mac().final(&buffer[buffer.size() - tag_size()]);
       cbc_encrypt_record(buffer, offset, padding_length);
    }

--- a/src/lib/tls/tls12/tls_null/tls_null.cpp
+++ b/src/lib/tls/tls12/tls_null/tls_null.cpp
@@ -12,6 +12,7 @@
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
 #include <botan/internal/fmt.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 
 namespace Botan::TLS {
@@ -122,16 +123,18 @@ void TLS_NULL_HMAC_AEAD_Encryption::set_associated_data_n(size_t idx, std::span<
 }
 
 size_t TLS_NULL_HMAC_AEAD_Encryption::output_length(size_t input_length) const {
-   return input_length + tag_size();
+   return add_or_throw(input_length, tag_size(), "TLS NULL input too large");
 }
 
 void TLS_NULL_HMAC_AEAD_Encryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    process(std::span{buffer}.subspan(offset));
-   buffer.resize(buffer.size() + tag_size());
+   const size_t output_size = add_or_throw(buffer.size(), tag_size(), "TLS NULL input too large");
+   buffer.resize(output_size);
    mac().final(std::span{buffer}.last(tag_size()));
 }
 
 size_t TLS_NULL_HMAC_AEAD_Decryption::output_length(size_t input_length) const {
+   BOTAN_ARG_CHECK(input_length >= tag_size(), "Message too short to be valid");
    return input_length - tag_size();
 }
 

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -284,8 +284,12 @@ void decrypt_record(secure_vector<uint8_t>& output,
    AEAD_Mode& aead = cs.aead();
 
    const std::vector<uint8_t> nonce = cs.aead_nonce(record_contents, record_len, record_sequence);
-   const uint8_t* msg = &record_contents[cs.nonce_bytes_from_record()];
-   const size_t msg_length = record_len - cs.nonce_bytes_from_record();
+   const size_t nonce_from_record = cs.nonce_bytes_from_record();
+   if(record_len <= nonce_from_record) {
+      throw TLS_Exception(Alert::BadRecordMac, "AEAD packet too short to be valid");
+   }
+   const uint8_t* msg = &record_contents[nonce_from_record];
+   const size_t msg_length = record_len - nonce_from_record;
 
    /*
    * This early rejection is based just on public information (length of the

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -20,6 +20,7 @@
 #include <botan/strong_type.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/stl_util.h>
 
@@ -465,19 +466,22 @@ class bitvector_base final {
        * @param bits   (optional) if not all @p bytes should be loaded in full
        */
       void from_bytes(std::span<const uint8_t> bytes, std::optional<size_type> bits = std::nullopt) {
-         m_bits = bits.value_or(bytes.size_bytes() * 8);
-         BOTAN_ARG_CHECK(m_bits <= bytes.size_bytes() * 8, "not enough data to load so many bits");
-         resize(m_bits);
+         const size_type new_bits = bits.has_value()
+                                       ? bits.value()
+                                       : mul_or_throw<size_t>(8, bytes.size_bytes(), "bitvector input is too large");
+         const size_type bytes_needed = (new_bits / 8) + (new_bits % 8 != 0 ? 1 : 0);
+         BOTAN_ARG_CHECK(bytes_needed <= bytes.size_bytes(), "not enough data to load so many bits");
+         resize(new_bits);
 
          // load as much aligned data as possible
-         const auto verbatim_blocks = m_bits / block_size_bits;
+         const auto verbatim_blocks = new_bits / block_size_bits;
          const auto verbatim_bytes = verbatim_blocks * block_size_bytes;
          if(verbatim_blocks > 0) {
             typecast_copy(std::span{m_blocks}.first(verbatim_blocks), bytes.first(verbatim_bytes));
          }
 
          // load remaining unaligned data
-         for(size_type i = verbatim_bytes * 8; i < m_bits; ++i) {
+         for(size_type i = verbatim_bytes * 8; i < new_bits; ++i) {
             ref(i) = ((bytes[i >> 3] & (uint8_t(1) << (i & 7))) != 0);
          }
       }
@@ -921,7 +925,7 @@ class bitvector_base final {
       }
 
       static constexpr size_type ceil_toblocks(size_type bits) {
-         return (bits + block_size_bits - 1) / block_size_bits;
+         return add_or_throw(bits, block_size_bits - 1, "bitvector size is too large") / block_size_bits;
       }
 
       auto ref(size_type pos) const { return bitref<const block_type>(m_blocks, pos); }

--- a/src/lib/utils/int_utils.h
+++ b/src/lib/utils/int_utils.h
@@ -56,6 +56,36 @@ constexpr inline std::optional<T> checked_mul(T a, T b) {
    return r;
 }
 
+/**
+* Add @p a and @p b, throwing Invalid_Argument with message @p msg if the
+* addition would overflow.
+*
+* TODO(Botan4) add std::source_location argument
+*/
+template <std::unsigned_integral T>
+constexpr T add_or_throw(T a, T b, std::string_view msg) {
+   if(auto r = checked_add(a, b)) {
+      return r.value();
+   } else {
+      throw Invalid_Argument(msg);
+   }
+}
+
+/**
+* Multiply @p a and @p b, throwing Invalid_Argument with message @p msg if the
+* multiplication would overflow.
+*
+* TODO(Botan4) add std::source_location argument
+*/
+template <std::unsigned_integral T>
+constexpr T mul_or_throw(T a, T b, std::string_view msg) {
+   if(auto r = checked_mul(a, b)) {
+      return r.value();
+   } else {
+      throw Invalid_Argument(msg);
+   }
+}
+
 template <typename RT, typename ExceptionType, typename AT>
    requires std::integral<strong_type_wrapped_type<RT>> && std::integral<strong_type_wrapped_type<AT>>
 constexpr RT checked_cast_to_or_throw(AT i, std::string_view error_msg_on_fail) {


### PR DESCRIPTION
These were all either currently unreachable due to prior checks (but potentially fragile under refactoring), or very theoretical (mostly involving a scenario of a 32-bit size_t, then somehow processing a 4 GB input)