### PR TITLE
Add iteration limits to X509 path building functions

### DIFF
--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -899,13 +899,24 @@ CertificatePathStatusCodes PKIX::check_crl_online(const std::vector<X509_Certifi
 Certificate_Status_Code PKIX::build_certificate_path(std::vector<X509_Certificate>& cert_path,
                                                      const std::vector<Certificate_Store*>& trusted_certstores,
                                                      const X509_Certificate& end_entity,
-                                                     const std::vector<X509_Certificate>& end_entity_extra) {
+                                                     const std::vector<X509_Certificate>& end_entity_extra,
+                                                     std::optional<size_t> max_paths) {
+   if(max_paths.has_value() && max_paths.value() == 0) {
+      return Certificate_Status_Code::EXCEEDED_SEARCH_LIMITS;
+   }
+
    CertificatePathBuilder builder(trusted_certstores, end_entity, end_entity_extra);
 
    std::vector<X509_Certificate> first_path;
+   size_t paths_examined = 0;
 
    while(auto path = builder.next()) {
       BOTAN_ASSERT_NOMSG(path->empty() == false);
+
+      if(max_paths.has_value() && paths_examined >= max_paths.value()) {
+         break;
+      }
+      paths_examined += 1;
 
       // Prefer paths ending in self-signed certificates.
       if(path->back().is_self_signed()) {
@@ -932,7 +943,8 @@ Certificate_Status_Code PKIX::build_certificate_path(std::vector<X509_Certificat
 Certificate_Status_Code PKIX::build_all_certificate_paths(std::vector<std::vector<X509_Certificate>>& cert_paths_out,
                                                           const std::vector<Certificate_Store*>& trusted_certstores,
                                                           const X509_Certificate& end_entity,
-                                                          const std::vector<X509_Certificate>& end_entity_extra) {
+                                                          const std::vector<X509_Certificate>& end_entity_extra,
+                                                          std::optional<size_t> max_paths) {
    if(!cert_paths_out.empty()) {
       throw Invalid_Argument("PKIX::build_all_certificate_paths: cert_paths_out must be empty");
    }
@@ -940,6 +952,10 @@ Certificate_Status_Code PKIX::build_all_certificate_paths(std::vector<std::vecto
 
    while(auto path = builder.next()) {
       BOTAN_ASSERT_NOMSG(path->empty() == false);
+      if(max_paths.has_value() && cert_paths_out.size() >= max_paths.value()) {
+         // More paths exist than the caller permitted us to enumerate
+         return Certificate_Status_Code::EXCEEDED_SEARCH_LIMITS;
+      }
       cert_paths_out.push_back(std::move(*path));
    }
 

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -13,6 +13,7 @@
 #include <botan/pkix_enums.h>
 #include <botan/x509cert.h>
 #include <chrono>
+#include <optional>
 #include <set>
 
 #if defined(BOTAN_TARGET_OS_HAS_THREADS) && defined(BOTAN_HAS_HTTP_UTIL)
@@ -361,13 +362,16 @@ namespace PKIX {
 * @param trusted_certstores list of certificate stores that contain trusted certificates
 * @param end_entity the cert to be validated
 * @param end_entity_extra optional list of additional untrusted certs for path building
+* @param max_paths if set, enumerate at most this many paths and return
+*        EXCEEDED_SEARCH_LIMITS if more paths exist; if nullopt, unbounded
 * @return result of the path building operation (OK or error)
 */
 Certificate_Status_Code BOTAN_PUBLIC_API(3, 11)
    build_all_certificate_paths(std::vector<std::vector<X509_Certificate>>& cert_paths,
                                const std::vector<Certificate_Store*>& trusted_certstores,
                                const X509_Certificate& end_entity,
-                               const std::vector<X509_Certificate>& end_entity_extra);
+                               const std::vector<X509_Certificate>& end_entity_extra,
+                               std::optional<size_t> max_paths = std::nullopt);
 
 /**
 * Same as build_all_certificate_paths but only outputs a single path. If there are
@@ -381,6 +385,7 @@ Certificate_Status_Code BOTAN_PUBLIC_API(3, 11)
 * @param trusted_certstores list of certificate stores that contain trusted certificates
 * @param end_entity the cert to be validated
 * @param end_entity_extra optional list of additional untrusted certs for path building
+* @param max_paths if set, examine at most this many candidate paths; if nullopt, unbounded
 * @return result of the path building operation (OK or error)
 */
 BOTAN_DEPRECATED("Use build_all_certificate_paths")
@@ -388,7 +393,8 @@ Certificate_Status_Code BOTAN_PUBLIC_API(2, 0)
    build_certificate_path(std::vector<X509_Certificate>& cert_path_out,
                           const std::vector<Certificate_Store*>& trusted_certstores,
                           const X509_Certificate& end_entity,
-                          const std::vector<X509_Certificate>& end_entity_extra);
+                          const std::vector<X509_Certificate>& end_entity_extra,
+                          std::optional<size_t> max_paths = std::nullopt);
 
 /**
 * Check the certificate chain, but not any revocation data

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -905,6 +905,19 @@ class Non_Self_Signed_Trust_Anchors_Test final : public Test {
                                to_string(Botan::Certificate_Status_Code::OK));
             test_arb_eq(result, "build_all_certificate_paths paths", cert_paths, expected_paths);
 
+            // Capped enumeration: asking for fewer than the available paths returns
+            // EXCEEDED_SEARCH_LIMITS with exactly that many paths.
+            if(expected_paths.size() > 1) {
+               std::vector<Cert_Path> capped_paths;
+               const auto capped_res = Botan::PKIX::build_all_certificate_paths(
+                  capped_paths, {&cert_store}, certs.at(0), certs, expected_paths.size() - 1);
+               result.test_enum_eq("build_all_certificate_paths capped result",
+                                   capped_res,
+                                   Botan::Certificate_Status_Code::EXCEEDED_SEARCH_LIMITS);
+               result.test_sz_eq(
+                  "build_all_certificate_paths capped count", capped_paths.size(), expected_paths.size() - 1);
+            }
+
             Cert_Path cert_path;
             const auto build_path_res =
                Botan::PKIX::build_certificate_path(cert_path, {&cert_store}, certs.at(0), certs);


### PR DESCRIPTION
Already this is in place for certificate validation, but path building had no such limitations. Add an optional limit on how many paths are examined.