### PR TITLE
Remove noexcept annotations from functions which might throw

### DIFF
--- a/src/lib/codec/base32/base32.cpp
+++ b/src/lib/codec/base32/base32.cpp
@@ -22,7 +22,7 @@ namespace {
 
 class Base32 final {
    public:
-      static std::string name() noexcept { return "base32"; }
+      static std::string name() { return "base32"; }
 
       static constexpr size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
 

--- a/src/lib/codec/base64/base64.cpp
+++ b/src/lib/codec/base64/base64.cpp
@@ -21,7 +21,7 @@ namespace {
 
 class Base64 final {
    public:
-      static std::string name() noexcept { return "base64"; }
+      static std::string name() { return "base64"; }
 
       static constexpr size_t encoding_bytes_in() noexcept { return m_encoding_bytes_in; }
 

--- a/src/lib/prov/pkcs11/p11_mechanism.cpp
+++ b/src/lib/prov/pkcs11/p11_mechanism.cpp
@@ -53,7 +53,7 @@ class MechanismData {
 
 class RSA_SignMechanism final : public MechanismData {
    public:
-      explicit RSA_SignMechanism(MechanismType typ) noexcept :
+      explicit RSA_SignMechanism(MechanismType typ) :
             MechanismData(typ), m_hash(static_cast<MechanismType>(0)), m_mgf(MGF::MgfUnused), m_salt_size(0) {
          auto pss_option = PssOptions().find(type());
          if(pss_option != PssOptions().end()) {

--- a/src/lib/prov/tpm2/tpm2_algo_mappings.h
+++ b/src/lib/prov/tpm2/tpm2_algo_mappings.h
@@ -82,7 +82,7 @@ namespace Botan::TPM2 {
  * @returns a Botan hash name string if the @p hash_id value is known,
  *          otherwise std::nullopt
  */
-[[nodiscard]] inline std::optional<std::string> hash_algo_tss2_to_botan(TPMI_ALG_HASH hash_id) noexcept {
+[[nodiscard]] inline std::optional<std::string> hash_algo_tss2_to_botan(TPMI_ALG_HASH hash_id) {
    switch(hash_id) {
       case TPM2_ALG_SHA1:
          return "SHA-1";
@@ -118,7 +118,7 @@ namespace Botan::TPM2 {
 }
 
 [[nodiscard]] inline std::optional<std::string> block_cipher_tss2_to_botan(TPMI_ALG_SYM cipher_id,
-                                                                           TPM2_KEY_BITS key_bits) noexcept {
+                                                                           TPM2_KEY_BITS key_bits) {
    switch(cipher_id) {
       case TPM2_ALG_AES:
          if(key_bits == 128) {
@@ -279,7 +279,7 @@ namespace Botan::TPM2 {
  * @returns a Botan cipher mode name string if the @p cipher_id, @p key_bits and
  *          @p mode_name are known, otherwise std::nullopt
  */
-[[nodiscard]] inline std::optional<std::string> cipher_tss2_to_botan(TPMT_SYM_DEF cipher_def) noexcept {
+[[nodiscard]] inline std::optional<std::string> cipher_tss2_to_botan(TPMT_SYM_DEF cipher_def) {
    const auto cipher_name = block_cipher_tss2_to_botan(cipher_def.algorithm, cipher_def.keyBits.sym);
    const auto mode_name = cipher_mode_tss2_to_botan(cipher_def.mode.sym);
 

--- a/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
+++ b/src/lib/prov/tpm2/tpm2_crypto_backend/tpm2_crypto_backend_impl.cpp
@@ -72,11 +72,12 @@ template <typename T>
       return std::nullopt;
    }
 
-   if(!std::holds_alternative<std::unique_ptr<T>>(blob->ctx)) {
+   auto* ctx = std::get_if<std::unique_ptr<T>>(&blob->ctx);
+   if(ctx == nullptr) {
       return std::nullopt;
    }
 
-   return {std::ref(*std::get<std::unique_ptr<T>>(blob->ctx))};
+   return {std::ref(**ctx)};
 }
 
 template <typename T>

--- a/src/lib/prov/tpm2/tpm2_error.cpp
+++ b/src/lib/prov/tpm2/tpm2_error.cpp
@@ -37,7 +37,7 @@ TSS2_RC get_raw_rc(TSS2_RC rc) {
 
 namespace {
 
-std::string raw_rc_to_string(TSS2_RC rc) noexcept {
+std::string raw_rc_to_string(TSS2_RC rc) {
    switch(rc) {
       case TPM2_RC_SUCCESS:
          return "TPM2_RC_SUCCESS";

--- a/src/lib/prov/tpm2/tpm2_object.cpp
+++ b/src/lib/prov/tpm2/tpm2_object.cpp
@@ -105,7 +105,9 @@ void Object::_reset() noexcept {
 
 /// Reset the object's internal state without flushing its TPM handles
 void Object::_disengage() noexcept {
-   m_handles = std::make_unique<ObjectHandles>();
+   if(m_handles) {
+      *m_handles = ObjectHandles();
+   }
    m_public_info.reset();
 }
 

--- a/src/lib/prov/tpm2/tpm2_session.h
+++ b/src/lib/prov/tpm2/tpm2_session.h
@@ -171,7 +171,7 @@ class SessionBundle {
                     std::shared_ptr<Session> s3 = nullptr) :
             m_sessions({std::move(s1), std::move(s2), std::move(s3)}) {}
 
-      [[nodiscard]] detail::SessionHandle operator[](size_t i) const noexcept {
+      [[nodiscard]] detail::SessionHandle operator[](size_t i) const {
          if(m_sessions[i] == nullptr) {
             return {};
          } else {

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_keys.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_keys.h
@@ -96,16 +96,12 @@ class Dilithium_PrivateKeyInternal final {
       void _const_time_poison() const {
          // Note: m_rho and m_tr is public knowledge
          CT::poison_all(m_signing_seed, m_s1, m_s2, m_t0);
-         if(m_seed.has_value()) {
-            CT::poison(m_seed.value());
-         }
+         CT::poison(m_seed);
       }
 
       void _const_time_unpoison() const {
          CT::unpoison_all(m_signing_seed, m_s1, m_s2, m_t0);
-         if(m_seed.has_value()) {
-            CT::unpoison(*m_seed);
-         }
+         CT::unpoison(m_seed);
       }
 
    private:

--- a/src/lib/pubkey/pqcrystals/pqcrystals.h
+++ b/src/lib/pubkey/pqcrystals/pqcrystals.h
@@ -375,7 +375,7 @@ class PolynomialVector {
       template <Domain OtherD>
          requires(D != OtherD)
       /* NOLINTNEXTLINE(*rvalue-reference-param-not-moved) */ explicit PolynomialVector(
-         PolynomialVector<Trait, OtherD>&& other) noexcept :
+         PolynomialVector<Trait, OtherD>&& other) :
             m_polys_storage(std::move(other.m_polys_storage)) {
          BOTAN_DEBUG_ASSERT(m_polys_storage.size() % Trait::N == 0);
          const size_t vecsize = m_polys_storage.size() / Trait::N;

--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -5,12 +5,12 @@
 * Botan is released under the Simplified BSD License (see license.txt)
 */
 
+#include <botan/assert.h>
 #include <botan/tls_signature_scheme.h>
 
 #include <botan/pk_keys.h>
 #include <botan/pss_params.h>
 #include <botan/tls_version.h>
-#include <botan/internal/stl_util.h>
 
 namespace Botan::TLS {
 
@@ -51,14 +51,27 @@ Signature_Scheme::Signature_Scheme(uint16_t wire_code) : Signature_Scheme(Signat
 Signature_Scheme::Signature_Scheme(Signature_Scheme::Code wire_code) : m_code(wire_code) {}
 
 bool Signature_Scheme::is_available() const noexcept {
-   return value_exists(Signature_Scheme::all_available_schemes(), *this);
+   switch(m_code) {
+      case RSA_PSS_SHA384:
+      case RSA_PSS_SHA256:
+      case RSA_PSS_SHA512:
+      case RSA_PKCS1_SHA384:
+      case RSA_PKCS1_SHA512:
+      case RSA_PKCS1_SHA256:
+      case ECDSA_SHA384:
+      case ECDSA_SHA512:
+      case ECDSA_SHA256:
+         return true;
+      default:
+         return false;
+   }
 }
 
 bool Signature_Scheme::is_set() const noexcept {
    return m_code != NONE;
 }
 
-std::string Signature_Scheme::to_string() const noexcept {
+std::string Signature_Scheme::to_string() const {
    switch(m_code) {
       case RSA_PKCS1_SHA1:
          return "RSA_PKCS1_SHA1";
@@ -95,7 +108,7 @@ std::string Signature_Scheme::to_string() const noexcept {
    }
 }
 
-std::string Signature_Scheme::hash_function_name() const noexcept {
+std::string Signature_Scheme::hash_function_name() const {
    switch(m_code) {
       case RSA_PKCS1_SHA1:
       case ECDSA_SHA1:
@@ -125,7 +138,7 @@ std::string Signature_Scheme::hash_function_name() const noexcept {
    }
 }
 
-std::string Signature_Scheme::padding_string() const noexcept {
+std::string Signature_Scheme::padding_string() const {
    switch(m_code) {
       case RSA_PKCS1_SHA1:
          return "PKCS1v15(SHA-1)";
@@ -161,7 +174,7 @@ std::string Signature_Scheme::padding_string() const noexcept {
    }
 }
 
-std::string Signature_Scheme::algorithm_name() const noexcept {
+std::string Signature_Scheme::algorithm_name() const {
    switch(m_code) {
       case RSA_PKCS1_SHA1:
       case RSA_PKCS1_SHA256:
@@ -189,7 +202,7 @@ std::string Signature_Scheme::algorithm_name() const noexcept {
    }
 }
 
-AlgorithmIdentifier Signature_Scheme::key_algorithm_identifier() const noexcept {
+AlgorithmIdentifier Signature_Scheme::key_algorithm_identifier() const {
    const auto der_encode_oid = [](const std::string_view oid_name) {
       try {
          if(auto oid = OID::from_name(oid_name)) {
@@ -227,7 +240,7 @@ AlgorithmIdentifier Signature_Scheme::key_algorithm_identifier() const noexcept 
    }
 }
 
-AlgorithmIdentifier Signature_Scheme::algorithm_identifier() const noexcept {
+AlgorithmIdentifier Signature_Scheme::algorithm_identifier() const {
    switch(m_code) {
       case RSA_PKCS1_SHA1:
          return AlgorithmIdentifier(OID::from_string("RSA/PKCS1v15(SHA-1)"), AlgorithmIdentifier::USE_NULL_PARAM);
@@ -290,7 +303,7 @@ bool Signature_Scheme::is_compatible_with(const Protocol_Version& protocol_versi
    //   CertificateVerify messages.
    //
    // Note that Botan enforces that for TLS 1.2 as well.
-   if(hash_function_name() == "SHA-1") {
+   if(m_code == RSA_PKCS1_SHA1 || m_code == ECDSA_SHA1) {
       return false;
    }
 
@@ -307,7 +320,7 @@ bool Signature_Scheme::is_compatible_with(const Protocol_Version& protocol_versi
    return true;
 }
 
-bool Signature_Scheme::is_suitable_for(const Private_Key& private_key) const noexcept {
+bool Signature_Scheme::is_suitable_for(const Private_Key& private_key) const {
    if(algorithm_name() != private_key.algo_name()) {
       return false;
    }

--- a/src/lib/tls/tls_signature_scheme.h
+++ b/src/lib/tls/tls_signature_scheme.h
@@ -83,12 +83,12 @@ class BOTAN_PUBLIC_API(3, 0) Signature_Scheme final {
       */
       bool is_set() const noexcept;
 
-      std::string to_string() const noexcept;
-      std::string hash_function_name() const noexcept;
-      std::string padding_string() const noexcept;
-      std::string algorithm_name() const noexcept;
-      AlgorithmIdentifier key_algorithm_identifier() const noexcept;
-      AlgorithmIdentifier algorithm_identifier() const noexcept;
+      std::string to_string() const;
+      std::string hash_function_name() const;
+      std::string padding_string() const;
+      std::string algorithm_name() const;
+      AlgorithmIdentifier key_algorithm_identifier() const;
+      AlgorithmIdentifier algorithm_identifier() const;
       std::optional<Signature_Format> format() const noexcept;
 
       bool is_compatible_with(const Protocol_Version& protocol_version) const noexcept;
@@ -101,7 +101,7 @@ class BOTAN_PUBLIC_API(3, 0) Signature_Scheme final {
       * pairs with no curve binding -- any hash may be used with any ECDSA
       * curve per RFC 5246.
       */
-      bool is_suitable_for(const Private_Key& private_key) const noexcept;
+      bool is_suitable_for(const Private_Key& private_key) const;
 
       bool operator==(const Signature_Scheme& rhs) const { return m_code == rhs.m_code; }
 

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -1270,8 +1270,13 @@ class bitvector_base final {
             //       If this assumption changes, we need to add further handling
             //       to process a byte padding at the beginning of the bitvector
             //       until a memory alignment boundary is reached.
-            const bool alignment = (ops.template is_memory_aligned_to<uint64_t>() && ...);
-            BOTAN_ASSERT_NOMSG(alignment);
+            //
+            // An empty range has no blocks to process and a possibly-null
+            // underlying buffer, so the alignment check does not apply.
+            if(detail::first(ops...).size() != 0) {
+               const bool alignment = (ops.template is_memory_aligned_to<uint64_t>() && ...);
+               BOTAN_ASSERT_NOMSG(alignment);
+            }
 
             return _process_in_fully_aligned_blocks_of<uint64_t>(fn, ops...) &&
                    _process_in_fully_aligned_blocks_of<uint32_t>(fn, ops...) &&

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -450,8 +450,17 @@ class bitvector_base final {
        * @returns true if @p other contains the same bit pattern as this
        */
       template <bitvectorish OtherT>
-      bool equals(const OtherT& other) const {
-         return (*this ^ other).none();
+      bool equals(const OtherT& other) const noexcept {
+         if(size() != other.size()) {
+            return false;
+         }
+
+         uint64_t acc = 0;
+         full_range_operation(
+            [&]<std::unsigned_integral BlockT>(BlockT lhs, BlockT rhs) { acc |= static_cast<uint64_t>(lhs ^ rhs); },
+            *this,
+            unwrap_strong_type(other));
+         return !CT::Choice::from_int(acc).as_bool();
       }
 
       /// @name Serialization

--- a/src/lib/utils/locking_allocator/locking_allocator.cpp
+++ b/src/lib/utils/locking_allocator/locking_allocator.cpp
@@ -44,15 +44,21 @@ bool mlock_allocator::deallocate(void* p, size_t num_elems, size_t elem_size) no
 }
 
 mlock_allocator::mlock_allocator() noexcept {
-   const size_t mem_to_lock = OS::get_memory_locking_limit();
-   const size_t page_size = OS::system_page_size();
+   try {
+      const size_t mem_to_lock = OS::get_memory_locking_limit();
+      const size_t page_size = OS::system_page_size();
 
-   if(mem_to_lock > 0 && mem_to_lock % page_size == 0) {
-      m_locked_pages = OS::allocate_locked_pages(mem_to_lock / page_size);
+      if(mem_to_lock > 0 && mem_to_lock % page_size == 0) {
+         m_locked_pages = OS::allocate_locked_pages(mem_to_lock / page_size);
 
-      if(!m_locked_pages.empty()) {
-         m_pool = std::make_unique<Memory_Pool>(m_locked_pages, page_size);
+         if(!m_locked_pages.empty()) {
+            m_pool = std::make_unique<Memory_Pool>(m_locked_pages, page_size);
+         }
       }
+   } catch(...) {
+      OS::free_locked_pages(m_locked_pages);
+      m_locked_pages.clear();
+      m_pool.reset();
    }
 }
 

--- a/src/lib/utils/mem_pool/mem_pool.cpp
+++ b/src/lib/utils/mem_pool/mem_pool.cpp
@@ -290,7 +290,7 @@ class Bucket final {
       bool m_is_full;
 };
 
-Memory_Pool::Memory_Pool(const std::vector<void*>& pages, size_t page_size) noexcept : m_page_size(page_size) {
+Memory_Pool::Memory_Pool(const std::vector<void*>& pages, size_t page_size) : m_page_size(page_size) {
    for(auto* page : pages) {
       const uintptr_t p = reinterpret_cast<uintptr_t>(page);
 

--- a/src/lib/utils/mem_pool/mem_pool.h
+++ b/src/lib/utils/mem_pool/mem_pool.h
@@ -26,7 +26,7 @@ class BOTAN_TEST_API Memory_Pool final {
       * @param page_size the system page size, each page should
       *        point to exactly this much memory.
       */
-      Memory_Pool(const std::vector<void*>& pages, size_t page_size) noexcept;
+      Memory_Pool(const std::vector<void*>& pages, size_t page_size);
 
       ~Memory_Pool() noexcept;
 

--- a/src/tests/test_utils_bitvector.cpp
+++ b/src/tests/test_utils_bitvector.cpp
@@ -362,6 +362,45 @@ std::vector<Test::Result> test_bitvector_capacity(Botan::RandomNumberGenerator& 
                result.test_is_true("XOR sets differing bit 1", xor_ab.at(1).is_set());
                result.test_is_true("XOR clears common bit 3", !xor_ab.at(3).is_set());
             }),
+
+      CHECK("comparison and reduction of empty bitvectors",
+            [](Test::Result& result) {
+               const Botan::bitvector empty1;
+               const Botan::bitvector empty2;
+               result.test_is_true("empty is empty", empty1.empty());
+               result.test_sz_eq("empty has zero size", empty1.size(), size_t(0));
+
+               // Full-range reductions on an empty bitvector must not throw or
+               // terminate (the underlying buffer may be null).
+               result.test_is_true("empty none()", empty1.none());
+               result.test_is_true("empty none_vartime()", empty1.none_vartime());
+               result.test_is_true("empty !any()", !empty1.any());
+               result.test_is_true("empty !any_vartime()", !empty1.any_vartime());
+               result.test_is_true("empty all()", empty1.all());
+               result.test_is_true("empty all_vartime()", empty1.all_vartime());
+               result.test_sz_eq("empty hamming_weight()", empty1.hamming_weight(), size_t(0));
+
+               // Two empty bitvectors compare equal. equals() is constant-time
+               // and noexcept, so a throw here would call std::terminate().
+               result.test_is_true("empty equals empty", empty1.equals(empty2));
+               result.test_is_true("empty equals_vartime empty", empty1.equals_vartime(empty2));
+               result.test_is_true("empty == empty", empty1 == empty2);
+               result.test_is_true("empty not != empty", !(empty1 != empty2));
+
+               // Mismatched sizes must compare unequal without touching blocks.
+               const Botan::bitvector nonempty(8);
+               result.test_is_true("empty does not equal non-empty", !empty1.equals(nonempty));
+               result.test_is_true("empty does not equal_vartime non-empty", !empty1.equals_vartime(nonempty));
+               result.test_is_true("empty != non-empty", empty1 != nonempty);
+
+               // Same coverage for the secure allocator, whose empty buffer is
+               // likewise potentially null.
+               const Botan::secure_bitvector sempty1;
+               const Botan::secure_bitvector sempty2;
+               result.test_is_true("empty secure none()", sempty1.none());
+               result.test_is_true("empty secure equals empty", sempty1.equals(sempty2));
+               result.test_is_true("empty secure == empty", sempty1 == sempty2);
+            }),
    };
 }
 


### PR DESCRIPTION
Typically this only could really happen if allocation failed (std::bad_alloc) but still we do not want the application to terminate if this happens.