### PR TITLE
Optimize Streebog compression scheduling on ARM64

### DIFF
--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -64,6 +64,43 @@ inline void lps(uint64_t block[8]) {
    }
 }
 
+#if defined(BOTAN_TARGET_ARCH_IS_ARM64) && \
+   (defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XCODE))
+// Apply two independent LPS transformations together. This exposes the table
+// lookups from both states to the compiler, improving instruction scheduling in
+// the compression loop where A and hN are transformed back-to-back. This
+// formulation regresses performance on x86_64 and with GCC on ARM64.
+inline void lps2(uint64_t block_a[8], uint64_t block_b[8]) {
+   const uint64_t block2_a[8] = {
+      block_a[0], block_a[1], block_a[2], block_a[3], block_a[4], block_a[5], block_a[6], block_a[7]};
+   const uint64_t block2_b[8] = {
+      block_b[0], block_b[1], block_b[2], block_b[3], block_b[4], block_b[5], block_b[6], block_b[7]};
+
+   const std::span<const uint8_t> a{reinterpret_cast<const uint8_t*>(block2_a), 64};
+   const std::span<const uint8_t> b{reinterpret_cast<const uint8_t*>(block2_b), 64};
+
+   uint64_t acc_a[8];
+   uint64_t acc_b[8];
+
+   for(int i = 0; i < 8; ++i) {
+      acc_a[i] = force_le(STREEBOG_Ax[0][a[i]]);
+      acc_b[i] = force_le(STREEBOG_Ax[0][b[i]]);
+   }
+
+   for(int k = 1; k < 8; ++k) {
+      for(int i = 0; i < 8; ++i) {
+         acc_a[i] ^= force_le(STREEBOG_Ax[k][a[i + k * 8]]);
+         acc_b[i] ^= force_le(STREEBOG_Ax[k][b[i + k * 8]]);
+      }
+   }
+
+   for(int i = 0; i < 8; ++i) {
+      block_a[i] = acc_a[i];
+      block_b[i] = acc_b[i];
+   }
+}
+#endif
+
 }  //namespace
 
 std::unique_ptr<HashFunction> Streebog::copy_state() const {
@@ -204,9 +241,13 @@ void Streebog::compress_64(const uint64_t M[], bool last_block) {
       for(size_t j = 0; j != 8; ++j) {
          A[j] ^= force_le(STREEBOG_C[i][7 - j]);
       }
+#if defined(BOTAN_TARGET_ARCH_IS_ARM64) && \
+   (defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XCODE))
+      lps2(A, hN);
+#else
       lps(A);
-
       lps(hN);
+#endif
       for(size_t j = 0; j != 8; ++j) {
          hN[j] ^= A[j];
       }

--- a/src/lib/hash/streebog/streebog.cpp
+++ b/src/lib/hash/streebog/streebog.cpp
@@ -119,6 +119,43 @@ inline void lps(uint64_t block[8]) {
    }
 }
 
+#if defined(BOTAN_TARGET_ARCH_IS_ARM64) && \
+   (defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XCODE))
+// Apply two independent LPS transformations together. This exposes the table
+// lookups from both states to the compiler, improving instruction scheduling in
+// the compression loop where A and hN are transformed back-to-back. This
+// formulation regresses performance on x86_64 and with GCC on ARM64.
+inline void lps2(uint64_t block_a[8], uint64_t block_b[8]) {
+   const uint64_t block2_a[8] = {
+      block_a[0], block_a[1], block_a[2], block_a[3], block_a[4], block_a[5], block_a[6], block_a[7]};
+   const uint64_t block2_b[8] = {
+      block_b[0], block_b[1], block_b[2], block_b[3], block_b[4], block_b[5], block_b[6], block_b[7]};
+
+   const std::span<const uint8_t> a{reinterpret_cast<const uint8_t*>(block2_a), 64};
+   const std::span<const uint8_t> b{reinterpret_cast<const uint8_t*>(block2_b), 64};
+
+   uint64_t acc_a[8];
+   uint64_t acc_b[8];
+
+   for(int i = 0; i < 8; ++i) {
+      acc_a[i] = force_le(STREEBOG_Ax[0][a[i]]);
+      acc_b[i] = force_le(STREEBOG_Ax[0][b[i]]);
+   }
+
+   for(int k = 1; k < 8; ++k) {
+      for(int i = 0; i < 8; ++i) {
+         acc_a[i] ^= force_le(STREEBOG_Ax[k][a[i + k * 8]]);
+         acc_b[i] ^= force_le(STREEBOG_Ax[k][b[i + k * 8]]);
+      }
+   }
+
+   for(int i = 0; i < 8; ++i) {
+      block_a[i] = acc_a[i];
+      block_b[i] = acc_b[i];
+   }
+}
+#endif
+
 }  //namespace
 
 std::unique_ptr<HashFunction> Streebog::copy_state() const {
@@ -221,9 +258,13 @@ void Streebog::compress_64(const uint64_t M[], bool last_block) {
       for(size_t j = 0; j != 8; ++j) {
          A[j] ^= force_le(STREEBOG_C[i][7 - j]);
       }
+#if defined(BOTAN_TARGET_ARCH_IS_ARM64) && \
+   (defined(BOTAN_BUILD_COMPILER_IS_CLANG) || defined(BOTAN_BUILD_COMPILER_IS_XCODE))
+      lps2(A, hN);
+#else
       lps(A);
-
       lps(hN);
+#endif
       for(size_t j = 0; j != 8; ++j) {
          hN[j] ^= A[j];
       }


### PR DESCRIPTION
This improves Streebog throughput on ARM64 by applying two independent LPS transformations together inside `Streebog::compress_64`.

In each round, `A` and `hN` are transformed back-to-back and are independent at that point. The new ARM64-only helper processes both states together, exposing more table lookups to the compiler and improving instruction scheduling. The algorithm and output are unchanged.

The optimization is limited to `BOTAN_TARGET_ARCH_IS_ARM64`. Testing on x86_64 showed that applying this unconditionally regressed performance, likely due to increased register pressure, so other architectures keep the existing two separate `lps` calls.

**Benchmarks**

Commands used:

```sh
for i in 1 2 3 ; do
  botan speed --msec=3000 --buf-size=8192 Streebog-256 Streebog-512
  botan speed --msec=3000 --buf-size=65536 Streebog-256 Streebog-512
  botan speed --msec=3000 --buf-size=1048576 Streebog-256 Streebog-512
done
```

Median throughput from 3 runs:

```text
ARM64

Buffer      Algorithm      Before       After        Change
8192        Streebog-256   221.9 MiB/s  290.9 MiB/s  +31.1%
8192        Streebog-512   222.0 MiB/s  295.2 MiB/s  +33.0%
65536       Streebog-256   227.3 MiB/s  295.6 MiB/s  +30.1%
65536       Streebog-512   226.0 MiB/s  295.9 MiB/s  +30.9%
1048576     Streebog-256   227.6 MiB/s  303.3 MiB/s  +33.3%
1048576     Streebog-512   227.1 MiB/s  303.7 MiB/s  +33.7%
```

**Testing**

```sh
python3 configure.py --with-build-dir=build/streebog-lps2-guarded \
  --build-targets=static,cli,tests --disable-shared-library

make -f build/streebog-lps2-guarded/Makefile -j8 libs cli tests
build/streebog-lps2-guarded/botan-test hash_algos
```

`hash_algos` passed, including the Streebog-256 and Streebog-512 known-answer tests.