### PR TITLE
check output span length in hex_decode

### DIFF
--- a/src/lib/codec/hex/hex.cpp
+++ b/src/lib/codec/hex/hex.cpp
@@ -130,6 +130,9 @@ size_t hex_decode(uint8_t output[], std::string_view input, bool ignore_ws) {
 }
 
 size_t hex_decode(std::span<uint8_t> output, std::string_view input, bool ignore_ws) {
+   if(output.size() < (input.size() + 1) / 2) {
+      throw Invalid_Argument("hex_decode: output buffer is too short");
+   }
    return hex_decode(output.data(), input.data(), input.length(), ignore_ws);
 }
 

--- a/src/tests/test_codec.cpp
+++ b/src/tests/test_codec.cpp
@@ -216,6 +216,28 @@ BOTAN_REGISTER_TEST("codec", "base64", Base64_Tests);
 
 #endif
 
+class Hex_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("Hex");
+
+         // The span output overload must reject a buffer too small to hold the
+         // decoding instead of writing past the end, matching base64_decode.
+         std::vector<uint8_t> too_small(2);
+         result.test_throws("hex_decode rejects short output span",
+                            "hex_decode: output buffer is too short",
+                            [&]() { Botan::hex_decode(std::span{too_small}, "aabbccdd"); });
+
+         std::vector<uint8_t> exact(4);
+         const size_t written = Botan::hex_decode(std::span{exact}, "aabbccdd");
+         result.test_sz_eq("hex_decode into exact-sized span", written, 4);
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("codec", "hex", Hex_Tests);
+
 }  // namespace
 
 }  // namespace Botan_Tests


### PR DESCRIPTION
The std::span overload of hex_decode forwards straight to the raw pointer version without ever consulting output.size(), so the decoder writes input.length()/2 bytes (the leading clear_mem alone zeroes that many) into whatever span it was handed. Handing it a span shorter than the decoded output walks off the end; under AddressSanitizer this shows up as a heap-buffer-overflow WRITE inside hex_decode, reached purely through the public span API. While checking the codec helpers I noticed base64_decode(std::span,...) already rejects this exact case, so the two decoders disagreed on a basic safety property.

The fix rejects an undersized buffer up front, mirroring base64_decode. The bound is (input.size() + 1) / 2 rather than input.size() / 2 because an odd-length input still touches output[input.size()/2] for the trailing half nibble before that byte is reported as incomplete. Keeping the check inside the span overload means the buffer length travels with the buffer, so callers using the span form get the same guarantee the base64 form already provides.