### PR TITLE
Add a path validation warning for empty DN entries

### DIFF
--- a/src/lib/x509/cert_status.cpp
+++ b/src/lib/x509/cert_status.cpp
@@ -33,6 +33,8 @@ const char* to_string(Certificate_Status_Code code) {
          return "Trusted certificate has expired";
       case Certificate_Status_Code::OCSP_ISSUER_NOT_TRUSTED:
          return "OCSP issuer is not trustworthy";
+      case Certificate_Status_Code::EMPTY_DIRECTORYNAME:
+         return "DirectoryName was empty";
 
       case Certificate_Status_Code::NO_REVOCATION_DATA:
          return "No revocation data";

--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -37,6 +37,7 @@ enum class Certificate_Status_Code : uint16_t {
    OCSP_SERVER_NOT_AVAILABLE = 503,
    TRUSTED_CERT_HAS_EXPIRED = 504,
    TRUSTED_CERT_NOT_YET_VALID = 505,
+   EMPTY_DIRECTORYNAME = 506,
 
    // Errors
    FIRST_ERROR_STATUS = 1000,

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -375,8 +375,12 @@ CertificatePathStatusCodes PKIX::check_chain(const std::vector<X509_Certificate>
 
       for(const auto& rdn : subject.subject_dn().rdns()) {
          for(const auto& ava : rdn) {
+            const size_t dn_len = ava.second.size();
             const size_t dn_ub = X509_DN::lookup_ub(ava.first);
-            if(dn_ub > 0 && ava.second.size() > dn_ub) {
+            if(dn_len == 0) {
+               // RFC 5280 DirectoryStrings are supposed to be non-empty
+               status.insert(Certificate_Status_Code::EMPTY_DIRECTORYNAME);
+            } else if(dn_ub > 0 && dn_len > dn_ub) {
                status.insert(Certificate_Status_Code::DN_TOO_LONG);
             }
          }


### PR DESCRIPTION
RFC 5280's DirectoryString definition clearly indicates it should be non-empty. Add a warning during path validation for this, similar to the DN too long issue.