### PR TITLE
Add X509_DN::parse and improve DN string parsing

### DIFF
--- a/src/lib/x509/asn1_alt_name.cpp
+++ b/src/lib/x509/asn1_alt_name.cpp
@@ -55,10 +55,11 @@ void AlternativeName::add_attribute(std::string_view type, std::string_view valu
    } else if(type == "URI") {
       this->add_uri(value);
    } else if(type == "DN") {
-      X509_DN dn;
-      std::istringstream ss{std::string(value)};
-      ss >> dn;
-      this->add_dn(dn);
+      if(auto dn = X509_DN::parse(value)) {
+         this->add_dn(*dn);
+      } else {
+         throw Invalid_Argument(fmt("Invalid X.509 DN '{}'", value));
+      }
    } else if(type == "IP") {
       if(auto ipv4 = IPv4Address::from_string(value)) {
          add_ipv4_address(*ipv4);
@@ -176,11 +177,9 @@ X509_DN AlternativeName::dn() const {
    X509_DN combined_dn;
 
    for(const auto& dn : this->directory_names()) {
-      std::ostringstream oss;
-      oss << dn;
-
-      std::istringstream iss(oss.str());
-      iss >> combined_dn;
+      for(const auto& rdn : dn.rdns()) {
+         combined_dn.add_rdn(rdn);
+      }
    }
 
    return combined_dn;

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -23,6 +23,7 @@
 #include <iosfwd>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>
@@ -100,6 +101,17 @@ class BOTAN_PUBLIC_API(2, 0) X509_DN final : public ASN1_Object {
       std::string to_string() const;
 
       /**
+      * Parse the string representation of a distinguished name.
+      *
+      * The grammar accepted is a subset of RFC 4514 Section 3, but also accepts
+      * quoted-value forms ala RFC 2253. The entire input must be consumed.
+      *
+      * @param str the string to parse
+      * @return the parsed DN, or nullopt if @p str is not a well-formed DN
+      */
+      static std::optional<X509_DN> parse(std::string_view str);
+
+      /**
       * Return the DN as a sequence of RDNs. Each RDN is an X.501
       * SET OF AttributeTypeAndValue; the inner vector preserves the
       * decoded order but RDN equality is set-based per RFC 5280 7.1.
@@ -171,7 +183,12 @@ It is intended for allowing DNs as keys in std::map and similar containers
 BOTAN_PUBLIC_API(2, 0) bool operator<(const X509_DN& dn1, const X509_DN& dn2);
 
 BOTAN_PUBLIC_API(2, 0) std::ostream& operator<<(std::ostream& out, const X509_DN& dn);
-BOTAN_PUBLIC_API(2, 0) std::istream& operator>>(std::istream& in, X509_DN& dn);
+
+/**
+* Parse the input stream as a DN
+* Prefer X509_DN::parse
+*/
+BOTAN_DEPRECATED_API("Use X509_DN::parse") std::istream& operator>>(std::istream& in, X509_DN& dn);
 
 /**
 * Alternative Name
@@ -351,6 +368,12 @@ class BOTAN_PUBLIC_API(2, 0) AlternativeName final : public ASN1_Object {
 
       BOTAN_DEPRECATED("Use AlternativeName::othernames") std::multimap<OID, ASN1_String> get_othernames() const;
 
+      /**
+      * This returns all of the alternative name DNs combined into a single DN
+      *
+      * This result is not a valid DN. The logic is retained for compatibility,
+      * but this function should not be used. It will be removed in Botan4.
+      */
       BOTAN_DEPRECATED("Use AlternativeName::directory_names") X509_DN dn() const;
 
       BOTAN_DEPRECATED("Use plain constructor plus add_{uri,dns,email,ipv4_address}")

--- a/src/lib/x509/x509_dn.cpp
+++ b/src/lib/x509/x509_dn.cpp
@@ -14,6 +14,8 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/x509_utils.h>
 #include <algorithm>
+#include <istream>
+#include <iterator>
 #include <optional>
 #include <ostream>
 #include <sstream>
@@ -35,6 +37,40 @@ std::optional<uint8_t> hex_digit_value(char c) {
       return static_cast<uint8_t>(c - 'A' + 10);
    } else {
       return {};
+   }
+}
+
+/*
+* RFC 4514 Section 3 specifies which characters can be escaped
+*/
+bool is_escapable_char(char c) {
+   switch(c) {
+      case '\\':
+      case '"':
+      case '+':
+      case ',':
+      case ';':
+      case '<':
+      case '>':
+      case ' ':
+      case '#':
+      case '=':
+         return true;
+      default:
+         return false;
+   }
+}
+
+bool is_unescaped_special_value_char(char c) {
+   switch(c) {
+      case ';':
+      case '<':
+      case '>':
+      case '#':
+      case '=':
+         return true;
+      default:
+         return false;
    }
 }
 
@@ -510,97 +546,159 @@ std::ostream& operator<<(std::ostream& out, const X509_DN& dn) {
    return out;
 }
 
-std::istream& operator>>(std::istream& in, X509_DN& dn) {
-   in >> std::noskipws;
+/*
+* Parse the string representation of a distinguished name, accepting
+* the formats specified in RFC 4514 Section 3 as well as RFC 2253's
+* quoted format.
+*/
+std::optional<X509_DN> X509_DN::parse(std::string_view str) {
+   X509_DN dn;
 
-   // AVAs are buffered until we hit a ',' (or EOF), at which point they
-   // are flushed as a single RDN. A '+' between AVAs keeps them in the
-   // same RDN, matching the output of operator<<.
+   // AVAs accumulate here; a trailing '+' keeps the next AVA in the same
+   // RDN, while a ',' (or end of input) flushes them as a single RDN.
    std::vector<std::pair<OID, ASN1_String>> pending_rdn;
 
-   // NOLINTNEXTLINE(*-avoid-do-while)
-   do {
-      std::string key;
-      std::string val;
-      char c = 0;
+   // Separator that ended the previous AVA. A ',' or '+' still pending after the
+   // loop means the input ended with a separator and no AVA to follow it.
+   char terminator = '\0';
 
-      while(in.good()) {
-         in >> c;
-
-         if(is_space(c) && key.empty()) {
-            continue;
-         } else if(!is_space(c)) {
-            key.push_back(c);
-            break;
-         } else {
-            break;
-         }
+   size_t pos = 0;
+   while(pos < str.size()) {
+      // Whitespace separating an attributeType from the preceding ',' or '+'
+      // is tolerated even though RFC 4514 does not produce it.
+      while(pos < str.size() && is_space(str[pos])) {
+         ++pos;
       }
-
-      while(in.good()) {
-         in >> c;
-
-         if(!is_space(c) && c != '=') {
-            key.push_back(c);
-         } else if(c == '=') {
-            break;
-         } else {
-            throw Invalid_Argument("Ill-formed X.509 DN");
-         }
-      }
-
-      bool in_quotes = false;
-      char terminator = '\0';
-      while(in.good()) {
-         in >> c;
-
-         if(is_space(c)) {
-            if(!in_quotes && !val.empty()) {
-               break;
-            } else if(in_quotes) {
-               val.push_back(' ');
-            }
-         } else if(c == '"') {
-            in_quotes = !in_quotes;
-         } else if(c == '\\') {
-            char e = 0;
-            in >> e;
-            if(!in) {
-               // A trailing backslash is taken literally
-               val.push_back('\\');
-            } else if(const auto hi = hex_digit_value(e)) {
-               // Backslash plus two hex digits decodes to one octet (RFC 4514 2.4)
-               char lo_c = 0;
-               in >> lo_c;
-               const auto lo = hex_digit_value(lo_c);
-               if(!in || !lo) {
-                  throw Invalid_Argument("Ill-formed X.509 DN");
-               }
-               val.push_back(static_cast<char>((*hi << 4) | *lo));
-            } else {
-               val.push_back(e);
-            }
-         } else if((c == ',' || c == '+') && !in_quotes) {
-            terminator = c;
-            break;
-         } else {
-            val.push_back(c);
-         }
-      }
-
-      if(!key.empty() && !val.empty()) {
-         const OID oid = OID::from_string(X509_DN::deref_info_field(key));
-         pending_rdn.emplace_back(oid, ASN1_String(val));
-         if(terminator != '+') {
-            dn.add_rdn(std::move(pending_rdn));
-            pending_rdn.clear();
-         }
-      } else {
+      if(pos == str.size()) {
          break;
       }
-   } while(in.good());
 
-   dn.add_rdn(std::move(pending_rdn));
+      // attributeType, terminated by '='
+      const size_t type_start = pos;
+      while(pos < str.size() && str[pos] != '=' && !is_space(str[pos])) {
+         ++pos;
+      }
+      const std::string_view type = str.substr(type_start, pos - type_start);
+      if(type.empty() || pos == str.size() || str[pos] != '=') {
+         return std::nullopt;
+      }
+      ++pos;  // consume '='
+
+      /*
+      attributeValue, in RFC 4514 <string> form plus the legacy quoted form.
+      value_len tracks the length up to the last significant octet: leading and
+      trailing unescaped whitespace is not significant unless it was escaped or
+      quoted, so trailing whitespace is dropped by the final resize.
+      */
+      std::string value;
+      size_t value_len = 0;
+
+      // The legacy quoted form wraps the whole value: a quote is only an opening
+      // quote at the start of the value, and nothing but trailing whitespace or a
+      // separator may follow the closing quote.
+      enum class Quote : uint8_t { None, Open, Closed };
+      Quote quote = Quote::None;
+
+      terminator = '\0';
+
+      while(pos < str.size()) {
+         const char c = str[pos];
+
+         if(c == '"') {
+            if(quote == Quote::Open) {
+               quote = Quote::Closed;
+            } else if(quote == Quote::None && value.empty()) {
+               quote = Quote::Open;
+            } else {
+               return std::nullopt;  // quote in mid-value or after the closing quote
+            }
+            ++pos;
+         } else if(c == '\\') {
+            if(quote == Quote::Closed) {
+               return std::nullopt;  // escape after the closing quote
+            }
+            // pair = ESC ( ESC / special / hexpair )
+            ++pos;
+            if(pos == str.size()) {
+               return std::nullopt;
+            }
+            if(const auto hi = hex_digit_value(str[pos])) {
+               const auto lo = (pos + 1 < str.size()) ? hex_digit_value(str[pos + 1]) : std::nullopt;
+               if(!lo) {
+                  return std::nullopt;
+               }
+               value.push_back(static_cast<char>((*hi << 4) | *lo));
+               pos += 2;
+            } else if(is_escapable_char(str[pos])) {
+               value.push_back(str[pos]);
+               ++pos;
+            } else {
+               return std::nullopt;  // not ESC / special / hexpair
+            }
+            value_len = value.size();  // an escaped octet is always significant
+         } else if((c == ',' || c == '+') && quote != Quote::Open) {
+            terminator = c;
+            ++pos;
+            break;
+         } else if(quote == Quote::Closed) {
+            if(!is_space(c)) {
+               return std::nullopt;  // content after the closing quote
+            }
+            ++pos;  // trailing whitespace after the closing quote is insignificant
+         } else if(quote != Quote::Open && is_unescaped_special_value_char(c)) {
+            return std::nullopt;
+         } else {
+            ++pos;
+            if(is_space(c) && quote != Quote::Open) {
+               // Keep interior whitespace only if more content follows; skip it
+               // entirely while leading (value is still empty)
+               if(!value.empty()) {
+                  value.push_back(c);
+               }
+            } else {
+               value.push_back(c);
+               value_len = value.size();
+            }
+         }
+      }
+
+      if(quote == Quote::Open) {
+         return std::nullopt;  // unterminated quoted value
+      }
+      value.resize(value_len);  // strip trailing unescaped whitespace
+
+      try {
+         OID oid = OID::from_string(deref_info_field(type));
+         // ASN1_String rejects values (e.g. a \FF hexpair) that are not valid
+         // for any supported string encoding.
+         pending_rdn.emplace_back(std::move(oid), ASN1_String(value));
+      } catch(const Exception&) {
+         return std::nullopt;  // unknown attributeType or invalid attributeValue
+      }
+
+      if(terminator != '+') {
+         dn.add_rdn(std::move(pending_rdn));
+         pending_rdn.clear();
+      }
+   }
+
+   // A trailing ',' or '+' leaves an RDN/AVA with nothing to follow it
+   if(terminator == ',' || terminator == '+') {
+      return std::nullopt;
+   }
+   return dn;
+}
+
+std::istream& operator>>(std::istream& in, X509_DN& dn) {
+   const std::istreambuf_iterator<char> begin(in);
+   const std::istreambuf_iterator<char> end;
+   const std::string contents(begin, end);
+
+   if(auto parsed = X509_DN::parse(contents)) {
+      dn = std::move(*parsed);
+   } else {
+      in.setstate(std::ios::failbit);
+   }
    return in;
 }
 }  // namespace Botan

--- a/src/tests/data/x509/x509_dn_invalid.vec
+++ b/src/tests/data/x509/x509_dn_invalid.vec
@@ -1,0 +1,42 @@
+# No '=' delimiter
+Input = Alice
+# Bare attribute type, no value
+Input = CN
+# Empty attribute type
+Input = =Alice
+# Whitespace before '='
+Input = CN =Alice
+# Unterminated quoted value
+Input = CN="Alice
+# Dangling escape at end of input
+Input = CN=Alice\
+# Truncated hex escape
+Input = CN=\4
+# Non-hex digit in hex escape
+Input = CN=\4z
+# Empty RDN between separators
+Input = CN=A,,O=B
+# Unknown attribute type name
+Input = NoSuchType=x
+# Escape of a non-special character
+Input = CN=\q
+# Escape of an at sign
+Input = CN=\@
+# Escaped octet that is not valid UTF-8
+Input = CN=\FF
+# Trailing comma separator
+Input = CN=A,
+# Trailing plus separator
+Input = CN=A+
+# Quote in the middle of the value
+Input = CN=Al"ice"
+# Content after the closing quote
+Input = CN="Alice"junk
+# Reopened quote after an empty quoted value
+Input = CN=""Alice
+# Unescaped special characters in unquoted values
+Input = CN=A;B
+Input = CN=A<B
+Input = CN=A>B
+Input = CN=A#B
+Input = CN=A=B

--- a/src/tests/data/x509/x509_dn_valid.vec
+++ b/src/tests/data/x509/x509_dn_valid.vec
@@ -1,0 +1,83 @@
+# Empty string is the empty DN
+Input =
+DER = 3000
+
+# Single AVA, round-trips
+Input = CN="Alice"
+DER = 3010310E300C06035504031305416C696365
+
+# Two single-AVA RDNs, round-trips
+Input = CN="Alice",O="Example"
+DER = 3022310E300C06035504031305416C6963653110300E060355040A13074578616D706C65
+
+# Multi-AVA RDN ('+' keeps AVAs in one SET), round-trips
+Input = CN="Alice"+O="Example"
+DER = 3020311E300C06035504031305416C696365300E060355040A13074578616D706C65
+
+# Mixed single- and multi-AVA RDNs, round-trips
+Input = C="US",CN="Alice"+O="Example",OU="Eng"
+DER = 303B310B3009060355040613025553311E300C06035504031305416C696365300E060355040A13074578616D706C65310C300A060355040B1303456E67
+
+# Interior space is part of the value (PrintableString)
+Input = CN="Alice Smith"
+DER = 3016311430120603550403130B416C69636520536D697468
+
+# Value with non-PrintableString octet is encoded as UTF8String
+Input = CN="foo_bar"
+DER = 30123110300E06035504030C07666F6F5F626172
+
+# Embedded double quote, escaped as backslash-quote
+Input = CN="a\"b"
+DER = 300E310C300A06035504030C03612262
+
+# Embedded control character, hex-escaped on output
+Input = CN="ACME\1BTRUSTED"
+DER = 30173115301306035504030C0C41434D451B54525553544544
+
+# Embedded NUL, hex-escaped on output
+Input = CN="a\00b"
+DER = 300E310C300A06035504030C03610062
+
+# Unquoted value normalizes to the quoted form
+Input = CN=Alice
+Output = CN="Alice"
+DER = 3010310E300C06035504031305416C696365
+
+# Unquoted value keeps interior whitespace
+Input = CN=Alice Smith
+Output = CN="Alice Smith"
+DER = 3016311430120603550403130B416C69636520536D697468
+
+# Trailing whitespace before a separator is dropped
+Input = CN=Alice ,O="Example"
+Output = CN="Alice",O="Example"
+DER = 3022310E300C06035504031305416C6963653110300E060355040A13074578616D706C65
+
+# RFC 4514 unquoted escaping of a special character
+Input = CN=Smith\, Jones
+Output = CN="Smith, Jones"
+DER = 3017311530130603550403130C536D6974682C204A6F6E6573
+
+# Escaped special characters in an unquoted value
+Input = CN=A\;B\<C\>D\#E\=F
+Output = CN="A;B<C>D#E=F"
+DER = 30163114301206035504030C0B413B423C433E4423453D46
+
+# Escaped leading and trailing spaces are significant
+Input = CN=\20Alice\20
+Output = CN=" Alice "
+DER = 30123110300E0603550403130720416C69636520
+
+# Numeric OID for the type normalizes to its short form
+Input = 2.5.4.3=Alice
+Output = CN="Alice"
+DER = 3010310E300C06035504031305416C696365
+
+# Unregistered OID round-trips in dotted-decimal form
+Input = 1.2.3.4="Test"
+DER = 300F310D300B06032A0304130454657374
+
+# UTF-8 value, hex-escaped on input, raw on output
+Input = CN="Fr\C3\A4ulein"
+Output = CN="Fräulein"
+DER = 30143112301006035504030C094672C3A4756C65696E

--- a/src/tests/test_x509_dn.cpp
+++ b/src/tests/test_x509_dn.cpp
@@ -63,6 +63,67 @@ class X509_DN_Comparisons_Tests final : public Text_Based_Test {
 
 BOTAN_REGISTER_TEST("x509", "x509_dn_cmp", X509_DN_Comparisons_Tests);
 
+class X509_DN_Valid_String_Tests final : public Text_Based_Test {
+   public:
+      X509_DN_Valid_String_Tests() : Text_Based_Test("x509/x509_dn_valid.vec", "Input,DER", "Output") {}
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         Test::Result result("X509_DN valid string encoding");
+
+         const std::string input = vars.get_req_str("Input");
+         const std::vector<uint8_t> expected_der = vars.get_req_bin("DER");
+         const std::string expected_print = vars.get_opt_str("Output", input);
+
+         const auto parsed = Botan::X509_DN::parse(input);
+         if(!result.test_is_true("X509_DN::parse accepts valid input", parsed.has_value())) {
+            return result;
+         }
+
+         // The parsed DN must encode to exactly the expected bytes ...
+         result.test_bin_eq("DER encoding", parsed->DER_encode(), expected_der);
+
+         // ... and that DER must decode back to an equal DN
+         Botan::X509_DN decoded;
+         Botan::BER_Decoder ber(expected_der);
+         decoded.decode_from(ber);
+         ber.verify_end();
+         result.test_is_true("DER decodes to equal DN", *parsed == decoded);
+
+         // to_string reproduces the input exactly, unless it's not canonical
+         result.test_str_eq("string formatting", parsed->to_string(), expected_print);
+
+         // to_string of the parsed DN and the decoded-from-DER DN should be the same
+         result.test_str_eq("string formatting", parsed->to_string(), decoded.to_string());
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("x509", "x509_dn_valid", X509_DN_Valid_String_Tests);
+
+class X509_DN_Invalid_String_Tests final : public Text_Based_Test {
+   public:
+      X509_DN_Invalid_String_Tests() : Text_Based_Test("x509/x509_dn_invalid.vec", "Input") {}
+
+      Test::Result run_one_test(const std::string& /*header*/, const VarMap& vars) override {
+         Test::Result result("X509_DN invalid string rejection");
+
+         const std::string input = vars.get_req_str("Input");
+
+         result.test_is_false("parse rejects malformed input", Botan::X509_DN::parse(input).has_value());
+
+         // Stream extraction must signal the same failure via the failbit
+         std::istringstream iss(input);
+         Botan::X509_DN dn;
+         iss >> dn;
+         result.test_is_true("stream extraction sets failbit", iss.fail());
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("x509", "x509_dn_invalid", X509_DN_Invalid_String_Tests);
+
 class X509_DN_String_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
@@ -73,6 +134,7 @@ class X509_DN_String_Tests final : public Test {
          results.push_back(test_parse_multi_ava_rdn());
          results.push_back(test_mixed_single_and_multi_ava_round_trip());
          results.push_back(test_quoted_plus_in_value_not_split());
+         results.push_back(test_parse_rejects_trailing_separator_with_whitespace());
          results.push_back(test_decode_failure_leaves_dn_unchanged());
          results.push_back(test_value_escaping_round_trips());
          return results;
@@ -174,6 +236,20 @@ class X509_DN_String_Tests final : public Test {
          result.test_sz_eq("one RDN", parsed.count(), size_t(1));
          result.test_sz_eq("one AVA", parsed.rdns().at(0).size(), size_t(1));
          result.test_str_eq("value preserved", parsed.get_first_attribute("CN"), "A+B");
+         return result;
+      }
+
+      static Test::Result test_parse_rejects_trailing_separator_with_whitespace() {
+         Test::Result result("X509_DN parser rejects trailing separators");
+
+         // The test vector harness strips trailing whitespace from the input, so
+         // the whitespace-after-separator forms are checked here directly.
+         for(const auto* input : {"CN=A,   ", "CN=A+   ", "CN=A, \t"}) {
+            result.test_is_false(std::string("rejects '") + input + "'", Botan::X509_DN::parse(input).has_value());
+         }
+
+         // A separator with a following AVA is still accepted
+         result.test_is_true("accepts CN=A, O=B", Botan::X509_DN::parse("CN=A, O=B").has_value());
          return result;
       }
 


### PR DESCRIPTION
The operator>> interface is a bit funky to use; within our own usage we always just copied our input to a stringstream in order to parse a DN.

Fix various DN string parsing bugs, for example that `CN=Al"ice"` was accepted. Now parsing follows the rules from RFC 2253 and RFC 4514, though we only accept a subset of the overall syntax from those RFCs.