### PR TITLE
Consistently zero output data if AEAD tag or CBC padding fails

### DIFF
--- a/src/lib/modes/cbc/cbc.cpp
+++ b/src/lib/modes/cbc/cbc.cpp
@@ -239,6 +239,7 @@ void CBC_Decryption::finish_msg(secure_vector<uint8_t>& buffer, size_t offset) {
    const size_t pad_bytes = BS - padding().unpad(std::span{buffer}.last(BS));
    buffer.resize(buffer.size() - pad_bytes);  // remove padding
    if(pad_bytes == 0 && padding().name() != "NoPadding") {
+      clear_mem(std::span{buffer}.subspan(offset));
       throw Decoding_Error("Invalid CBC padding");
    }
 }

--- a/src/tests/test_aead.cpp
+++ b/src/tests/test_aead.cpp
@@ -474,6 +474,22 @@ class AEAD_Tests final : public Text_Based_Test {
             result.test_failure("Failure processing AEAD ciphertext", e.what());
          }
 
+         // On tag check failure, every AEAD must zero the unauthenticated
+         // plaintext in the caller's buffer before throwing
+         auto check_plaintext_cleared =
+            [&result, &dec](const std::string& msg, const Botan::secure_vector<uint8_t>& b, size_t ctext_and_tag_len) {
+               const size_t ptext_len = ctext_and_tag_len - dec->tag_size();
+               bool cleared = (b.size() >= ptext_len);
+               if(cleared) {
+                  uint8_t accum = 0;
+                  for(size_t i = 0; i != ptext_len; ++i) {
+                     accum |= b[i];
+                  }
+                  cleared = (accum == 0);
+               }
+               result.test_is_true(msg, cleared);
+            };
+
          // test decryption with modified ciphertext
          const std::vector<uint8_t> mutated_input = mutate_vec(input, rng, true);
          buf.assign(mutated_input.begin(), mutated_input.end());
@@ -488,6 +504,7 @@ class AEAD_Tests final : public Text_Based_Test {
             result.test_failure("accepted modified message", mutated_input);
          } catch(Botan::Integrity_Failure&) {
             result.test_success("correctly rejected modified message");
+            check_plaintext_cleared("plaintext zeroed after rejecting modified message", buf, mutated_input.size());
          } catch(std::exception& e) {
             result.test_failure("unexpected error while rejecting modified message", e.what());
          }
@@ -506,6 +523,7 @@ class AEAD_Tests final : public Text_Based_Test {
                result.test_failure("accepted message with modified nonce", bad_nonce);
             } catch(Botan::Integrity_Failure&) {
                result.test_success("correctly rejected modified nonce");
+               check_plaintext_cleared("plaintext zeroed after rejecting modified nonce", buf, input.size());
             } catch(std::exception& e) {
                result.test_failure("unexpected error while rejecting modified nonce", e.what());
             }
@@ -525,6 +543,7 @@ class AEAD_Tests final : public Text_Based_Test {
             result.test_failure("accepted message with modified ad", bad_ad);
          } catch(Botan::Integrity_Failure&) {
             result.test_success("correctly rejected modified ad");
+            check_plaintext_cleared("plaintext zeroed after rejecting modified ad", buf, input.size());
          } catch(std::exception& e) {
             result.test_failure("unexpected error while rejecting modified nonce", e.what());
          }

--- a/src/tests/test_modes.cpp
+++ b/src/tests/test_modes.cpp
@@ -473,6 +473,46 @@ class Cipher_Mode_IV_Carry_Tests final : public Test {
 
 BOTAN_REGISTER_TEST("modes", "iv_carryover", Cipher_Mode_IV_Carry_Tests);
 
+class CBC_Invalid_Padding_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("CBC invalid padding");
+
+   #if defined(BOTAN_HAS_MODE_CBC) && defined(BOTAN_HAS_AES)
+         auto enc = Botan::Cipher_Mode::create_or_throw("AES-128/CBC/NoPadding", Botan::Cipher_Dir::Encryption);
+         auto dec = Botan::Cipher_Mode::create_or_throw("AES-128/CBC/PKCS7", Botan::Cipher_Dir::Decryption);
+
+         const std::vector<uint8_t> key(16, 0xAB);
+         const std::vector<uint8_t> iv(16, 0xCD);
+
+         // A final byte of 0x00 is never valid PKCS#7 padding
+         Botan::secure_vector<uint8_t> buf(32, 0x42);
+         buf[31] = 0x00;
+
+         enc->set_key(key);
+         enc->start(iv);
+         enc->finish(buf);
+
+         dec->set_key(key);
+         dec->start(iv);
+
+         result.test_throws<Botan::Decoding_Error>("invalid CBC padding is rejected", [&]() { dec->finish(buf); });
+
+         // The decrypted but unverified plaintext must have been zeroed
+         result.test_sz_eq("buffer size unchanged after padding failure", buf.size(), 32);
+         uint8_t accum = 0;
+         for(const uint8_t b : buf) {
+            accum |= b;
+         }
+         result.test_is_true("plaintext zeroed after padding failure", accum == 0);
+   #endif
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("modes", "cbc_invalid_padding", CBC_Invalid_Padding_Test);
+
 #endif
 
 }  // namespace


### PR DESCRIPTION
CBC padding missed this, and there were no tests for the AEAD or CBC cases