### PR TITLE
Fix some stateful signature edge cases

### DIFF
--- a/src/lib/pubkey/hss_lms/hss.cpp
+++ b/src/lib/pubkey/hss_lms/hss.cpp
@@ -74,6 +74,26 @@ std::vector<LMS_Tree_Node_Idx> derive_lms_leaf_indices_from_hss_index(HSS_Sig_Id
    return q;
 }
 
+/**
+ * Encode the HSS-LMS parameter set, for use as the algorithm parameters
+ * in the key's Stateful_Key_Index_Registry identity.
+ */
+std::vector<uint8_t> hss_param_encoding(const HSS_LMS_Params& params) {
+   std::vector<uint8_t> enc;
+   enc.reserve(sizeof(uint32_t) * (1 + 2 * params.L().get()));
+
+   const auto append = [&](std::span<const uint8_t> bytes) { enc.insert(enc.end(), bytes.begin(), bytes.end()); };
+
+   append(store_be(params.L()));
+   for(HSS_Level layer(0); layer < params.L(); ++layer) {
+      const auto& layer_params = params.params_at_level(layer);
+      append(store_be(layer_params.lms_params().algorithm_type()));
+      append(store_be(layer_params.lmots_params().algorithm_type()));
+   }
+
+   return enc;
+}
+
 }  // namespace
 
 HSS_LMS_Params::HSS_LMS_Params(std::vector<LMS_LMOTS_Params_Pair> lm_lmots_params) :
@@ -124,9 +144,8 @@ HSS_LMS_PrivateKeyInternal::HSS_LMS_PrivateKeyInternal(const HSS_LMS_Params& hss
       m_hss_params(hss_params),
       m_hss_seed(rng.random_vec<LMS_Seed>(m_hss_params.params_at_level(HSS_Level(0)).lms_params().m())),
       m_identifier(rng.random_vec<LMS_Identifier>(LMS_IDENTIFIER_LEN)),
-      // LMS doesn't have a single unique parameter code that we can easily use,
-      // so algo_params is left as 0
-      m_keyid("HSS-LMS", 0, m_hss_seed, m_identifier),
+      m_keyid(
+         "HSS-LMS", hss_param_encoding(m_hss_params), m_hss_params.max_sig_count().get(), m_hss_seed, m_identifier),
       m_sig_size(HSS_Signature::size(m_hss_params)) {}
 
 HSS_LMS_PrivateKeyInternal::HSS_LMS_PrivateKeyInternal(HSS_LMS_Params hss_params,
@@ -135,8 +154,8 @@ HSS_LMS_PrivateKeyInternal::HSS_LMS_PrivateKeyInternal(HSS_LMS_Params hss_params
       m_hss_params(std::move(hss_params)),
       m_hss_seed(std::move(hss_seed)),
       m_identifier(std::move(identifier)),
-      // LMS doesn't have a single unique parameter code that we can easily use, so algo_params is left as 0
-      m_keyid("HSS-LMS", 0, m_hss_seed, m_identifier),
+      m_keyid(
+         "HSS-LMS", hss_param_encoding(m_hss_params), m_hss_params.max_sig_count().get(), m_hss_seed, m_identifier),
       m_sig_size(HSS_Signature::size(m_hss_params)) {
    BOTAN_ARG_CHECK(m_hss_seed.size() == m_hss_params.params_at_level(HSS_Level(0)).lms_params().m(),
                    "Invalid HSS-LMS seed size");
@@ -213,20 +232,24 @@ secure_vector<uint8_t> HSS_LMS_PrivateKeyInternal::to_bytes() const {
    return sk_bytes;
 }
 
-HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::remaining_operations(HSS_Sig_Idx idx) const {
-   return HSS_Sig_Idx(Stateful_Key_Index_Registry::global().remaining_operations(m_keyid, idx.get()));
+HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::remaining_operations() const {
+   return HSS_Sig_Idx(Stateful_Key_Index_Registry::global().remaining_operations(m_keyid));
 }
 
 void HSS_LMS_PrivateKeyInternal::set_idx(HSS_Sig_Idx idx) {
+   // An index equal to max_sig_count is valid and denotes an exhausted key
+   if(idx > m_hss_params.max_sig_count()) {
+      throw Decoding_Error("HSS-LMS private key index out of bounds");
+   }
    Stateful_Key_Index_Registry::global().set_index_lower_bound(m_keyid, idx.get());
 }
 
 HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::reserve_next_idx() {
-   const auto idx = HSS_Sig_Idx(Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid));
-   if(idx >= m_hss_params.max_sig_count()) {
-      throw Decoding_Error("HSS private key is exhausted");
+   const auto idx = Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid);
+   if(!idx.has_value()) {
+      throw Invalid_State("HSS private key is exhausted");
    }
-   return idx;
+   return HSS_Sig_Idx(idx.value());
 }
 
 size_t HSS_LMS_PrivateKeyInternal::size() const {

--- a/src/lib/pubkey/hss_lms/hss.h
+++ b/src/lib/pubkey/hss_lms/hss.h
@@ -154,15 +154,16 @@ class HSS_LMS_PrivateKeyInternal final {
       secure_vector<uint8_t> to_bytes() const;
 
       /**
-       * @brief Get the idx of the next signature to generate.
+       * @brief Get the number of remaining signatures for this key.
        */
-      HSS_Sig_Idx remaining_operations(HSS_Sig_Idx idx) const;
+      HSS_Sig_Idx remaining_operations() const;
 
       /**
        * @brief Set the idx of the next signature to generate.
        *
        * Note that creating two signatures with the same index is insecure.
-       * The index must be lower than hss_params().max_sig_count().
+       * The index must be lower than or equal to hss_params().max_sig_count(),
+       * with an index == max indicating the key is completely exhausted.
        * The index will never go backward (highest value wins).
        */
       void set_idx(HSS_Sig_Idx idx);

--- a/src/lib/pubkey/hss_lms/hss_lms.cpp
+++ b/src/lib/pubkey/hss_lms/hss_lms.cpp
@@ -182,7 +182,7 @@ AlgorithmIdentifier HSS_LMS_PrivateKey::pkcs8_algorithm_identifier() const {
 }
 
 std::optional<uint64_t> HSS_LMS_PrivateKey::remaining_operations() const {
-   return m_private->remaining_operations(m_private->hss_params().max_sig_count()).get();
+   return m_private->remaining_operations().get();
 }
 
 std::unique_ptr<Private_Key> HSS_LMS_PrivateKey::generate_another(RandomNumberGenerator& rng) const {

--- a/src/lib/pubkey/stateful_key_index/stateful_key_index_registry.cpp
+++ b/src/lib/pubkey/stateful_key_index/stateful_key_index_registry.cpp
@@ -8,7 +8,9 @@
 #include <botan/internal/stateful_key_index_registry.h>
 
 #include <botan/assert.h>
+#include <botan/exceptn.h>
 #include <botan/hash.h>
+#include <algorithm>
 
 namespace Botan {
 
@@ -22,16 +24,18 @@ Stateful_Key_Index_Registry::Stateful_Key_Index_Registry() = default;
 Stateful_Key_Index_Registry::~Stateful_Key_Index_Registry() = default;
 
 Stateful_Key_Index_Registry::KeyId::KeyId(std::string_view algo_name,
-                                          uint32_t algo_params,
+                                          std::span<const uint8_t> algo_params,
+                                          uint64_t max_operations,
                                           std::span<const uint8_t> key_material_1,
                                           std::span<const uint8_t> key_material_2) :
-      m_val() {
+      m_max_operations(max_operations) {
    auto hash = HashFunction::create_or_throw("SHA-256");
 
    hash->update("Botan Stateful_Key_Index_Registry KeyID");
    hash->update_be(static_cast<uint64_t>(algo_name.size()));
    hash->update(algo_name);
-   hash->update_be(algo_params);
+   hash->update_be(static_cast<uint64_t>(algo_params.size()));
+   hash->update(algo_params);
    hash->update_be(static_cast<uint64_t>(key_material_1.size()));
    hash->update(key_material_1);
    hash->update_be(static_cast<uint64_t>(key_material_2.size()));
@@ -44,7 +48,12 @@ Stateful_Key_Index_Registry::KeyId::KeyId(std::string_view algo_name,
 
 // Lock must be held while this function is called
 Stateful_Key_Index_Registry::RegistryMap::iterator Stateful_Key_Index_Registry::lookup(const KeyId& key_id) {
-   auto [i, _inserted] = m_registry.emplace(key_id, 0);
+   auto [i, inserted] = m_registry.emplace(key_id, 0);
+
+   if(!inserted && i->first.max_operations() != key_id.max_operations()) {
+      throw Internal_Error("Stateful key was already registered with a different maximum operation count");
+   }
+
    return i;
 }
 
@@ -54,23 +63,28 @@ uint64_t Stateful_Key_Index_Registry::current_index(const KeyId& key_id) {
    return idx->second;
 }
 
-uint64_t Stateful_Key_Index_Registry::reserve_next_index(const KeyId& key_id) {
+std::optional<uint64_t> Stateful_Key_Index_Registry::reserve_next_index(const KeyId& key_id) {
    const lock_guard_type<mutex_type> lock(m_mutex);
    auto idx = this->lookup(key_id);
    const uint64_t cur = idx->second;
-   idx->second += 1;
+   if(cur >= key_id.max_operations()) {
+      return std::nullopt;
+   }
+   idx->second = cur + 1;
    return cur;
 }
 
 void Stateful_Key_Index_Registry::set_index_lower_bound(const KeyId& key_id, uint64_t min) {
+   BOTAN_ARG_CHECK(min <= key_id.max_operations(), "Index lower bound exceeds maximum operation count");
    const lock_guard_type<mutex_type> lock(m_mutex);
    auto idx = this->lookup(key_id);
    idx->second = std::max(idx->second, min);
 }
 
-uint64_t Stateful_Key_Index_Registry::remaining_operations(const KeyId& key_id, uint64_t max) {
+uint64_t Stateful_Key_Index_Registry::remaining_operations(const KeyId& key_id) {
    const lock_guard_type<mutex_type> lock(m_mutex);
    const uint64_t idx = this->lookup(key_id)->second;
+   const uint64_t max = key_id.max_operations();
 
    if(idx >= max) {
       return 0;

--- a/src/lib/pubkey/stateful_key_index/stateful_key_index_registry.h
+++ b/src/lib/pubkey/stateful_key_index/stateful_key_index_registry.h
@@ -12,6 +12,7 @@
 #include <botan/types.h>
 #include <array>
 #include <map>
+#include <optional>
 #include <span>
 #include <string_view>
 
@@ -19,9 +20,13 @@ namespace Botan {
 
 /**
  * A process-wide registry mapping stateful key identity to a shared
- * atomic counter. Ensures that independent copies of the same key
+ * monotonic counter. Ensures that independent copies of the same key
  * material (e.g. deserialized separately) share a single leaf index,
  * preventing catastrophic one-time signature reuse.
+ *
+ * The same key material used with different algorithm parameters is
+ * tracked independently, since the parameters are part of the key
+ * identity. The maximum operation count is a function of the identity.
  *
  * Used by XMSS and HSS-LMS.
  */
@@ -33,21 +38,34 @@ class Stateful_Key_Index_Registry final {
             * Create a KeyId for some kind of key material
             *
             * @param algo_name     Algorithm name (ex "XMSS", "HSS-LMS")
-            * @param algo_params   Algorithm specific parameters
+            * @param algo_params   Encoding of the algorithm parameters
+            * @param max_operations Maximum number of operations the key supports.
+            *                       This must be derived from algo_params; equal
+            *                       identities must have equal maximums.
             * @param key_material_1 First part of key identifying material
             * @param key_material_2 Second part of key identifying material (can be omitted)
             */
             KeyId(std::string_view algo_name,
-                  uint32_t algo_params,
+                  std::span<const uint8_t> algo_params,
+                  uint64_t max_operations,
                   std::span<const uint8_t> key_material_1,
                   std::span<const uint8_t> key_material_2);
 
+            // A default constructed KeyId permits no operations
             KeyId() = default;
 
-            auto operator<=>(const KeyId& other) const = default;
+            uint64_t max_operations() const { return m_max_operations; }
+
+            // Identity is the hash; the maximum is not hashed in, since an
+            // inconsistent maximum forking the counter would be worse than
+            // the error the registry raises for it.
+            auto operator<=>(const KeyId& other) const { return m_val <=> other.m_val; }
+
+            bool operator==(const KeyId& other) const { return m_val == other.m_val; }
 
          private:
-            std::array<uint8_t, 32> m_val;
+            std::array<uint8_t, 32> m_val{};
+            uint64_t m_max_operations = 0;
       };
 
       Stateful_Key_Index_Registry(const Stateful_Key_Index_Registry&) = delete;
@@ -67,9 +85,12 @@ class Stateful_Key_Index_Registry final {
       uint64_t current_index(const KeyId& key_id);
 
       /**
-      * Return a new counter
+      * Reserve and return the next counter value, or nullopt if the counter
+      * has already reached the key's maximum. The counter never increments
+      * past the maximum, so it cannot wrap, and an exhausted key remains
+      * exhausted.
       */
-      uint64_t reserve_next_index(const KeyId& key_id);
+      std::optional<uint64_t> reserve_next_index(const KeyId& key_id);
 
       /**
       * Set the counter to at least min (but if already higher it will retain its current value)
@@ -77,9 +98,9 @@ class Stateful_Key_Index_Registry final {
       void set_index_lower_bound(const KeyId& key_id, uint64_t min);
 
       /**
-      * If the current counter is >= max returns 0, otherwise max - counter
+      * If the current counter is >= the key's maximum returns 0, otherwise maximum - counter
       */
-      uint64_t remaining_operations(const KeyId& key_id, uint64_t max);
+      uint64_t remaining_operations(const KeyId& key_id);
 
    private:
       typedef std::map<KeyId, uint64_t> RegistryMap;

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -66,7 +66,11 @@ class XMSS_PrivateKey_Internal final {
             m_wots_derivation_method(wots_derivation_method),
             m_prf(rng.random_vec(m_xmss_params.element_size())),
             m_private_seed(rng.random_vec(m_xmss_params.element_size())),
-            m_keyid(Stateful_Key_Index_Registry::KeyId("XMSS", m_xmss_params.oid(), m_private_seed, m_prf)) {}
+            m_keyid(Stateful_Key_Index_Registry::KeyId("XMSS",
+                                                       store_be(static_cast<uint32_t>(m_xmss_params.oid())),
+                                                       m_xmss_params.total_number_of_signatures(),
+                                                       m_private_seed,
+                                                       m_prf)) {}
 
       XMSS_PrivateKey_Internal(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                                WOTS_Derivation_Method wots_derivation_method,
@@ -77,12 +81,14 @@ class XMSS_PrivateKey_Internal final {
             m_wots_derivation_method(wots_derivation_method),
             m_prf(std::move(prf)),
             m_private_seed(std::move(private_seed)),
-            m_keyid(Stateful_Key_Index_Registry::KeyId("XMSS", m_xmss_params.oid(), m_private_seed, m_prf)) {}
+            m_keyid(Stateful_Key_Index_Registry::KeyId("XMSS",
+                                                       store_be(static_cast<uint32_t>(m_xmss_params.oid())),
+                                                       m_xmss_params.total_number_of_signatures(),
+                                                       m_private_seed,
+                                                       m_prf)) {}
 
       XMSS_PrivateKey_Internal(XMSS_Parameters::xmss_algorithm_t xmss_algo_id, std::span<const uint8_t> key_bits) :
-            m_xmss_params(XMSS_Parameters::from_id(xmss_algo_id)),
-            m_wots_params(m_xmss_params.wots_parameters()),
-            m_keyid(/* initialized later*/) {
+            m_xmss_params(XMSS_Parameters::from_id(xmss_algo_id)), m_wots_params(m_xmss_params.wots_parameters()) {
          /*
          The code requires sizeof(size_t) >= ceil(tree_height / 8)
 
@@ -107,14 +113,15 @@ class XMSS_PrivateKey_Internal final {
 
          auto unused_leaf_bytes = s.take(sizeof(uint32_t));
          const size_t unused_leaf = load_be<uint32_t>(unused_leaf_bytes.data(), 0);
-         if(unused_leaf >= (1ULL << m_xmss_params.tree_height())) {
-            throw Decoding_Error("XMSS private key leaf index out of bounds");
-         }
 
          m_prf = s.copy_as_secure_vector(m_xmss_params.element_size());
          m_private_seed = s.copy_as_secure_vector(m_xmss_params.element_size());
 
-         m_keyid = Stateful_Key_Index_Registry::KeyId("XMSS", m_xmss_params.oid(), m_private_seed, m_prf);
+         m_keyid = Stateful_Key_Index_Registry::KeyId("XMSS",
+                                                      store_be(static_cast<uint32_t>(m_xmss_params.oid())),
+                                                      m_xmss_params.total_number_of_signatures(),
+                                                      m_private_seed,
+                                                      m_prf);
 
          // Note m_keyid must be initialized before set_unused_leaf_index is called!
          set_unused_leaf_index(unused_leaf);
@@ -129,7 +136,7 @@ class XMSS_PrivateKey_Internal final {
 
       secure_vector<uint8_t> serialize(std::vector<uint8_t> raw_public_key) const {
          std::vector<uint8_t> unused_index(4);
-         store_be(static_cast<uint32_t>(unused_leaf_index()), unused_index.data());
+         store_be(checked_cast_to<uint32_t>(unused_leaf_index()), unused_index.data());
 
          std::vector<uint8_t> wots_derivation_method;
          wots_derivation_method.push_back(static_cast<uint8_t>(m_wots_derivation_method));
@@ -147,7 +154,8 @@ class XMSS_PrivateKey_Internal final {
       WOTS_Derivation_Method wots_derivation_method() const { return m_wots_derivation_method; }
 
       void set_unused_leaf_index(size_t idx) {
-         if(idx >= (1ULL << m_xmss_params.tree_height())) {
+         // An index equal to 2^h is valid and denotes an exhausted key
+         if(idx > (1ULL << m_xmss_params.tree_height())) {
             throw Decoding_Error("XMSS private key leaf index out of bounds");
          } else {
             Stateful_Key_Index_Registry::global().set_index_lower_bound(m_keyid, idx);
@@ -155,12 +163,12 @@ class XMSS_PrivateKey_Internal final {
       }
 
       size_t reserve_unused_leaf_index() {
-         const uint64_t idx = Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid);
-         if(idx >= m_xmss_params.total_number_of_signatures()) {
-            throw Decoding_Error("XMSS private key, one time signatures exhausted");
+         const auto idx = Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid);
+         if(!idx.has_value()) {
+            throw Invalid_State("XMSS private key, one time signatures exhausted");
          }
          // Cast is safe even on 32 bit since total_number_of_signatures will be less
-         return static_cast<size_t>(idx);
+         return static_cast<size_t>(idx.value());
       }
 
       size_t unused_leaf_index() const {
@@ -169,8 +177,7 @@ class XMSS_PrivateKey_Internal final {
       }
 
       uint64_t remaining_signatures() const {
-         const size_t max = m_xmss_params.total_number_of_signatures();
-         return Stateful_Key_Index_Registry::global().remaining_operations(m_keyid, max);
+         return Stateful_Key_Index_Registry::global().remaining_operations(m_keyid);
       }
 
    private:

--- a/src/tests/data/pubkey/hss_lms_sig.vec
+++ b/src/tests/data/pubkey/hss_lms_sig.vec
@@ -1,9 +1,11 @@
 # Test cases created using the reference implementation https://github.com/cisco/hash-sigs
 # with seed derivation logic Secret Method 2.
 #
-# NOTE: Some of test vectors use the same seed and identifier. They must be
-# ordered by index, as Stateful_Key_Index_Registry enforces that the index for
-# any key only moves forward.
+# NOTE: Some of test vectors use the same seed and identifier, but with
+# different HSS-LMS parameters; Stateful_Key_Index_Registry tracks these
+# independently since the parameters are part of the key identity. Any
+# entries sharing both key material and parameters would have to be ordered
+# by index, as the registry only allows the index of a key to move forward.
 
 # HSS with 8 levels:
 #   Root Level: LMS_SHA256_N32_H5  with LMOTS_SHA256_N32_W8

--- a/src/tests/test_concurrent_pk.cpp
+++ b/src/tests/test_concurrent_pk.cpp
@@ -11,6 +11,7 @@
    #include <botan/pubkey.h>
    #include <botan/rng.h>
    #include <botan/internal/fmt.h>
+   #include <algorithm>
    #include <future>
    #include <sstream>
 #endif
@@ -97,19 +98,30 @@ Test::Result test_concurrent_signing(const ConcurrentPkTestCase& tc,
 
    Botan::PK_Verifier verifier(pubkey, tc.op_params());
 
+   std::vector<std::vector<uint8_t>> signatures;
+
    for(size_t i = 0; i != ConcurrentThreads; ++i) {
       try {
-         const auto signature = futures[i].get();
+         auto signature = futures[i].get();
 
          if(signature.empty()) {
             result.test_failure(Botan::fmt("Thread {} produced empty signature", i));
          } else {
             const bool valid = verifier.verify_message(test_message, signature);
             result.test_is_true(Botan::fmt("Thread {} signature is valid", i), valid);
+            signatures.push_back(std::move(signature));
          }
       } catch(std::exception& e) {
          result.test_failure(Botan::fmt("Thread {} failed: {}", i, e.what()));
       }
+   }
+
+   if(privkey.stateful_operation()) {
+      // Stateful schemes sign deterministically for a given index, so a
+      // duplicate signature over the same message indicates index reuse
+      std::sort(signatures.begin(), signatures.end());
+      const bool unique = std::adjacent_find(signatures.begin(), signatures.end()) == signatures.end();
+      result.test_is_true("Stateful key used a distinct index for each signature", unique);
    }
 
    if(operations_remaining_at_start.has_value()) {

--- a/src/tests/test_hss_lms.cpp
+++ b/src/tests/test_hss_lms.cpp
@@ -17,6 +17,7 @@
    #include <botan/internal/fmt.h>
    #include <botan/internal/hss.h>
    #include <botan/internal/loadstor.h>
+   #include <limits>
 
 namespace Botan_Tests {
 
@@ -290,7 +291,117 @@ class HSS_LMS_Statefulness_Test final : public Test {
          return result;
       }
 
-      std::vector<Test::Result> run() final { return {test_sig_changes_state(), test_max_sig_count()}; }
+      Test::Result test_idx_bound_checked_on_load() {
+         Test::Result result("HSS-LMS");
+
+         // create_private_key_with_idx uses a single HW(5,8) layer, so the
+         // maximum signature count is 32
+         result.test_no_throw("Index == max_sig_count is accepted on load", [&]() {
+            auto sk = create_private_key_with_idx(32);
+            result.test_opt_u64_eq("Exhausted key loads with no remaining signatures", sk.remaining_operations(), 0);
+            Botan::PK_Signer signer(sk, Test::rng(), "");
+            const std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
+            result.test_throws("Cannot sign with exhausted key", [&]() { signer.sign_message(mes, Test::rng()); });
+         });
+
+         result.test_throws<Botan::Decoding_Error>("Index > max_sig_count is rejected on load",
+                                                   [&]() { create_private_key_with_idx(33); });
+
+         result.test_throws<Botan::Decoding_Error>("Huge index is rejected on load", [&]() {
+            create_private_key_with_idx(std::numeric_limits<uint64_t>::max());
+         });
+
+         return result;
+      }
+
+      Test::Result test_exhausted_key_stays_exhausted() {
+         Test::Result result("HSS-LMS");
+
+         // With a total tree height >= 64 the maximum signature count is
+         // clamped to 2^64 - 1, so an index of 2^64 - 1 is accepted on load
+         auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8),HW(25,8),HW(25,8),HW(25,8)");
+         auto bytes = sk.private_key_bits();
+         Botan::store_be(std::numeric_limits<uint64_t>::max(), bytes.data() + sizeof(uint32_t));
+
+         auto exhausted_sk = Botan::HSS_LMS_PrivateKey(Botan::AlgorithmIdentifier(), bytes);
+         result.test_opt_u64_eq("Exhausted key has no remaining signatures", exhausted_sk.remaining_operations(), 0);
+
+         Botan::PK_Signer signer(exhausted_sk, Test::rng(), "");
+         const std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
+
+         // A failed signing attempt must not wrap the index back to zero
+         result.test_throws("Cannot sign with exhausted key", [&]() { signer.sign_message(mes, Test::rng()); });
+         result.test_opt_u64_eq("Failed signing does not reset the state", exhausted_sk.remaining_operations(), 0);
+         result.test_throws("Exhausted key stays exhausted", [&]() { signer.sign_message(mes, Test::rng()); });
+
+         return result;
+      }
+
+      Test::Result test_params_are_part_of_key_identity() {
+         Test::Result result("HSS-LMS");
+
+         const auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
+         auto bytes = sk.private_key_bits();
+
+         // Patch the LMOTS algorithm type from SHA256_N24_W8 (0x08) to
+         // SHA256_N24_W4 (0x07), pretending the same seed and identifier
+         // belong to a key with a different Winternitz parameter
+         result.require("LMOTS type byte has expected value", bytes[19] == 0x08);
+         bytes[19] = 0x07;
+
+         // The index registry tracks the same key material under different
+         // parameter sets independently. Nothing can prevent such (insecurely)
+         // related keys from issuing overlapping one time signatures.
+         const Botan::HSS_LMS_PrivateKey patched(Botan::AlgorithmIdentifier(), bytes);
+
+         Botan::PK_Signer signer(sk, Test::rng(), "");
+         const std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
+         signer.sign_message(mes, Test::rng());
+
+         result.test_opt_u64_eq("Original key consumed an index", sk.remaining_operations(), 31);
+         result.test_opt_u64_eq(
+            "Key with the same material but other params is unaffected", patched.remaining_operations(), 32);
+
+         return result;
+      }
+
+      Test::Result test_separately_loaded_copies_share_state() {
+         Test::Result result("HSS-LMS");
+
+         const auto sk = Botan::HSS_LMS_PrivateKey(Test::rng(), "Truncated(SHA-256,192),HW(5,8)");
+         const auto sk_bytes = sk.private_key_bits();
+
+         const Botan::HSS_LMS_PrivateKey copy1(Botan::AlgorithmIdentifier(), sk_bytes);
+         const Botan::HSS_LMS_PrivateKey copy2(Botan::AlgorithmIdentifier(), sk_bytes);
+
+         const std::vector<uint8_t> mes = {0xde, 0xad, 0xbe, 0xef};
+
+         Botan::PK_Signer signer1(copy1, Test::rng(), "");
+         const auto sig_0 = signer1.sign_message(mes, Test::rng());
+
+         result.test_opt_u64_eq("Signing with one copy is seen by the other", copy2.remaining_operations(), 31);
+
+         Botan::PK_Signer signer2(copy2, Test::rng(), "");
+         const auto sig_1 = signer2.sign_message(mes, Test::rng());
+
+         result.test_is_true(
+            "First signature uses index 0",
+            Botan::HSS_Signature::from_bytes_or_throw(sig_0).bottom_sig().q() == Botan::LMS_Tree_Node_Idx(0));
+         result.test_is_true(
+            "Second signature uses index 1",
+            Botan::HSS_Signature::from_bytes_or_throw(sig_1).bottom_sig().q() == Botan::LMS_Tree_Node_Idx(1));
+
+         return result;
+      }
+
+      std::vector<Test::Result> run() final {
+         return {test_sig_changes_state(),
+                 test_max_sig_count(),
+                 test_idx_bound_checked_on_load(),
+                 test_exhausted_key_stays_exhausted(),
+                 test_params_are_part_of_key_identity(),
+                 test_separately_loaded_copies_share_state()};
+      }
 };
 
 /**

--- a/src/tests/test_xmss.cpp
+++ b/src/tests/test_xmss.cpp
@@ -149,8 +149,21 @@ std::vector<Test::Result> xmss_statefulness() {
       auto msg = Botan::hex_decode("deadbeef");
 
       Botan::PK_Signer signer(sk, *rng, "SHA2_10_256");
-      signer.sign_message(msg, *rng);
+      return signer.sign_message(msg, *rng);
    };
+
+   // An XMSS-SHA2_10_256 private key whose unused leaf index is at 1023,
+   // ie that has exactly one signature left
+   const auto almost_exhausted_sk_bytes = Botan::hex_decode(
+      "000000011BBB81273E8057724A2A894593A1A688B3271410B3BEAB9F5587337BCDCBBF5C4E43AB"
+      "0AB2F88258E5AC54BB252E39335AE9B0D4AF0C0347EA45B8AA0AA3804C000003FFAC0C29C1ACD3"
+      //                                                         ~~1023~~
+      "19DA96E9C8EE4E28C2078441A76B6BB8BAFD358F67FBCBFC559B55C37C01FFADBB118099759EEB"
+      "A3B07643F73BCB4AAC546E244B57782D6BEABC");
+
+   // The 4 byte unused leaf index is stored just after the raw public key
+   // (4 byte OID, 32 byte root, 32 byte public seed)
+   const size_t leaf_idx_offset = 68;
 
    return {CHECK("signing alters state",
                  [&](auto& result) {
@@ -162,20 +175,45 @@ std::vector<Test::Result> xmss_statefulness() {
                     result.test_opt_u64_eq("allows 1023 signatures", sk.remaining_operations(), 1023);
                  }),
 
-           CHECK("state can become exhausted", [&](auto& result) {
-              const auto skbytes = Botan::hex_decode(
-                 "000000011BBB81273E8057724A2A894593A1A688B3271410B3BEAB9F5587337BCDCBBF5C4E43AB"
-                 "0AB2F88258E5AC54BB252E39335AE9B0D4AF0C0347EA45B8AA0AA3804C000003FFAC0C29C1ACD3"
-                 //                                                         ~~1023~~
-                 "19DA96E9C8EE4E28C2078441A76B6BB8BAFD358F67FBCBFC559B55C37C01FFADBB118099759EEB"
-                 "A3B07643F73BCB4AAC546E244B57782D6BEABC");
-              Botan::XMSS_PrivateKey sk(skbytes);
-              result.test_opt_u64_eq("allow one last signature", sk.remaining_operations(), 1);
+           CHECK("state can become exhausted",
+                 [&](auto& result) {
+                    Botan::XMSS_PrivateKey sk(almost_exhausted_sk_bytes);
+                    result.test_opt_u64_eq("allow one last signature", sk.remaining_operations(), 1);
 
-              sign_something(sk);
+                    sign_something(sk);
 
-              result.test_opt_u64_eq("allow no more signatures", sk.remaining_operations(), 0);
-              result.test_throws("no more signing", [&] { sign_something(sk); });
+                    result.test_opt_u64_eq("allow no more signatures", sk.remaining_operations(), 0);
+                    result.test_throws("no more signing", [&] { sign_something(sk); });
+
+                    // The exhausted state must survive a serialization round trip
+                    const Botan::XMSS_PrivateKey sk2(sk.raw_private_key());
+                    result.test_opt_u64_eq("reloaded key allows no signatures", sk2.remaining_operations(), 0);
+                    result.test_throws("no signing with reloaded key", [&] { sign_something(sk2); });
+                 }),
+
+           CHECK("out of range leaf index is rejected on load",
+                 [&](Test::Result& result) {
+                    auto skbytes = almost_exhausted_sk_bytes;
+                    Botan::store_be(static_cast<uint32_t>(1025), &skbytes[leaf_idx_offset]);
+                    result.test_throws<Botan::Decoding_Error>("no key with leaf index 2^h + 1",
+                                                              [&] { const Botan::XMSS_PrivateKey sk(skbytes); });
+                 }),
+
+           CHECK("separately loaded copies share state", [&](auto& result) {
+              const Botan::XMSS_PrivateKey sk(Botan::XMSS_Parameters::XMSS_SHA2_10_256, *rng);
+              const auto skbytes = sk.raw_private_key();
+
+              const Botan::XMSS_PrivateKey copy1(skbytes);
+              const Botan::XMSS_PrivateKey copy2(skbytes);
+
+              const auto sig1 = sign_something(copy1);
+              result.test_opt_u64_eq("signing with one copy is seen by the other", copy2.remaining_operations(), 1023);
+
+              const auto sig2 = sign_something(copy2);
+
+              // The first four bytes of an XMSS signature encode the leaf index
+              result.test_u64_eq("first signature used leaf 0", Botan::load_be<uint32_t>(sig1.data(), 0), 0);
+              result.test_u64_eq("second signature used leaf 1", Botan::load_be<uint32_t>(sig2.data(), 0), 1);
            })};
 }
 


### PR DESCRIPTION
If you invoked an exhausted XMSS/LMS key ~ 2**64 times, eventually the counter would overflow, resulting in a leaf reuse. This practically speaking cannot occur since it requires the actions of the legitimate signer and they are probably not going to spin in a failing signature generation loop for years waiting for an overflow.

Fix other related bugs. In HSS-LMS, it was possible to decode a corrupted private key with its index pre-set to 2**64-1. The loader would miss that the index exceeded the maximum for the key. The first signature attempt would fail, and a subsequent attempt would reuse leaf 0. An attacker who can arbitrarily set the index can more easily attack the key by rolling back to a prior state (eg setting index = 0 directly) with the same effect, so this isn't really an attack, but this particular instance is easily avoidable.

In XMSS correctly handle exhausted keys. An exhausted key could previously be serialied, but not deserialized again. Now it can be deserialized and just reports itself as exhausted.

#5661 