### PR TITLE
TLS 1.3 handshake hardenings

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -342,6 +342,8 @@ std::string map_to_bogo_error(const std::string& e) noexcept {
        ":UNEXPECTED_MESSAGE:"},
       {"Unexpected state transition in handshake got a certificate expected finished seen server_hello+encrypted_extensions",
        ":UNEXPECTED_MESSAGE:"},
+      {"Unexpected state transition in handshake got a encrypted_extensions expected finished seen client_hello",
+       ":UNEXPECTED_MESSAGE:"},
       {"Unexpected state transition in handshake got a finished expected certificate_verify seen server_hello+certificate+encrypted_extensions",
        ":BAD_HELLO_REQUEST:"},
       {"Unknown TLS handshake message type 43", ":UNEXPECTED_MESSAGE:"},

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -79,11 +79,12 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
 void Client_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
    BOTAN_STATE_CHECK(m_handshake != nullptr);
 
+   // first verify that the message was expected by the state machine
+   // (and only then store it in the handshake state)
+   m_handshake->transitions.confirm_transition_to(std::visit([](const auto& msg) { return msg.type(); }, message));
+
    std::visit(
       [&](auto msg) {
-         // first verify that the message was expected by the state machine...
-         m_handshake->transitions.confirm_transition_to(msg.get().type());
-
          // ... then allow the library user to abort on their discretion
          callbacks().tls_inspect_handshake_msg(msg.get());
 

--- a/src/lib/tls/tls13/tls_handshake_state_13.cpp
+++ b/src/lib/tls/tls13/tls_handshake_state_13.cpp
@@ -24,39 +24,49 @@ Client_Hello_13& Handshake_State_13_Base::store(Client_Hello_13 client_hello, co
 }
 
 Client_Hello_12_Shim& Handshake_State_13_Base::store(Client_Hello_12_Shim client_hello, const bool /*from_peer*/) {
+   BOTAN_STATE_CHECK(!m_client_hello_12.has_value());
    m_client_hello_12 = std::move(client_hello);
    return m_client_hello_12.value();
 }
 
 Server_Hello_13& Handshake_State_13_Base::store(Server_Hello_13 server_hello, const bool /*from_peer*/) {
+   BOTAN_STATE_CHECK(!m_server_hello.has_value());
    m_server_hello = std::move(server_hello);
    return m_server_hello.value();
 }
 
 Server_Hello_12_Shim& Handshake_State_13_Base::store(Server_Hello_12_Shim server_hello, const bool /*from_peer*/) {
+   BOTAN_STATE_CHECK(!m_server_hello_12.has_value());
    m_server_hello_12 = std::move(server_hello);
    return m_server_hello_12.value();
 }
 
 Hello_Retry_Request& Handshake_State_13_Base::store(Hello_Retry_Request hello_retry_request, const bool /*from_peer*/) {
+   // RFC 8446 4.1.4
+   //    If a client receives a second HelloRetryRequest in the same connection
+   //    [...], it MUST abort the handshake with an "unexpected_message" alert.
+   BOTAN_STATE_CHECK(!m_hello_retry_request.has_value());
    m_hello_retry_request = std::move(hello_retry_request);
    return m_hello_retry_request.value();
 }
 
 Encrypted_Extensions& Handshake_State_13_Base::store(Encrypted_Extensions encrypted_extensions,
                                                      const bool /*from_peer*/) {
+   BOTAN_STATE_CHECK(!m_encrypted_extensions.has_value());
    m_encrypted_extensions = std::move(encrypted_extensions);
    return m_encrypted_extensions.value();
 }
 
 Certificate_Request_13& Handshake_State_13_Base::store(Certificate_Request_13 certificate_request,
                                                        const bool /*from_peer*/) {
+   BOTAN_STATE_CHECK(!m_certificate_request.has_value());
    m_certificate_request = std::move(certificate_request);
    return m_certificate_request.value();
 }
 
 Certificate_13& Handshake_State_13_Base::store(Certificate_13 certificate, const bool from_peer) {
    auto& target = ((m_side == Connection_Side::Client) == from_peer) ? m_server_certificate : m_client_certificate;
+   BOTAN_STATE_CHECK(!target.has_value());
    target = std::move(certificate);
    return target.value();
 }
@@ -64,12 +74,14 @@ Certificate_13& Handshake_State_13_Base::store(Certificate_13 certificate, const
 Certificate_Verify_13& Handshake_State_13_Base::store(Certificate_Verify_13 certificate_verify, const bool from_peer) {
    auto& target =
       ((m_side == Connection_Side::Client) == from_peer) ? m_server_certificate_verify : m_client_certificate_verify;
+   BOTAN_STATE_CHECK(!target.has_value());
    target = std::move(certificate_verify);
    return target.value();
 }
 
 Finished_13& Handshake_State_13_Base::store(Finished_13 finished, const bool from_peer) {
    auto& target = ((m_side == Connection_Side::Client) == from_peer) ? m_server_finished : m_client_finished;
+   BOTAN_STATE_CHECK(!target.has_value());
    target = std::move(finished);
    return target.value();
 }

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -152,11 +152,12 @@ size_t Server_Impl_13::send_new_session_tickets(const size_t tickets) {
 void Server_Impl_13::process_handshake_msg(Handshake_Message_13 message) {
    BOTAN_STATE_CHECK(m_handshake != nullptr);
 
+   // first verify that the message was expected by the state machine
+   // (and only then store it in the handshake state)
+   m_handshake->transitions.confirm_transition_to(std::visit([](const auto& msg) { return msg.type(); }, message));
+
    std::visit(
       [&](auto msg) {
-         // first verify that the message was expected by the state machine...
-         m_handshake->transitions.confirm_transition_to(msg.get().type());
-
          // ... then allow the library user to abort on their discretion
          callbacks().tls_inspect_handshake_msg(msg.get());
 
@@ -196,7 +197,7 @@ void Server_Impl_13::process_dummy_change_cipher_spec() {
 }
 
 bool Server_Impl_13::is_handshake_complete() const {
-   return m_active_state.has_value() || (m_handshake != nullptr && m_handshake->state.has_client_finished());
+   return m_active_state.has_value() || (m_handshake != nullptr && m_handshake->state.handshake_finished());
 }
 
 void Server_Impl_13::maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const {


### PR DESCRIPTION
During the handshake, verify the state transition prior to storing the incoming message into the structure. This prevents any possibility of examining the invalid message during unwinding after the rejected state transition.

Add STATE_CHECK assertions that a handshake message is never written twice. This is already guaranteed by the existing transition gates but it's an easy thing to check.