### PR TITLE
Fix a bug in SIV when AADs are set with a gap in the index

### DIFF
--- a/src/lib/modes/aead/siv/siv.cpp
+++ b/src/lib/modes/aead/siv/siv.cpp
@@ -93,7 +93,12 @@ void SIV_Mode::set_associated_data_n(size_t n, std::span<const uint8_t> ad) {
       throw Invalid_Argument(name() + " allows no more than " + std::to_string(max_ads) + " ADs");
    }
 
-   if(n >= m_ad_macs.size()) {
+   if(n > m_ad_macs.size()) {
+      // If we are potentially skipping over AD elements in a way that will
+      // create a gap, fill the gaps in with the mac of the empty string.
+      const auto empty_mac = m_mac->process(std::span<const uint8_t>{});
+      m_ad_macs.resize(n + 1, empty_mac);
+   } else if(n == m_ad_macs.size()) {
       m_ad_macs.resize(n + 1);
    }
 

--- a/src/tests/test_siv.cpp
+++ b/src/tests/test_siv.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 2017 Jack Lloyd
+* (C) 2017,2026 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -9,6 +9,7 @@
 #if defined(BOTAN_HAS_AEAD_SIV)
    #include <botan/aead.h>
    #include <botan/hex.h>
+   #include <botan/rng.h>
    #include <botan/internal/parsing.h>
 #endif
 
@@ -58,6 +59,60 @@ class SIV_Tests final : public Text_Based_Test {
 };
 
 BOTAN_REGISTER_TEST("modes", "siv_ad", SIV_Tests);
+
+class SIV_Noncontiguous_AD_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("SIV non-contiguous AD");
+
+         auto gapped = Botan::AEAD_Mode::create("AES-128/SIV", Botan::Cipher_Dir::Encryption);
+         if(!gapped) {
+            result.test_note("Skipping test due to missing cipher");
+            return {result};
+         }
+         auto enc = Botan::AEAD_Mode::create("AES-128/SIV", Botan::Cipher_Dir::Encryption);
+
+         const auto key = rng().random_vec(16 * 2);
+         const auto ad0 = rng().random_vec(32);
+         const auto ad2 = rng().random_vec(48);
+         const auto input = rng().random_vec(10);
+
+         gapped->set_key(key);
+         enc->set_key(key);
+
+         // gapped: indices 0 and 2 set, index 1 skipped
+         gapped->set_associated_data_n(0, ad0);
+         gapped->set_associated_data_n(2, ad2);
+
+         Botan::secure_vector<uint8_t> buf_gapped = input;
+         gapped->start();
+         gapped->finish(buf_gapped, 0);
+
+         // enc: index 1 set to a zero-length AD
+         enc->set_associated_data_n(0, ad0);
+         enc->set_associated_data_n(1, {});
+         enc->set_associated_data_n(2, ad2);
+
+         Botan::secure_vector<uint8_t> buf_explicit = input;
+         enc->start();
+         enc->finish(buf_explicit, 0);
+
+         result.test_bin_eq("SIV AD gap is equivalent to an explicit empty AD", buf_gapped, buf_explicit);
+
+         // Decryption must similarly handle an AAD gap
+         auto dec = Botan::AEAD_Mode::create("AES-128/SIV", Botan::Cipher_Dir::Decryption);
+         dec->set_key(key);
+         dec->set_associated_data_n(0, ad0);
+         dec->set_associated_data_n(2, ad2);
+         dec->start();
+         dec->finish(buf_gapped, 0);
+         result.test_bin_eq("gapped AD round-trips", buf_gapped, input);
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("modes", "siv_noncontiguous_ad", SIV_Noncontiguous_AD_Tests);
 
 #endif
 


### PR DESCRIPTION
If there is a gap between AAD indicies, act as if the empty string was provided for that index.