### PR TITLE
Avoid using `bool` for secret bits in Classic McEliece

### DIFF
--- a/src/lib/pubkey/classic_mceliece/cmce_decaps.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_decaps.cpp
@@ -30,7 +30,7 @@ Classic_McEliece_Polynomial Classic_McEliece_Decryptor::compute_goppa_syndrome(
       auto g_alpha = goppa_poly(alphas[i]);
       auto r = (g_alpha * g_alpha).inv();
 
-      auto c_mask = GF_Mask::expand(static_cast<bool>(code_word.at(i)));
+      auto c_mask = GF_Mask::expand(code_word.at(i).as_choice());
 
       for(size_t j = 0; j < 2 * params.t(); ++j) {
          syndrome[j] += c_mask.if_set_return(r);
@@ -109,7 +109,7 @@ std::pair<CT::Mask<uint8_t>, CmceErrorVector> Classic_McEliece_Decryptor::decode
    e.get().reserve(m_key->params().n());
    auto decode_success = CT::Mask<uint8_t>::set();  // Avoid bool to avoid possible compiler optimizations
    for(const auto& image : images) {
-      e.push_back(GF_Mask::is_zero(image).as_bool());
+      e.push_back(GF_Mask::is_zero(image).as_choice());
    }
    decode_success &= CT::Mask<uint8_t>(CT::Mask<size_t>::is_equal(e.hamming_weight(), m_key->params().t()));
 

--- a/src/lib/pubkey/classic_mceliece/cmce_gf.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_gf.h
@@ -156,6 +156,8 @@ class BOTAN_TEST_API GF_Mask final {
          return GF_Mask(CT::Mask<uint16_t>::expand(v));
       }
 
+      static GF_Mask expand(CT::Choice v) { return GF_Mask(CT::Mask<uint16_t>::from_choice(v)); }
+
       static GF_Mask expand(Classic_McEliece_GF v) { return expand(v.elem().get()); }
 
       static GF_Mask is_zero(Classic_McEliece_GF v) { return GF_Mask(CT::Mask<uint16_t>::is_zero(v.elem().get())); }
@@ -191,7 +193,7 @@ class BOTAN_TEST_API GF_Mask final {
          return (*this);
       }
 
-      bool as_bool() const { return m_mask.as_bool(); }
+      CT::Choice as_choice() const { return m_mask.as_choice(); }
 
       CT::Mask<uint16_t>& elem_mask() { return m_mask; }
 

--- a/src/lib/pubkey/classic_mceliece/cmce_matrix.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_matrix.cpp
@@ -68,7 +68,8 @@ CmceMatrix init_matrix_with_alphas(const Classic_McEliece_Parameters& params,
       for(size_t j = 0; j < params.n(); ++j) {
          const auto inv_g = inv_g_of_alpha[j].elem().get();
          for(size_t alpha_i_j_bit = 0; alpha_i_j_bit < params.m(); ++alpha_i_j_bit) {
-            mat[i * params.m() + alpha_i_j_bit][j] = static_cast<bool>((inv_g >> alpha_i_j_bit) & 1);
+            mat[i * params.m() + alpha_i_j_bit][j] =
+               CT::Choice::from_int(static_cast<uint16_t>((inv_g >> alpha_i_j_bit) & 1));
          }
       }
       // Update for the next i so that:
@@ -158,7 +159,7 @@ std::optional<CmceColumnSelection> move_columns(CmceMatrix& mat, const Classic_M
    for(auto pivot_idx : pivot_indices) {
       for(size_t i = 0; i < Classic_McEliece_Parameters::nu(); ++i) {
          auto mask_is_at_current_idx = Botan::CT::Mask<size_t>::is_equal(i, pivot_idx);
-         pivots.at(i) = static_cast<bool>(mask_is_at_current_idx.select(1, pivots.at(i).as<size_t>()));
+         pivots.at(i) = mask_is_at_current_idx.as_choice() || pivots.at(i).as_choice();
       }
    }
 
@@ -290,7 +291,7 @@ CmceCodeWord Classic_McEliece_Matrix::mul(const Classic_McEliece_Parameters& par
       auto pk_current_bytes = pk_slicer.take(params.pk_row_size_bytes());
       auto row = secure_bitvector(pk_current_bytes, params.n() - params.pk_no_rows());
       row &= e_T;
-      s[i] ^= row.has_odd_hamming_weight().as_bool();
+      s[i] ^= row.has_odd_hamming_weight();
    }
 
    BOTAN_ASSERT_NOMSG(pk_slicer.empty());

--- a/src/lib/utils/bitvector/bitvector.h
+++ b/src/lib/utils/bitvector/bitvector.h
@@ -350,6 +350,12 @@ class bitvector_base final {
                return *this;
             }
 
+            constexpr bitref& operator=(CT::Choice bit) noexcept {
+               const auto mask = CT::Mask<BlockT>::from_choice(bit);
+               this->m_block = mask.select(this->m_mask | this->m_block, this->m_block & ~this->m_mask);
+               return *this;
+            }
+
             constexpr bitref& operator=(const bitref& bit) noexcept { return *this = bit.is_set(); }
 
             constexpr bitref& operator=(bitref&& bit) noexcept { return *this = bit.is_set(); }
@@ -361,13 +367,28 @@ class bitvector_base final {
                return *this;
             }
 
+            constexpr bitref& operator&=(CT::Choice other) noexcept {
+               this->m_block &= ~CT::Mask<BlockT>::from_choice(other).if_not_set_return(this->m_mask);
+               return *this;
+            }
+
             constexpr bitref& operator|=(bool other) noexcept {
                this->m_block |= CT::Mask<BlockT>::expand(other).if_set_return(this->m_mask);
                return *this;
             }
 
+            constexpr bitref& operator|=(CT::Choice other) noexcept {
+               this->m_block |= CT::Mask<BlockT>::from_choice(other).if_set_return(this->m_mask);
+               return *this;
+            }
+
             constexpr bitref& operator^=(bool other) noexcept {
                this->m_block ^= CT::Mask<BlockT>::expand(other).if_set_return(this->m_mask);
+               return *this;
+            }
+
+            constexpr bitref& operator^=(CT::Choice other) noexcept {
+               this->m_block ^= CT::Mask<BlockT>::from_choice(other).if_set_return(this->m_mask);
                return *this;
             }
       };
@@ -567,6 +588,12 @@ class bitvector_base final {
       }
 
       void push_back(bool bit) {
+         const auto i = size();
+         resize(i + 1);
+         ref(i) = bit;
+      }
+
+      void push_back(CT::Choice bit) {
          const auto i = size();
          resize(i + 1);
          ref(i) = bit;
@@ -1426,6 +1453,8 @@ class Strong_Adapter<T> : public Container_Strong_Adapter_Base<T> {
       }
 
       auto push_back(bool b) { return this->get().push_back(b); }
+
+      auto push_back(CT::Choice b) { return this->get().push_back(b); }
 
       auto pop_back() { return this->get().pop_back(); }
 

--- a/src/tests/test_utils_bitvector.cpp
+++ b/src/tests/test_utils_bitvector.cpp
@@ -222,6 +222,25 @@ std::vector<Test::Result> test_bitvector_bitwise_accessors(Botan::RandomNumberGe
                bv[2] ^= !bv[3];
                result.test_is_true("bv[2] is 0 again", !bv[2]);
             }),
+
+      CHECK("CT::Choice bit modifiers",
+            [](auto& result) {
+               Botan::bitvector bv(6);
+
+               bv[0] = Botan::CT::Choice::yes();
+               bv[1] = Botan::CT::Choice::no();
+               bv[2] |= Botan::CT::Choice::yes();
+               bv[3].set();
+               bv[3] &= Botan::CT::Choice::no();
+               bv[4] ^= Botan::CT::Choice::yes();
+
+               result.test_is_true("CT::Choice assignment set", bv[0]);
+               result.test_is_true("CT::Choice assignment cleared", !bv[1]);
+               result.test_is_true("CT::Choice or", bv[2]);
+               result.test_is_true("CT::Choice and", !bv[3]);
+               result.test_is_true("CT::Choice xor", bv[4]);
+               result.test_is_true("CT::Choice untouched", !bv[5]);
+            }),
    };
 }
 
@@ -268,17 +287,21 @@ std::vector<Test::Result> test_bitvector_capacity(Botan::RandomNumberGenerator& 
                bv.push_back(false);
                bv.push_back(true);
                bv.push_back(false);
+               bv.push_back(Botan::CT::Choice::yes());
+               bv.push_back(Botan::CT::Choice::no());
 
                result.test_is_true("not empty", !bv.empty());
-               result.test_sz_eq("some size", bv.size(), size_t(4));
+               result.test_sz_eq("some size", bv.size(), size_t(6));
                result.test_sz_gte("capacity is typically bigger than size", bv.capacity(), size_t(8));
 
                result.test_is_true("bit 0", bv.at(0));
                result.test_is_true("bit 1", !bv.at(1));
                result.test_is_true("bit 2", bv.at(2));
                result.test_is_true("bit 3", !bv.at(3));
+               result.test_is_true("bit 4", bv.at(4));
+               result.test_is_true("bit 5", !bv.at(5));
 
-               result.test_throws("bit 4 is not yet allocated", [&] { bv.at(4); });
+               result.test_throws("bit 6 is not yet allocated", [&] { bv.at(6); });
             }),
 
       CHECK("pop_back() shortens bitvector",


### PR DESCRIPTION
This can be tempting for a compiler to convert to conditional jumps, since the range is known to be one of just two values. Instead use CT::Choice.