### PR TITLE
Various small optimizations for X509 path validation

### DIFF
--- a/src/lib/asn1/asn1_obj.cpp
+++ b/src/lib/asn1/asn1_obj.cpp
@@ -179,8 +179,11 @@ std::vector<uint8_t> put_in_sequence(const std::vector<uint8_t>& contents) {
 }
 
 std::vector<uint8_t> put_in_sequence(const uint8_t bits[], size_t len) {
-   std::vector<uint8_t> output;
-   DER_Encoder(output).start_sequence().raw_bytes(bits, len).end_cons();
+   std::vector<uint8_t> output = der_sequence_header(len);
+   output.reserve(output.size() + len);
+   if(len > 0) {
+      output.insert(output.end(), bits, bits + len);
+   }
    return output;
 }
 

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -181,6 +181,8 @@ class DataSource;
 
 namespace ASN1 {
 
+std::vector<uint8_t> der_sequence_header(size_t contents_len);
+
 std::vector<uint8_t> put_in_sequence(const std::vector<uint8_t>& val);
 std::vector<uint8_t> put_in_sequence(const uint8_t bits[], size_t len);
 std::string to_string(const BER_Object& obj);

--- a/src/lib/asn1/der_enc.cpp
+++ b/src/lib/asn1/der_enc.cpp
@@ -65,6 +65,18 @@ void encode_length(std::vector<uint8_t>& encoded_length, size_t length) {
 
 }  // namespace
 
+namespace ASN1 {
+
+std::vector<uint8_t> der_sequence_header(size_t contents_len) {
+   std::vector<uint8_t> header;
+   header.reserve(2 + sizeof(contents_len));
+   encode_tag(header, ASN1_Type::Sequence, ASN1_Class::Constructed);
+   encode_length(header, contents_len);
+   return header;
+}
+
+}  // namespace ASN1
+
 DER_Encoder::DER_Encoder(secure_vector<uint8_t>& vec) {
    m_append_output = [&vec](const uint8_t b[], size_t l) { vec.insert(vec.end(), b, b + l); };
 }

--- a/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
+++ b/src/lib/x509/certstor_flatfile/certstor_flatfile.cpp
@@ -86,11 +86,12 @@ bool Flatfile_Certificate_Store::contains(const X509_Certificate& cert) const {
 
 std::vector<X509_Certificate> Flatfile_Certificate_Store::find_all_certs(const X509_DN& subject_dn,
                                                                          const std::vector<uint8_t>& key_id) const {
-   if(!m_dn_to_cert.contains(subject_dn)) {
+   const auto certs_for_dn = m_dn_to_cert.find(subject_dn);
+   if(certs_for_dn == m_dn_to_cert.end()) {
       return {};
    }
 
-   const auto& certs = m_dn_to_cert.at(subject_dn);
+   const auto& certs = certs_for_dn->second;
 
    std::vector<X509_Certificate> found_certs;
    for(const auto& cert : certs) {
@@ -138,11 +139,12 @@ std::optional<X509_Certificate> Flatfile_Certificate_Store::find_cert_by_raw_sub
 
 std::optional<X509_Certificate> Flatfile_Certificate_Store::find_cert_by_issuer_dn_and_serial_number(
    const X509_DN& issuer_dn, std::span<const uint8_t> serial_number) const {
-   if(!m_issuer_dn_to_cert.contains(issuer_dn)) {
+   const auto certs_for_issuer = m_issuer_dn_to_cert.find(issuer_dn);
+   if(certs_for_issuer == m_issuer_dn_to_cert.end()) {
       return std::nullopt;
    }
 
-   const auto& certs = m_issuer_dn_to_cert.at(issuer_dn);
+   const auto& certs = certs_for_issuer->second;
 
    for(const auto& cert : certs) {
       if(std::ranges::equal(cert.serial_number(), serial_number)) {

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -444,8 +444,9 @@ Certificate_Status_Code Response::verify_signature(const X509_Certificate& issue
       auto pub_key = issuer.subject_public_key();
 
       PK_Verifier verifier(*pub_key, m_sig_algo);
-
-      const bool valid_signature = verifier.verify_message(ASN1::put_in_sequence(m_tbs_bits), m_signature);
+      verifier.update(ASN1::der_sequence_header(m_tbs_bits.size()));
+      verifier.update(m_tbs_bits);
+      const bool valid_signature = verifier.check_signature(m_signature);
 
       if(valid_signature == false) {
          return Certificate_Status_Code::OCSP_SIGNATURE_ERROR;

--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -84,6 +84,7 @@ enum class Certificate_Status_Code : uint16_t {
 
    // Errors in extensions
    UNKNOWN_CRITICAL_EXTENSION = 4009,
+   // TODO(Botan4) remove this code, this is now rejected at parse time
    DUPLICATE_CERT_EXTENSION = 4010,
    IPADDR_BLOCKS_ERROR = 4011,
    AS_BLOCKS_ERROR = 4012,

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -885,6 +885,15 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
       std::vector<std::pair<std::unique_ptr<Certificate_Extension>, bool>> extensions() const;
 
       /**
+      * Invoke the validation callback for each extension.
+      */
+      void validate(const X509_Certificate& subject,
+                    const std::optional<X509_Certificate>& issuer,
+                    const std::vector<X509_Certificate>& cert_path,
+                    std::vector<std::set<Certificate_Status_Code>>& cert_status,
+                    size_t pos) const;
+
+      /**
       * Returns the list of extensions as raw, encoded bytes
       * together with the corresponding criticality flag.
       * Contains all extensions, including any extensions encoded as Unknown_Extension

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -729,7 +729,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Extension /* NOLINT(*-special-member-fu
                             const std::optional<X509_Certificate>& issuer,
                             const std::vector<X509_Certificate>& cert_path,
                             std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                            size_t pos);
+                            size_t pos) const;
 
       virtual ~Certificate_Extension() = default;
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -165,7 +165,7 @@ void Certificate_Extension::validate(const X509_Certificate& /*unused*/,
                                      const std::optional<X509_Certificate>& /*unused*/,
                                      const std::vector<X509_Certificate>& /*unused*/,
                                      std::vector<std::set<Certificate_Status_Code>>& /*unused*/,
-                                     size_t /*unused*/) {}
+                                     size_t /*unused*/) const {}
 
 /*
 * Add a new cert
@@ -733,7 +733,7 @@ void Name_Constraints::validate(const X509_Certificate& subject,
                                 const std::optional<X509_Certificate>& /*issuer*/,
                                 const std::vector<X509_Certificate>& cert_path,
                                 std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                                size_t pos) {
+                                size_t pos) const {
    if(!m_name_constraints.permitted().empty() || !m_name_constraints.excluded().empty()) {
       if(!subject.is_CA_cert()) {
          cert_status.at(pos).insert(Certificate_Status_Code::NAME_CONSTRAINT_ERROR);
@@ -827,7 +827,7 @@ void Certificate_Policies::validate(const X509_Certificate& /*subject*/,
                                     const std::optional<X509_Certificate>& /*issuer*/,
                                     const std::vector<X509_Certificate>& /*cert_path*/,
                                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                                    size_t pos) {
+                                    size_t pos) const {
    const std::set<OID> oid_set(m_oids.begin(), m_oids.end());
    if(oid_set.size() != m_oids.size()) {
       cert_status.at(pos).insert(Certificate_Status_Code::DUPLICATE_CERT_POLICY);
@@ -1716,7 +1716,7 @@ void IPAddressBlocks::validate(const X509_Certificate& /* unused */,
                                const std::optional<X509_Certificate>& /* unused */,
                                const std::vector<X509_Certificate>& cert_path,
                                std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                               size_t pos) {
+                               size_t pos) const {
    // maps in the form of (s)afi -> (needs_checking, ranges)
    auto [v4_needs_check, v6_needs_check] = create_validation_map(m_ip_addr_blocks);
 
@@ -1961,7 +1961,7 @@ void ASBlocks::validate(const X509_Certificate& /* unused */,
                         const std::optional<X509_Certificate>& /* unused */,
                         const std::vector<X509_Certificate>& cert_path,
                         std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                        size_t pos) {
+                        size_t pos) const {
    // the extension may not contain asnums or rdis, but one of them is always present
    const bool asnum_present = m_as_identifiers.asnum().has_value();
    const bool rdi_present = m_as_identifiers.rdi().has_value();
@@ -2031,7 +2031,7 @@ void OCSP_NoCheck::validate(const X509_Certificate& subject,
                             const std::optional<X509_Certificate>& /*issuer*/,
                             const std::vector<X509_Certificate>& /*cert_path*/,
                             std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                            size_t pos) {
+                            size_t pos) const {
    /*
    * RFC 6960 is not particularly explicit about when id-pkix-ocsp-nocheck can
    * or cannot be included in a certificate, but reasonably we should require
@@ -2066,7 +2066,7 @@ void NoRevocationAvailable::validate(const X509_Certificate& subject,
                                      const std::optional<X509_Certificate>& /*issuer*/,
                                      const std::vector<X509_Certificate>& /*cert_path*/,
                                      std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                                     size_t pos) {
+                                     size_t pos) const {
    // RFC 9608 Section 2:
    //    This extension MUST NOT be present in CA public key certificates.
    //

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -798,7 +798,20 @@ class Policy_Information final : public ASN1_Object {
       OID m_oid;
 };
 
+bool policy_oids_have_duplicate(const std::vector<OID>& oids) {
+   std::set<OID> seen;
+   for(const auto& oid : oids) {
+      if(!seen.insert(oid).second) {
+         return true;
+      }
+   }
+   return false;
+}
+
 }  // namespace
+
+Certificate_Policies::Certificate_Policies(const std::vector<OID>& oids) :
+      m_oids(oids), m_has_duplicate(policy_oids_have_duplicate(m_oids)) {}
 
 /*
 * Encode the extension
@@ -831,6 +844,7 @@ void Certificate_Policies::decode_inner(const std::vector<uint8_t>& in) {
    for(const auto& policy : policies) {
       m_oids.push_back(policy.oid());
    }
+   m_has_duplicate = policy_oids_have_duplicate(m_oids);
 }
 
 void Certificate_Policies::validate(const X509_Certificate& /*subject*/,
@@ -838,8 +852,7 @@ void Certificate_Policies::validate(const X509_Certificate& /*subject*/,
                                     const std::vector<X509_Certificate>& /*cert_path*/,
                                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
                                     size_t pos) const {
-   const std::set<OID> oid_set(m_oids.begin(), m_oids.end());
-   if(oid_set.size() != m_oids.size()) {
+   if(m_has_duplicate) {
       cert_status.at(pos).insert(Certificate_Status_Code::DUPLICATE_CERT_POLICY);
    }
 }

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -261,6 +261,16 @@ std::vector<std::pair<std::unique_ptr<Certificate_Extension>, bool>> Extensions:
    return exts;
 }
 
+void Extensions::validate(const X509_Certificate& subject,
+                          const std::optional<X509_Certificate>& issuer,
+                          const std::vector<X509_Certificate>& cert_path,
+                          std::vector<std::set<Certificate_Status_Code>>& cert_status,
+                          size_t pos) const {
+   for(const auto& ext : m_extension_info) {
+      ext.second.obj().validate(subject, issuer, cert_path, cert_status, pos);
+   }
+}
+
 std::map<OID, std::pair<std::vector<uint8_t>, bool>> Extensions::extensions_raw() const {
    std::map<OID, std::pair<std::vector<uint8_t>, bool>> out;
    for(auto&& ext : m_extension_info) {

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -302,12 +302,12 @@ class BOTAN_PUBLIC_API(2, 0) Name_Constraints final : public Certificate_Extensi
 class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Extension {
    public:
       std::unique_ptr<Certificate_Extension> copy() const override {
-         return std::make_unique<Certificate_Policies>(m_oids);
+         return std::make_unique<Certificate_Policies>(*this);
       }
 
       Certificate_Policies() = default;
 
-      explicit Certificate_Policies(const std::vector<OID>& o) : m_oids(o) {}
+      explicit Certificate_Policies(const std::vector<OID>& oids);
 
       const std::vector<OID>& get_policy_oids() const { return m_oids; }
 
@@ -332,6 +332,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
       void decode_inner(const std::vector<uint8_t>& in) override;
 
       std::vector<OID> m_oids;
+      bool m_has_duplicate = false;
 };
 
 /**

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -275,7 +275,7 @@ class BOTAN_PUBLIC_API(2, 0) Name_Constraints final : public Certificate_Extensi
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
       const NameConstraints& get_name_constraints() const { return m_name_constraints; }
 
@@ -319,7 +319,7 @@ class BOTAN_PUBLIC_API(2, 0) Certificate_Policies final : public Certificate_Ext
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
    private:
       std::string oid_name() const override { return "X509v3.CertificatePolicies"; }
@@ -561,7 +561,7 @@ class OCSP_NoCheck final : public Certificate_Extension {
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
    private:
       std::string oid_name() const override { return "PKIX.OCSP.NoCheck"; }
@@ -604,7 +604,7 @@ class BOTAN_PUBLIC_API(3, 13) NoRevocationAvailable final : public Certificate_E
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
    private:
       std::string oid_name() const override { return "X509v3.NoRevocationAvailable"; }
@@ -834,7 +834,7 @@ class BOTAN_PUBLIC_API(3, 9) IPAddressBlocks final : public Certificate_Extensio
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
       /// Add a single IP address to this extension (for the specified SAFI, if any)
       template <Version V>
@@ -975,7 +975,7 @@ class BOTAN_PUBLIC_API(3, 9) ASBlocks final : public Certificate_Extension {
                     const std::optional<X509_Certificate>& issuer,
                     const std::vector<X509_Certificate>& cert_path,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override;
+                    size_t pos) const override;
 
       /// Add a single asnum to this extension
       void add_asnum(asnum_t asnum) { add_asnum(asnum, asnum); }
@@ -1068,7 +1068,7 @@ class BOTAN_PUBLIC_API(2, 4) Unknown_Extension final : public Certificate_Extens
                     const std::optional<X509_Certificate>& /*issuer*/,
                     const std::vector<X509_Certificate>& /*cert_path*/,
                     std::vector<std::set<Certificate_Status_Code>>& cert_status,
-                    size_t pos) override {
+                    size_t pos) const override {
          if(m_failed_to_decode) {
             cert_status.at(pos).insert(Certificate_Status_Code::EXTENSION_ENCODING_ERROR);
          } else if(m_critical) {

--- a/src/lib/x509/x509_obj.cpp
+++ b/src/lib/x509/x509_obj.cpp
@@ -130,7 +130,10 @@ bool X509_Object::check_signature(const Public_Key& pub_key) const {
 std::pair<Certificate_Status_Code, std::string> X509_Object::verify_signature(const Public_Key& pub_key) const {
    try {
       PK_Verifier verifier(pub_key, signature_algorithm());
-      const bool valid = verifier.verify_message(tbs_data(), signature());
+      const auto& tbs = signed_body();
+      verifier.update(ASN1::der_sequence_header(tbs.size()));
+      verifier.update(tbs);
+      const bool valid = verifier.check_signature(signature());
 
       if(valid) {
          return std::make_pair(Certificate_Status_Code::VERIFIED, verifier.hash_function());

--- a/src/lib/x509/x509cert.cpp
+++ b/src/lib/x509/x509cert.cpp
@@ -78,6 +78,7 @@ class X509_Certificate_Data final {
       bool m_is_ca_certificate = false;
       bool m_serial_negative = false;
       bool m_subject_alt_name_exists = false;
+      bool m_skip_revocation_check = false;
 };
 
 X509_Certificate::~X509_Certificate() = default;
@@ -278,6 +279,18 @@ std::unique_ptr<X509_Certificate_Data> parse_x509_cert_body(const X509_Object& o
    const auto san_oid = OID::from_string("X509v3.SubjectAlternativeName");
    data->m_subject_alt_name_exists = data->m_v3_extensions.extension_set(san_oid);
 
+   /*
+   * RFC 9608 Section 4:
+   *
+   *   If the noRevAvail certificate extension specified in this document is
+   *   present or the ocsp-nocheck certificate extension [RFC6960] is
+   *   present, then Step (a)(3) is skipped.  Otherwise, revocation status
+   *   determination of the certificate is performed.
+   */
+   data->m_skip_revocation_check =
+      data->m_v3_extensions.extension_set(Cert_Extension::NoRevocationAvailable::static_oid()) ||
+      data->m_v3_extensions.extension_set(Cert_Extension::OCSP_NoCheck::static_oid());
+
    if(const auto* ext = data->m_v3_extensions.get_extension_object_as<Cert_Extension::Certificate_Policies>()) {
       data->m_cert_policies = ext->get_policy_oids();
    }
@@ -431,6 +444,10 @@ const std::vector<uint8_t>& X509_Certificate::serial_number() const {
 
 bool X509_Certificate::is_serial_negative() const {
    return data().m_serial_negative;
+}
+
+bool X509_Certificate::skip_revocation_check() const {
+   return data().m_skip_revocation_check;
 }
 
 const X509_DN& X509_Certificate::issuer_dn() const {

--- a/src/lib/x509/x509cert.h
+++ b/src/lib/x509/x509cert.h
@@ -197,6 +197,13 @@ class BOTAN_PUBLIC_API(2, 0) X509_Certificate : public X509_Object {
       bool is_serial_negative() const;
 
       /**
+      * Return true if revocation status checking of this certificate should be
+      * skipped, as indicated by the presence of either the noRevAvail extension
+      * (RFC 9608) or the ocsp-nocheck extension (RFC 6960).
+      */
+      bool skip_revocation_check() const;
+
+      /**
       * Get the DER encoded AuthorityKeyIdentifier of this certificate.
       * @return DER encoded AuthorityKeyIdentifier
       */

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -471,9 +471,10 @@ Certificate_Status_Code verify_ocsp_signing_cert(const X509_Certificate& signing
    //
    //    1. Matches a local configuration of OCSP signing authority
    //       for the certificate in question, or
-   if(restrictions.trusted_ocsp_responders() != nullptr &&
-      restrictions.trusted_ocsp_responders()->contains(signing_cert)) {
-      return Certificate_Status_Code::OK;
+   if(const auto* trusted_responders = restrictions.trusted_ocsp_responders()) {
+      if(trusted_responders->contains(signing_cert)) {
+         return Certificate_Status_Code::OK;
+      }
    }
 
    // RFC 6960 4.2.2.2

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -31,32 +31,6 @@ namespace Botan {
 
 namespace {
 
-/*
-* RFC 9608 Section 4:
-*
-*   Section 6.1.3 of [RFC5280] describes basic certificate processing
-*   within the certification path validation procedures.  In particular,
-*   Step (a)(3) says:
-*
-*   |  At the current time, the certificate is not revoked.  This may be
-*   |  determined by obtaining the appropriate CRL (Section 6.3), by
-*   |  status information, or by out-of-band mechanisms.
-*
-*   If the noRevAvail certificate extension specified in this document is
-*   present or the ocsp-nocheck certificate extension [RFC6960] is
-*   present, then Step (a)(3) is skipped.  Otherwise, revocation status
-*   determination of the certificate is performed.
-*/
-bool skip_revocation_check(const X509_Certificate& cert) {
-   const Extensions& exts = cert.v3_extensions();
-   return exts.extension_set(Cert_Extension::NoRevocationAvailable::static_oid()) ||
-          exts.extension_set(Cert_Extension::OCSP_NoCheck::static_oid());
-}
-
-}  // namespace
-
-namespace {
-
 /**
  * Lazy DFS iterator that yields certificate paths one at a time.
  *
@@ -617,7 +591,7 @@ CertificatePathStatusCodes PKIX::check_ocsp(const std::vector<X509_Certificate>&
       const X509_Certificate& subject = cert_path.at(i);
       const X509_Certificate& ca = cert_path.at(i + 1);
 
-      if(skip_revocation_check(subject)) {
+      if(subject.skip_revocation_check()) {
          continue;
       }
 
@@ -648,7 +622,7 @@ CertificatePathStatusCodes PKIX::check_crl(const std::vector<X509_Certificate>& 
    for(size_t i = 0; i != cert_path.size() - 1; ++i) {
       std::set<Certificate_Status_Code>& status = cert_status.at(i);
 
-      if(skip_revocation_check(cert_path.at(i))) {
+      if(cert_path.at(i).skip_revocation_check()) {
          continue;
       }
 
@@ -721,7 +695,7 @@ CertificatePathStatusCodes PKIX::check_crl(const std::vector<X509_Certificate>& 
    std::vector<std::optional<X509_CRL>> crls(cert_path.size());
 
    for(size_t i = 0; i != cert_path.size(); ++i) {
-      if(skip_revocation_check(cert_path[i])) {
+      if(cert_path[i].skip_revocation_check()) {
          continue;
       }
       for(auto* certstore : certstores) {
@@ -761,7 +735,7 @@ CertificatePathStatusCodes PKIX::check_ocsp_online(const std::vector<X509_Certif
       const auto& subject = cert_path.at(i);
       const auto& issuer = cert_path.at(i + 1);
 
-      if(skip_revocation_check(subject)) {
+      if(subject.skip_revocation_check()) {
          ocsp_response_futures.emplace_back(
             std::async(std::launch::deferred, []() -> std::optional<OCSP::Response> { return std::nullopt; }));
       } else {
@@ -823,7 +797,7 @@ CertificatePathStatusCodes PKIX::check_crl_online(const std::vector<X509_Certifi
    for(size_t i = 0; i != cert_path.size(); ++i) {
       const auto& cert = cert_path.at(i);
 
-      if(skip_revocation_check(cert)) {
+      if(cert.skip_revocation_check()) {
          future_crls.emplace_back(
             std::async(std::launch::deferred, []() -> std::optional<X509_CRL> { return std::nullopt; }));
          continue;
@@ -1083,7 +1057,7 @@ Path_Validation_Result x509_path_validate(const std::vector<X509_Certificate>& e
             const size_t to_online = restrictions.ocsp_all_intermediates() ? (cert_path->size() - 1) : 1;
             bool need_online = false;
             for(size_t i = 0; i < to_online; ++i) {
-               if(skip_revocation_check((*cert_path)[i])) {
+               if((*cert_path)[i].skip_revocation_check()) {
                   continue;
                }
                if(i >= ocsp_status.size() || ocsp_status[i].empty()) {
@@ -1122,7 +1096,7 @@ Path_Validation_Result x509_path_validate(const std::vector<X509_Certificate>& e
          // merge_revocation_status flags NO_REVOCATION_DATA when require_revocation
          // is set; clear it for certs where RFC 9608 Section 4 says to skip the check.
          for(size_t i = 0; i + 1 < cert_path->size() && i < status.size(); ++i) {
-            if(skip_revocation_check((*cert_path)[i])) {
+            if((*cert_path)[i].skip_revocation_check()) {
                status[i].erase(Certificate_Status_Code::NO_REVOCATION_DATA);
             }
          }

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -419,18 +419,11 @@ CertificatePathStatusCodes PKIX::check_chain(const std::vector<X509_Certificate>
       }
 
       const Extensions& extensions = subject.v3_extensions();
-      const auto& extensions_vec = extensions.extensions();
-      if(subject.x509_version() < 3 && !extensions_vec.empty()) {
+      if(subject.x509_version() < 3 && !extensions.get_extension_oids().empty()) {
          status.insert(Certificate_Status_Code::EXT_IN_V1_V2_CERT);
       }
 
-      for(const auto& extension : extensions_vec) {
-         extension.first->validate(subject, issuer, cert_path, cert_status, i);
-      }
-
-      if(extensions_vec.size() != extensions.get_extension_oids().size()) {
-         status.insert(Certificate_Status_Code::DUPLICATE_CERT_EXTENSION);
-      }
+      extensions.validate(subject, issuer, cert_path, cert_status, i);
    }
 
    // path len check

--- a/src/lib/x509/x509path.cpp
+++ b/src/lib/x509/x509path.cpp
@@ -15,7 +15,9 @@
 #include <botan/internal/concat_util.h>
 #include <algorithm>
 #include <chrono>
+#include <iterator>
 #include <set>
+#include <span>
 #include <sstream>
 #include <string>
 #include <unordered_set>
@@ -52,7 +54,7 @@ class CertificatePathBuilder final {
    public:
       CertificatePathBuilder(const std::vector<Certificate_Store*>& trusted_certstores,
                              const X509_Certificate& end_entity,
-                             const std::vector<X509_Certificate>& end_entity_extra,
+                             std::span<const X509_Certificate> end_entity_extra,
                              bool require_self_signed = false) :
             m_trusted_certstores(trusted_certstores), m_require_self_signed(require_self_signed) {
          if(std::ranges::any_of(trusted_certstores, [](auto* ptr) { return ptr == nullptr; })) {
@@ -161,11 +163,18 @@ class CertificatePathBuilder final {
          const X509_DN& issuer_dn = cert.issuer_dn();
          const std::vector<uint8_t>& auth_key_id = cert.authority_key_id();
 
-         // Search for trusted issuers
+         // Common case is a single trusted store; steal its buffer and only
+         // move-append if multiple stores return matches.
          std::vector<X509_Certificate> trusted_issuers;
          for(const Certificate_Store* store : m_trusted_certstores) {
             auto new_issuers = store->find_all_certs(issuer_dn, auth_key_id);
-            trusted_issuers.insert(trusted_issuers.end(), new_issuers.begin(), new_issuers.end());
+            if(trusted_issuers.empty()) {
+               trusted_issuers = std::move(new_issuers);
+            } else {
+               trusted_issuers.insert(trusted_issuers.end(),
+                                      std::make_move_iterator(new_issuers.begin()),
+                                      std::make_move_iterator(new_issuers.end()));
+            }
          }
 
          // Search the supplemental certs
@@ -1015,10 +1024,7 @@ Path_Validation_Result x509_path_validate(const std::vector<X509_Certificate>& e
    }
 
    const X509_Certificate& end_entity = end_certs[0];
-   std::vector<X509_Certificate> end_entity_extra;
-   for(size_t i = 1; i < end_certs.size(); ++i) {
-      end_entity_extra.push_back(end_certs[i]);
-   }
+   const auto end_entity_extra = std::span<const X509_Certificate>(end_certs).subspan(1);
 
    const bool require_self_signed = restrictions.require_self_signed_trust_anchors();
 

--- a/src/lib/x509/x509path.h
+++ b/src/lib/x509/x509path.h
@@ -48,7 +48,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
       * well as end entity (if OCSP enabled in path validation request)
       * @param max_ocsp_age maximum age of OCSP responses w/o next_update.
       *        If zero, there is no maximum age
-      * @param trusted_ocsp_responders certificate store containing certificates
+      * @param trusted_ocsp_responders optional certificate store containing certificates
       *        of trusted OCSP responders (additionally to the CA's responders)
       * @param ignore_trusted_root_time_range if true, validity checks on the
       *        time range of the trusted root certificate only produce warnings
@@ -61,7 +61,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
          size_t minimum_key_strength = 110,
          bool ocsp_all_intermediates = false,
          std::chrono::seconds max_ocsp_age = std::chrono::hours(24 * 7),
-         std::unique_ptr<Certificate_Store> trusted_ocsp_responders = std::make_unique<Certificate_Store_In_Memory>(),
+         std::unique_ptr<Certificate_Store> trusted_ocsp_responders = nullptr,
          bool ignore_trusted_root_time_range = false,
          bool require_self_signed_trust_anchors = true);
 
@@ -77,7 +77,7 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
       *        rejected.
       * @param max_ocsp_age maximum age of OCSP responses w/o next_update.
       *        If zero, there is no maximum age
-      * @param trusted_ocsp_responders certificate store containing certificates
+      * @param trusted_ocsp_responders optional certificate store containing certificates
       *        of trusted OCSP responders (additionally to the CA's responders)
       * @param ignore_trusted_root_time_range if true, validity checks on the
       *        time range of the trusted root certificate only produce warnings
@@ -85,15 +85,14 @@ class BOTAN_PUBLIC_API(2, 0) Path_Validation_Restrictions final {
       *        are allowed as trust anchors. Trust anchors based on intermediate
       *        and leaf certificates are forbidden in this case.
       */
-      Path_Validation_Restrictions(
-         bool require_rev,
-         size_t minimum_key_strength,
-         bool ocsp_all_intermediates,
-         const std::set<std::string>& trusted_hashes,
-         std::chrono::seconds max_ocsp_age = std::chrono::hours(24 * 7),
-         std::unique_ptr<Certificate_Store> trusted_ocsp_responders = std::make_unique<Certificate_Store_In_Memory>(),
-         bool ignore_trusted_root_time_range = false,
-         bool require_self_signed_trust_anchors = true) :
+      Path_Validation_Restrictions(bool require_rev,
+                                   size_t minimum_key_strength,
+                                   bool ocsp_all_intermediates,
+                                   const std::set<std::string>& trusted_hashes,
+                                   std::chrono::seconds max_ocsp_age = std::chrono::hours(24 * 7),
+                                   std::unique_ptr<Certificate_Store> trusted_ocsp_responders = nullptr,
+                                   bool ignore_trusted_root_time_range = false,
+                                   bool require_self_signed_trust_anchors = true) :
             m_require_revocation_information(require_rev),
             m_ocsp_all_intermediates(ocsp_all_intermediates),
             m_trusted_hashes(trusted_hashes),


### PR DESCRIPTION
Avoiding copies, pointless allocations, etc