### PR TITLE
In all public and private key classes, store data as a const shared_ptr

### DIFF
--- a/src/lib/pubkey/classic_mceliece/cmce.h
+++ b/src/lib/pubkey/classic_mceliece/cmce.h
@@ -88,7 +88,7 @@ class BOTAN_PUBLIC_API(3, 7) Classic_McEliece_PublicKey : public virtual Public_
       Classic_McEliece_PublicKey() = default;
 
    protected:
-      std::shared_ptr<Classic_McEliece_PublicKeyInternal> m_public;  // NOLINT(*-non-private-member-variable*)
+      std::shared_ptr<const Classic_McEliece_PublicKeyInternal> m_public;  // NOLINT(*-non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -134,7 +134,7 @@ class BOTAN_PUBLIC_API(3, 7) Classic_McEliece_PrivateKey final : public virtual 
                                                                        std::string_view provider) const override;
 
    private:
-      std::shared_ptr<Classic_McEliece_PrivateKeyInternal> m_private;
+      std::shared_ptr<const Classic_McEliece_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/classic_mceliece/cmce_decaps.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_decaps.h
@@ -29,7 +29,7 @@ class BOTAN_TEST_API Classic_McEliece_Decryptor final : public PK_Ops::KEM_Decry
        * @brief Constructs a Classic_McEliece_Decryptor object with the given private key.
        * @param key The private key used for decryption.
        */
-      Classic_McEliece_Decryptor(std::shared_ptr<Classic_McEliece_PrivateKeyInternal> key, std::string_view kdf) :
+      Classic_McEliece_Decryptor(std::shared_ptr<const Classic_McEliece_PrivateKeyInternal> key, std::string_view kdf) :
             KEM_Decryption_with_KDF(kdf), m_key(std::move(key)) {}
 
       size_t raw_kem_shared_key_length() const override { return m_key->params().hash_out_bytes(); }
@@ -76,7 +76,7 @@ class BOTAN_TEST_API Classic_McEliece_Decryptor final : public PK_Ops::KEM_Decry
        */
       std::pair<CT::Mask<uint8_t>, CmceErrorVector> decode(CmceCodeWord big_c) const;
 
-      std::shared_ptr<Classic_McEliece_PrivateKeyInternal> m_key;
+      std::shared_ptr<const Classic_McEliece_PrivateKeyInternal> m_key;
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/classic_mceliece/cmce_encaps.h
+++ b/src/lib/pubkey/classic_mceliece/cmce_encaps.h
@@ -27,7 +27,7 @@ namespace Botan {
  */
 class BOTAN_TEST_API Classic_McEliece_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      Classic_McEliece_Encryptor(std::shared_ptr<Classic_McEliece_PublicKeyInternal> key, std::string_view kdf) :
+      Classic_McEliece_Encryptor(std::shared_ptr<const Classic_McEliece_PublicKeyInternal> key, std::string_view kdf) :
             KEM_Encryption_with_KDF(kdf), m_key(std::move(key)) {}
 
       size_t raw_kem_shared_key_length() const override { return m_key->params().hash_out_bytes(); }
@@ -39,7 +39,7 @@ class BOTAN_TEST_API Classic_McEliece_Encryptor final : public PK_Ops::KEM_Encry
                            RandomNumberGenerator& rng) override;
 
    private:
-      std::shared_ptr<Classic_McEliece_PublicKeyInternal> m_key;
+      std::shared_ptr<const Classic_McEliece_PublicKeyInternal> m_key;
 
       /**
        * @brief Encodes an error vector by multiplying it with the Classic McEliece matrix.

--- a/src/lib/pubkey/curve448/ed448/ed448.cpp
+++ b/src/lib/pubkey/curve448/ed448/ed448.cpp
@@ -20,13 +20,38 @@
 
 namespace Botan {
 
+class Ed448_PublicKey_Data final {
+   public:
+      explicit Ed448_PublicKey_Data(std::array<uint8_t, ED448_LEN> key) : m_key(key) {}
+
+      const std::array<uint8_t, ED448_LEN>& key() const { return m_key; }
+
+   private:
+      std::array<uint8_t, ED448_LEN> m_key;
+};
+
+class Ed448_PrivateKey_Data final {
+   public:
+      explicit Ed448_PrivateKey_Data(secure_vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const secure_vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      secure_vector<uint8_t> m_key;
+};
+
+secure_vector<uint8_t> Ed448_PrivateKey::raw_private_key_bits() const {
+   const auto& sk = m_private->key();
+   return {sk.begin(), sk.end()};
+}
+
 AlgorithmIdentifier Ed448_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_EMPTY_PARAM);
 }
 
 bool Ed448_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
    try {
-      Ed448Point::decode(m_public);
+      Ed448Point::decode(m_public->key());
    } catch(Decoding_Error&) {
       return false;
    }
@@ -45,11 +70,14 @@ Ed448_PublicKey::Ed448_PublicKey(std::span<const uint8_t> key_bits) {
    if(key_bits.size() != ED448_LEN) {
       throw Decoding_Error("Invalid length for Ed448 public key");
    }
-   copy_mem(m_public, key_bits.first<ED448_LEN>());
+   std::array<uint8_t, ED448_LEN> pub{};
+   copy_mem(pub, key_bits.first<ED448_LEN>());
+   m_public = std::make_shared<const Ed448_PublicKey_Data>(pub);
 }
 
 std::vector<uint8_t> Ed448_PublicKey::raw_public_key_bits() const {
-   return {m_public.begin(), m_public.end()};
+   const auto& pub = m_public->key();
+   return {pub.begin(), pub.end()};
 }
 
 std::vector<uint8_t> Ed448_PublicKey::public_key_bits() const {
@@ -72,8 +100,9 @@ Ed448_PrivateKey::Ed448_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<
    if(bits.size() != ED448_LEN) {
       throw Decoding_Error("Invalid size for Ed448 private key");
    }
-   m_private = std::move(bits);
-   m_public = create_pk_from_sk(std::span(m_private).first<ED448_LEN>());
+   auto pub = create_pk_from_sk(std::span(bits).first<ED448_LEN>());
+   m_public = std::make_shared<const Ed448_PublicKey_Data>(pub);
+   m_private = std::make_shared<const Ed448_PrivateKey_Data>(std::move(bits));
 }
 
 Ed448_PrivateKey::Ed448_PrivateKey(RandomNumberGenerator& rng) : Ed448_PrivateKey(rng.random_vec(ED448_LEN)) {}
@@ -82,27 +111,34 @@ Ed448_PrivateKey::Ed448_PrivateKey(std::span<const uint8_t> key_bits) {
    if(key_bits.size() != ED448_LEN) {
       throw Decoding_Error("Invalid size for Ed448 private key");
    }
-   m_private.assign(key_bits.begin(), key_bits.end());
-   auto scope = CT::scoped_poison(m_private);
-   m_public = create_pk_from_sk(std::span(m_private).first<ED448_LEN>());
-   CT::unpoison(m_public);
+   secure_vector<uint8_t> sk(key_bits.begin(), key_bits.end());
+   std::array<uint8_t, ED448_LEN> pub{};
+   {
+      auto scope = CT::scoped_poison(sk);
+      pub = create_pk_from_sk(std::span(sk).first<ED448_LEN>());
+      CT::unpoison(pub);
+   }
+   m_public = std::make_shared<const Ed448_PublicKey_Data>(pub);
+   m_private = std::make_shared<const Ed448_PrivateKey_Data>(std::move(sk));
 }
 
 std::unique_ptr<Public_Key> Ed448_PrivateKey::public_key() const {
-   return std::make_unique<Ed448_PublicKey>(m_public);
+   return std::make_unique<Ed448_PublicKey>(raw_public_key_bits());
 }
 
 secure_vector<uint8_t> Ed448_PrivateKey::private_key_bits() const {
-   BOTAN_ASSERT_NOMSG(m_private.size() == ED448_LEN);
-   return DER_Encoder().encode(m_private, ASN1_Type::OctetString).get_contents();
+   const auto& sk = m_private->key();
+   BOTAN_ASSERT_NOMSG(sk.size() == ED448_LEN);
+   return DER_Encoder().encode(sk, ASN1_Type::OctetString).get_contents();
 }
 
 bool Ed448_PrivateKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
-   BOTAN_ASSERT_NOMSG(m_private.size() == ED448_LEN);
-   auto scope = CT::scoped_poison(m_private);
-   const auto public_point = create_pk_from_sk(std::span(m_private).first<ED448_LEN>());
+   const auto& sk = m_private->key();
+   BOTAN_ASSERT_NOMSG(sk.size() == ED448_LEN);
+   auto scope = CT::scoped_poison(sk);
+   const auto public_point = create_pk_from_sk(std::span(sk).first<ED448_LEN>());
    CT::unpoison(public_point);
-   return public_point == m_public;
+   return public_point == m_public->key();
 }
 
 namespace {
@@ -148,9 +184,9 @@ class Pure_Ed448_Message final : public Ed448_Message {
 */
 class Ed448_Verify_Operation final : public PK_Ops::Verification {
    public:
-      explicit Ed448_Verify_Operation(const Ed448_PublicKey& key,
+      explicit Ed448_Verify_Operation(std::shared_ptr<const Ed448_PublicKey_Data> public_key,
                                       std::optional<std::string> prehash_function = std::nullopt) :
-            m_pk(key.raw_public_key_bits()), m_prehash_function(std::move(prehash_function)) {
+            m_public_key(std::move(public_key)), m_prehash_function(std::move(prehash_function)) {
          if(m_prehash_function) {
             m_message = std::make_unique<Prehashed_Ed448_Message>(*m_prehash_function);
          } else {
@@ -163,7 +199,8 @@ class Ed448_Verify_Operation final : public PK_Ops::Verification {
       bool is_valid_signature(std::span<const uint8_t> sig) override {
          const auto msg = m_message->get_and_clear();
          try {
-            return verify_signature(std::span(m_pk).first<ED448_LEN>(), m_prehash_function.has_value(), {}, sig, msg);
+            return verify_signature(
+               std::span(m_public_key->key()).first<ED448_LEN>(), m_prehash_function.has_value(), {}, sig, msg);
          } catch(Decoding_Error&) {
             return false;
          }
@@ -172,7 +209,7 @@ class Ed448_Verify_Operation final : public PK_Ops::Verification {
       std::string hash_function() const override { return m_prehash_function.value_or("SHAKE-256(912)"); }
 
    private:
-      std::vector<uint8_t> m_pk;
+      std::shared_ptr<const Ed448_PublicKey_Data> m_public_key;
       std::unique_ptr<Ed448_Message> m_message;
       std::optional<std::string> m_prehash_function;
 };
@@ -182,10 +219,11 @@ class Ed448_Verify_Operation final : public PK_Ops::Verification {
 */
 class Ed448_Sign_Operation final : public PK_Ops::Signature {
    public:
-      explicit Ed448_Sign_Operation(const Ed448_PrivateKey& key,
-                                    std::optional<std::string> prehash_function = std::nullopt) :
-            m_pk(key.raw_public_key_bits()),
-            m_sk(key.raw_private_key_bits()),
+      Ed448_Sign_Operation(std::shared_ptr<const Ed448_PublicKey_Data> public_key,
+                           std::shared_ptr<const Ed448_PrivateKey_Data> private_key,
+                           std::optional<std::string> prehash_function = std::nullopt) :
+            m_public_key(std::move(public_key)),
+            m_private_key(std::move(private_key)),
             m_prehash_function(std::move(prehash_function)) {
          if(m_prehash_function) {
             m_message = std::make_unique<Prehashed_Ed448_Message>(*m_prehash_function);
@@ -197,10 +235,11 @@ class Ed448_Sign_Operation final : public PK_Ops::Signature {
       void update(std::span<const uint8_t> input) override { m_message->update(input); }
 
       std::vector<uint8_t> sign(RandomNumberGenerator& /*rng*/) override {
-         BOTAN_ASSERT_NOMSG(m_sk.size() == ED448_LEN);
-         auto scope = CT::scoped_poison(m_sk);
-         const auto sig = sign_message(std::span(m_sk).first<ED448_LEN>(),
-                                       std::span(m_pk).first<ED448_LEN>(),
+         const auto& sk = m_private_key->key();
+         BOTAN_ASSERT_NOMSG(sk.size() == ED448_LEN);
+         auto scope = CT::scoped_poison(sk);
+         const auto sig = sign_message(std::span(sk).first<ED448_LEN>(),
+                                       std::span(m_public_key->key()).first<ED448_LEN>(),
                                        m_prehash_function.has_value(),
                                        {},
                                        m_message->get_and_clear());
@@ -215,8 +254,8 @@ class Ed448_Sign_Operation final : public PK_Ops::Signature {
       std::string hash_function() const override { return m_prehash_function.value_or("SHAKE-256(912)"); }
 
    private:
-      std::vector<uint8_t> m_pk;
-      secure_vector<uint8_t> m_sk;
+      std::shared_ptr<const Ed448_PublicKey_Data> m_public_key;
+      std::shared_ptr<const Ed448_PrivateKey_Data> m_private_key;
       std::unique_ptr<Ed448_Message> m_message;
       std::optional<std::string> m_prehash_function;
 };
@@ -231,11 +270,11 @@ std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_verification_op(st
                                                                               std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
       if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Verify_Operation>(*this);
+         return std::make_unique<Ed448_Verify_Operation>(m_public);
       } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Verify_Operation>(*this, "SHAKE-256(512)");
+         return std::make_unique<Ed448_Verify_Operation>(m_public, "SHAKE-256(512)");
       } else {
-         return std::make_unique<Ed448_Verify_Operation>(*this, std::string(params));
+         return std::make_unique<Ed448_Verify_Operation>(m_public, std::string(params));
       }
    }
    throw Provider_Not_Found(algo_name(), provider);
@@ -248,7 +287,7 @@ std::unique_ptr<PK_Ops::Verification> Ed448_PublicKey::create_x509_verification_
          throw Decoding_Error("Unexpected AlgorithmIdentifier for Ed448 X509 signature");
       }
 
-      return std::make_unique<Ed448_Verify_Operation>(*this);
+      return std::make_unique<Ed448_Verify_Operation>(m_public);
    }
    throw Provider_Not_Found(algo_name(), provider);
 }
@@ -258,11 +297,11 @@ std::unique_ptr<PK_Ops::Signature> Ed448_PrivateKey::create_signature_op(RandomN
                                                                          std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
       if(params.empty() || params == "Identity" || params == "Pure" || params == "Ed448") {
-         return std::make_unique<Ed448_Sign_Operation>(*this);
+         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private);
       } else if(params == "Ed448ph") {
-         return std::make_unique<Ed448_Sign_Operation>(*this, "SHAKE-256(512)");
+         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private, "SHAKE-256(512)");
       } else {
-         return std::make_unique<Ed448_Sign_Operation>(*this, std::string(params));
+         return std::make_unique<Ed448_Sign_Operation>(m_public, m_private, std::string(params));
       }
    }
    throw Provider_Not_Found(algo_name(), provider);

--- a/src/lib/pubkey/curve448/ed448/ed448.h
+++ b/src/lib/pubkey/curve448/ed448/ed448.h
@@ -11,9 +11,13 @@
 
 #include <botan/pk_keys.h>
 
-#include <array>
+#include <memory>
+#include <vector>
 
 namespace Botan {
+
+class Ed448_PublicKey_Data;
+class Ed448_PrivateKey_Data;
 
 /**
  * @brief A public key for Ed448/Ed448ph according to RFC 8032.
@@ -64,7 +68,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PublicKey : public virtual Public_Key {
 
    protected:
       Ed448_PublicKey() = default;
-      std::array<uint8_t, 57> m_public{};  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const Ed448_PublicKey_Data> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -104,7 +108,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PrivateKey final : public Ed448_PublicKey,
       */
       explicit Ed448_PrivateKey(RandomNumberGenerator& rng);
 
-      secure_vector<uint8_t> raw_private_key_bits() const override { return {m_private.begin(), m_private.end()}; }
+      secure_vector<uint8_t> raw_private_key_bits() const override;
 
       secure_vector<uint8_t> private_key_bits() const override;
 
@@ -117,7 +121,7 @@ class BOTAN_PUBLIC_API(3, 4) Ed448_PrivateKey final : public Ed448_PublicKey,
                                                              std::string_view provider) const override;
 
    private:
-      secure_vector<uint8_t> m_private;
+      std::shared_ptr<const Ed448_PrivateKey_Data> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/curve448/x448/x448.cpp
+++ b/src/lib/pubkey/curve448/x448/x448.cpp
@@ -18,6 +18,31 @@
 
 namespace Botan {
 
+class X448_PublicKey_Data final {
+   public:
+      explicit X448_PublicKey_Data(std::array<uint8_t, X448_LEN> key) : m_key(key) {}
+
+      const std::array<uint8_t, X448_LEN>& key() const { return m_key; }
+
+   private:
+      std::array<uint8_t, X448_LEN> m_key;
+};
+
+class X448_PrivateKey_Data final {
+   public:
+      explicit X448_PrivateKey_Data(secure_vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const secure_vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      secure_vector<uint8_t> m_key;
+};
+
+secure_vector<uint8_t> X448_PrivateKey::raw_private_key_bits() const {
+   const auto& sk = m_private->key();
+   return {sk.begin(), sk.end()};
+}
+
 namespace {
 void x448_basepoint_from_data(std::span<uint8_t, X448_LEN> mypublic, std::span<const uint8_t, X448_LEN> secret) {
    auto bp = x448_basepoint(decode_scalar(secret));
@@ -34,6 +59,22 @@ secure_vector<uint8_t> ber_decode_sk(std::span<const uint8_t> key_bits) {
    return decoded_bits;
 }
 
+// Given a secret key compute the public value and build the immutable public
+// and private key data objects.
+void load_x448_keypair(secure_vector<uint8_t> secret,
+                       std::shared_ptr<const X448_PublicKey_Data>& pk_out,
+                       std::shared_ptr<const X448_PrivateKey_Data>& sk_out) {
+   BOTAN_ASSERT_NOMSG(secret.size() == X448_LEN);
+   std::array<uint8_t, X448_LEN> pub{};
+   {
+      auto scope = CT::scoped_poison(secret);
+      x448_basepoint_from_data(pub, std::span(secret).first<X448_LEN>());
+      CT::unpoison(pub);
+   }
+   pk_out = std::make_shared<const X448_PublicKey_Data>(pub);
+   sk_out = std::make_shared<const X448_PrivateKey_Data>(std::move(secret));
+}
+
 }  // namespace
 
 AlgorithmIdentifier X448_PublicKey::algorithm_identifier() const {
@@ -45,7 +86,8 @@ bool X448_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) 
 }
 
 std::vector<uint8_t> X448_PublicKey::raw_public_key_bits() const {
-   return {m_public.begin(), m_public.end()};
+   const auto& pub = m_public->key();
+   return {pub.begin(), pub.end()};
 }
 
 std::vector<uint8_t> X448_PublicKey::public_key_bits() const {
@@ -66,7 +108,9 @@ X448_PublicKey::X448_PublicKey(const AlgorithmIdentifier& alg_id, std::span<cons
 
 X448_PublicKey::X448_PublicKey(std::span<const uint8_t> pub) {
    BOTAN_ARG_CHECK(pub.size() == X448_LEN, "Invalid size for X448 public key");
-   copy_mem(m_public, pub);
+   std::array<uint8_t, X448_LEN> pub_arr{};
+   copy_mem(pub_arr, pub);
+   m_public = std::make_shared<const X448_PublicKey_Data>(pub_arr);
 }
 
 X448_PrivateKey::X448_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
@@ -79,10 +123,7 @@ X448_PrivateKey::X448_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<co
 
 X448_PrivateKey::X448_PrivateKey(std::span<const uint8_t> secret_key) {
    BOTAN_ARG_CHECK(secret_key.size() == X448_LEN, "Invalid size for X448 private key");
-   m_private.assign(secret_key.begin(), secret_key.end());
-   auto scope = CT::scoped_poison(m_private);
-   x448_basepoint_from_data(m_public, std::span(m_private).first<X448_LEN>());
-   CT::unpoison(m_public);
+   load_x448_keypair(secure_vector<uint8_t>(secret_key.begin(), secret_key.end()), m_public, m_private);
 }
 
 X448_PrivateKey::X448_PrivateKey(RandomNumberGenerator& rng) : X448_PrivateKey(rng.random_vec(X448_LEN)) {}
@@ -92,15 +133,17 @@ std::unique_ptr<Public_Key> X448_PrivateKey::public_key() const {
 }
 
 secure_vector<uint8_t> X448_PrivateKey::private_key_bits() const {
-   return DER_Encoder().encode(m_private, ASN1_Type::OctetString).get_contents();
+   return DER_Encoder().encode(m_private->key(), ASN1_Type::OctetString).get_contents();
 }
 
 bool X448_PrivateKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
+   const auto& sk = m_private->key();
+   const auto& pub = m_public->key();
    std::array<uint8_t, X448_LEN> public_point{};
-   BOTAN_ASSERT_NOMSG(m_private.size() == X448_LEN);
-   auto scope = CT::scoped_poison(m_private);
-   x448_basepoint_from_data(public_point, std::span(m_private).first<X448_LEN>());
-   return CT::is_equal(public_point.data(), m_public.data(), m_public.size()).as_bool();
+   BOTAN_ASSERT_NOMSG(sk.size() == X448_LEN);
+   auto scope = CT::scoped_poison(sk);
+   x448_basepoint_from_data(public_point, std::span(sk).first<X448_LEN>());
+   return CT::is_equal(public_point.data(), pub.data(), pub.size()).as_bool();
 }
 
 namespace {
@@ -110,21 +153,21 @@ namespace {
 */
 class X448_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
    public:
-      X448_KA_Operation(std::span<const uint8_t> sk, std::string_view kdf) :
-            PK_Ops::Key_Agreement_with_KDF(kdf), m_sk(sk.begin(), sk.end()) {
-         BOTAN_ARG_CHECK(sk.size() == X448_LEN, "Invalid size for X448 private key");
-      }
+      X448_KA_Operation(std::shared_ptr<const X448_PrivateKey_Data> key, std::string_view kdf) :
+            PK_Ops::Key_Agreement_with_KDF(kdf), m_key(std::move(key)) {}
 
       size_t agreed_value_size() const override { return X448_LEN; }
 
       secure_vector<uint8_t> raw_agree(const uint8_t w_data[], size_t w_len) override {
-         auto scope = CT::scoped_poison(m_sk);
+         const auto& sk = m_key->key();
+         BOTAN_ASSERT_NOMSG(sk.size() == X448_LEN);
+         auto scope = CT::scoped_poison(sk);
 
          const std::span<const uint8_t> w(w_data, w_len);
          if(w.size() != X448_LEN) {
             throw Decoding_Error("Invalid size for X448 public key");
          }
-         const auto k = decode_scalar(m_sk);
+         const auto k = decode_scalar(sk);
          const auto u = decode_point(w);
 
          auto shared_secret = encode_point(x448(k, u));
@@ -148,7 +191,7 @@ class X448_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       }
 
    private:
-      secure_vector<uint8_t> m_sk;
+      std::shared_ptr<const X448_PrivateKey_Data> m_key;
 };
 
 }  // namespace

--- a/src/lib/pubkey/curve448/x448/x448.h
+++ b/src/lib/pubkey/curve448/x448/x448.h
@@ -10,9 +10,14 @@
 
 #include <botan/pk_keys.h>
 
-#include <array>
+#include <memory>
+#include <vector>
 
 namespace Botan {
+
+class X448_PublicKey_Data;
+class X448_PrivateKey_Data;
+
 /**
  * @brief A public key for the X448 key agreement scheme according to RFC 7748.
  */
@@ -55,7 +60,7 @@ class BOTAN_PUBLIC_API(3, 4) X448_PublicKey : public virtual Public_Key {
 
    protected:
       X448_PublicKey() = default;
-      std::array<uint8_t, 56> m_public{};  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const X448_PublicKey_Data> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -89,7 +94,7 @@ class BOTAN_PUBLIC_API(3, 4) X448_PrivateKey final : public X448_PublicKey,
 
       std::vector<uint8_t> public_value() const override { return raw_public_key_bits(); }
 
-      secure_vector<uint8_t> raw_private_key_bits() const override { return {m_private.begin(), m_private.end()}; }
+      secure_vector<uint8_t> raw_private_key_bits() const override;
 
       secure_vector<uint8_t> private_key_bits() const override;
 
@@ -102,7 +107,7 @@ class BOTAN_PUBLIC_API(3, 4) X448_PrivateKey final : public X448_PublicKey,
                                                                      std::string_view provider) const override;
 
    private:
-      secure_vector<uint8_t> m_private;
+      std::shared_ptr<const X448_PrivateKey_Data> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -249,7 +249,7 @@ class Dilithium_Signature_Operation final : public PK_Ops::Signature {
 
 class Dilithium_Verification_Operation final : public PK_Ops::Verification {
    public:
-      explicit Dilithium_Verification_Operation(std::shared_ptr<Dilithium_PublicKeyInternal> pubkey) :
+      explicit Dilithium_Verification_Operation(std::shared_ptr<const Dilithium_PublicKeyInternal> pubkey) :
             m_pub_key(std::move(pubkey)),
             m_A(Dilithium_Algos::expand_A(m_pub_key->rho(), m_pub_key->mode())),
             m_t1_ntt_shifted(ntt(m_pub_key->t1() << DilithiumConstants::D)),
@@ -310,7 +310,7 @@ class Dilithium_Verification_Operation final : public PK_Ops::Verification {
       std::string hash_function() const override { return m_h->name(); }
 
    private:
-      std::shared_ptr<Dilithium_PublicKeyInternal> m_pub_key;
+      std::shared_ptr<const Dilithium_PublicKeyInternal> m_pub_key;
       DilithiumPolyMatNTT m_A;
       DilithiumPolyVecNTT m_t1_ntt_shifted;
       std::unique_ptr<DilithiumMessageHash> m_h;

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.h
@@ -103,7 +103,7 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PublicKey : public virtual Public_Key {
       friend class Dilithium_Verification_Operation;
       friend class Dilithium_Signature_Operation;
 
-      std::shared_ptr<Dilithium_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const Dilithium_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -147,7 +147,7 @@ class BOTAN_PUBLIC_API(3, 0) Dilithium_PrivateKey final : public virtual Dilithi
    private:
       friend class Dilithium_Signature_Operation;
 
-      std::shared_ptr<Dilithium_PrivateKeyInternal> m_private;
+      std::shared_ptr<const Dilithium_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium_types.h
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium_types.h
@@ -65,7 +65,7 @@ using DilithiumCommitmentHash = Strong<std::vector<uint8_t>, struct DilithiumCom
 
 /// Internal representation of a Dilithium key pair
 using DilithiumInternalKeypair =
-   std::pair<std::shared_ptr<Dilithium_PublicKeyInternal>, std::shared_ptr<Dilithium_PrivateKeyInternal>>;
+   std::pair<std::shared_ptr<const Dilithium_PublicKeyInternal>, std::shared_ptr<const Dilithium_PrivateKeyInternal>>;
 
 }  // namespace Botan
 

--- a/src/lib/pubkey/ed25519/ed25519.h
+++ b/src/lib/pubkey/ed25519/ed25519.h
@@ -10,9 +10,14 @@
 #define BOTAN_ED25519_H_
 
 #include <botan/pk_keys.h>
+#include <memory>
 #include <span>
+#include <vector>
 
 namespace Botan {
+
+class Ed25519_PublicKey_Data;
+class Ed25519_PrivateKey_Data;
 
 class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
    public:
@@ -34,9 +39,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
 
       bool supports_operation(PublicKeyOperation op) const override { return (op == PublicKeyOperation::Signature); }
 
-      BOTAN_DEPRECATED("Use raw_public_key_bits") const std::vector<uint8_t>& get_public_key() const {
-         return m_public;
-      }
+      BOTAN_DEPRECATED("Use raw_public_key_bits") const std::vector<uint8_t>& get_public_key() const;
 
       /**
       * Create a Ed25519 Public Key.
@@ -58,7 +61,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PublicKey : public virtual Public_Key {
 
    protected:
       Ed25519_PublicKey() = default;
-      std::vector<uint8_t> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const Ed25519_PublicKey_Data> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -111,11 +114,9 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PrivateKey final : public Ed25519_PublicKey
       */
       static Ed25519_PrivateKey from_bytes(std::span<const uint8_t> bytes);
 
-      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_private_key() const {
-         return m_private;
-      }
+      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_private_key() const;
 
-      secure_vector<uint8_t> raw_private_key_bits() const override { return m_private; }
+      secure_vector<uint8_t> raw_private_key_bits() const override;
 
       secure_vector<uint8_t> private_key_bits() const override;
 
@@ -128,7 +129,7 @@ class BOTAN_PUBLIC_API(2, 2) Ed25519_PrivateKey final : public Ed25519_PublicKey
                                                              std::string_view provider) const override;
 
    private:
-      secure_vector<uint8_t> m_private;
+      std::shared_ptr<const Ed25519_PrivateKey_Data> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/ed25519/ed25519_key.cpp
+++ b/src/lib/pubkey/ed25519/ed25519_key.cpp
@@ -18,12 +18,46 @@
 
 namespace Botan {
 
+class Ed25519_PublicKey_Data final {
+   public:
+      explicit Ed25519_PublicKey_Data(std::vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const std::vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      std::vector<uint8_t> m_key;
+};
+
+class Ed25519_PrivateKey_Data final {
+   public:
+      explicit Ed25519_PrivateKey_Data(secure_vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const secure_vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      secure_vector<uint8_t> m_key;
+};
+
+const std::vector<uint8_t>& Ed25519_PublicKey::get_public_key() const {
+   return m_public->key();
+}
+
+const secure_vector<uint8_t>& Ed25519_PrivateKey::get_private_key() const {
+   return m_private->key();
+}
+
+secure_vector<uint8_t> Ed25519_PrivateKey::raw_private_key_bits() const {
+   return m_private->key();
+}
+
 AlgorithmIdentifier Ed25519_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_EMPTY_PARAM);
 }
 
 bool Ed25519_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
-   if(m_public.size() != 32) {
+   const std::vector<uint8_t>& pub = m_public->key();
+
+   if(pub.size() != 32) {
       return false;
    }
 
@@ -32,7 +66,7 @@ bool Ed25519_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*
    */
 
    const uint8_t identity_element[32] = {1};
-   if(CT::is_equal(m_public.data(), identity_element, 32).as_bool()) {
+   if(CT::is_equal(pub.data(), identity_element, 32).as_bool()) {
       return false;
    }
 
@@ -45,7 +79,7 @@ bool Ed25519_PublicKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*
 
    unsigned char pkcopy[32];
 
-   copy_mem(pkcopy, m_public.data(), 32);
+   copy_mem(pkcopy, pub.data(), 32);
    pkcopy[31] ^= (1 << 7);  // flip sign
 
    return signature_check(pkcopy, modm_m, identity_element, zero);
@@ -55,7 +89,7 @@ Ed25519_PublicKey::Ed25519_PublicKey(const uint8_t pub_key[], size_t pub_len) {
    if(pub_len != 32) {
       throw Decoding_Error("Invalid length for Ed25519 key");
    }
-   m_public.assign(pub_key, pub_key + pub_len);
+   m_public = std::make_shared<const Ed25519_PublicKey_Data>(std::vector<uint8_t>(pub_key, pub_key + pub_len));
 }
 
 Ed25519_PublicKey::Ed25519_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) {
@@ -64,15 +98,15 @@ Ed25519_PublicKey::Ed25519_PublicKey(const AlgorithmIdentifier& alg_id, std::spa
       throw Decoding_Error("Unexpected parameters for Ed25519 public key");
    }
 
-   m_public.assign(key_bits.begin(), key_bits.end());
-
-   if(m_public.size() != 32) {
+   if(key_bits.size() != 32) {
       throw Decoding_Error("Invalid size for Ed25519 public key");
    }
+
+   m_public = std::make_shared<const Ed25519_PublicKey_Data>(std::vector<uint8_t>(key_bits.begin(), key_bits.end()));
 }
 
 std::vector<uint8_t> Ed25519_PublicKey::raw_public_key_bits() const {
-   return m_public;
+   return m_public->key();
 }
 
 std::vector<uint8_t> Ed25519_PublicKey::public_key_bits() const {
@@ -83,14 +117,35 @@ std::unique_ptr<Private_Key> Ed25519_PublicKey::generate_another(RandomNumberGen
    return std::make_unique<Ed25519_PrivateKey>(rng);
 }
 
+namespace {
+
+// Given the 64-byte expanded private key (32-byte private seed followed by the
+// 32-byte public key) build the immutable public and private key data objects.
+void load_ed25519_keypair(secure_vector<uint8_t> expanded_key,
+                          std::shared_ptr<const Ed25519_PublicKey_Data>& pk_out,
+                          std::shared_ptr<const Ed25519_PrivateKey_Data>& sk_out) {
+   BOTAN_ASSERT_NOMSG(expanded_key.size() == 64);
+   pk_out = std::make_shared<const Ed25519_PublicKey_Data>(
+      std::vector<uint8_t>(expanded_key.begin() + 32, expanded_key.end()));
+   sk_out = std::make_shared<const Ed25519_PrivateKey_Data>(std::move(expanded_key));
+}
+
+// Generate the 64-byte expanded private key from a 32-byte seed.
+secure_vector<uint8_t> ed25519_expand_seed(std::span<const uint8_t> seed) {
+   BOTAN_ASSERT_NOMSG(seed.size() == 32);
+   std::vector<uint8_t> pk(32);  // also written into the expanded private key
+   secure_vector<uint8_t> sk(64);
+   ed25519_gen_keypair(pk.data(), sk.data(), seed.data());
+   return sk;
+}
+
+}  // namespace
+
 Ed25519_PrivateKey::Ed25519_PrivateKey(std::span<const uint8_t> secret_key) {
    if(secret_key.size() == 64) {
-      m_private.assign(secret_key.begin(), secret_key.end());
-      m_public.assign(m_private.begin() + 32, m_private.end());
+      load_ed25519_keypair(secure_vector<uint8_t>(secret_key.begin(), secret_key.end()), m_public, m_private);
    } else if(secret_key.size() == 32) {
-      m_public.resize(32);
-      m_private.resize(64);
-      ed25519_gen_keypair(m_public.data(), m_private.data(), secret_key.data());
+      load_ed25519_keypair(ed25519_expand_seed(secret_key), m_public, m_private);
    } else {
       throw Decoding_Error("Invalid size for Ed25519 private key");
    }
@@ -110,9 +165,7 @@ Ed25519_PrivateKey Ed25519_PrivateKey::from_bytes(std::span<const uint8_t> bytes
 
 Ed25519_PrivateKey::Ed25519_PrivateKey(RandomNumberGenerator& rng) {
    const secure_vector<uint8_t> seed = rng.random_vec(32);
-   m_public.resize(32);
-   m_private.resize(64);
-   ed25519_gen_keypair(m_public.data(), m_private.data(), seed.data());
+   load_ed25519_keypair(ed25519_expand_seed(seed), m_public, m_private);
 }
 
 Ed25519_PrivateKey::Ed25519_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) {
@@ -127,26 +180,25 @@ Ed25519_PrivateKey::Ed25519_PrivateKey(const AlgorithmIdentifier& alg_id, std::s
    if(bits.size() != 32) {
       throw Decoding_Error("Invalid size for Ed25519 private key");
    }
-   m_public.resize(32);
-   m_private.resize(64);
-   ed25519_gen_keypair(m_public.data(), m_private.data(), bits.data());
+   load_ed25519_keypair(ed25519_expand_seed(bits), m_public, m_private);
 }
 
 std::unique_ptr<Public_Key> Ed25519_PrivateKey::public_key() const {
-   return std::make_unique<Ed25519_PublicKey>(get_public_key());
+   return std::make_unique<Ed25519_PublicKey>(raw_public_key_bits());
 }
 
 secure_vector<uint8_t> Ed25519_PrivateKey::private_key_bits() const {
-   const secure_vector<uint8_t> bits(m_private.data(), &m_private[32]);
+   const auto& priv = m_private->key();
+   const secure_vector<uint8_t> bits(priv.begin(), priv.begin() + 32);
    return DER_Encoder().encode(bits, ASN1_Type::OctetString).get_contents();
 }
 
 bool Ed25519_PrivateKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
    std::vector<uint8_t> public_point(32);
    secure_vector<uint8_t> private_key(64);  // discarded
-   ed25519_gen_keypair(public_point.data(), private_key.data(), m_private.data());
+   ed25519_gen_keypair(public_point.data(), private_key.data(), m_private->key().data());
    // Variable time comparison is fine here
-   return public_point == m_public;
+   return public_point == m_public->key();
 }
 
 namespace {
@@ -156,7 +208,8 @@ namespace {
 */
 class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
    public:
-      explicit Ed25519_Pure_Verify_Operation(const Ed25519_PublicKey& key) : m_key(key.get_public_key()) {}
+      explicit Ed25519_Pure_Verify_Operation(std::shared_ptr<const Ed25519_PublicKey_Data> key) :
+            m_key(std::move(key)) {}
 
       void update(std::span<const uint8_t> msg) override { m_msg.insert(m_msg.end(), msg.begin(), msg.end()); }
 
@@ -166,8 +219,9 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
             return false;
          }
 
-         BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
-         const bool ok = ed25519_verify(m_msg.data(), m_msg.size(), sig.data(), m_key.data(), nullptr, 0);
+         const auto& key = m_key->key();
+         BOTAN_ASSERT_EQUAL(key.size(), 32, "Expected size");
+         const bool ok = ed25519_verify(m_msg.data(), m_msg.size(), sig.data(), key.data(), nullptr, 0);
          m_msg.clear();
          return ok;
       }
@@ -176,7 +230,7 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 
    private:
       std::vector<uint8_t> m_msg;
-      std::vector<uint8_t> m_key;
+      std::shared_ptr<const Ed25519_PublicKey_Data> m_key;
 };
 
 /**
@@ -184,8 +238,10 @@ class Ed25519_Pure_Verify_Operation final : public PK_Ops::Verification {
 */
 class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_Hash {
    public:
-      Ed25519_Hashed_Verify_Operation(const Ed25519_PublicKey& key, std::string_view hash, bool rfc8032) :
-            PK_Ops::Verification_with_Hash(hash), m_key(key.get_public_key()) {
+      Ed25519_Hashed_Verify_Operation(std::shared_ptr<const Ed25519_PublicKey_Data> key,
+                                      std::string_view hash,
+                                      bool rfc8032) :
+            PK_Ops::Verification_with_Hash(hash), m_key(std::move(key)) {
          if(rfc8032) {
             m_domain_sep = {0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                             0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -198,13 +254,13 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_H
             return false;
          }
 
-         BOTAN_ASSERT_EQUAL(m_key.size(), 32, "Expected size");
-         return ed25519_verify(
-            ph.data(), ph.size(), sig.data(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+         const auto& key = m_key->key();
+         BOTAN_ASSERT_EQUAL(key.size(), 32, "Expected size");
+         return ed25519_verify(ph.data(), ph.size(), sig.data(), key.data(), m_domain_sep.data(), m_domain_sep.size());
       }
 
    private:
-      std::vector<uint8_t> m_key;
+      std::shared_ptr<const Ed25519_PublicKey_Data> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
 
@@ -213,13 +269,15 @@ class Ed25519_Hashed_Verify_Operation final : public PK_Ops::Verification_with_H
 */
 class Ed25519_Pure_Sign_Operation final : public PK_Ops::Signature {
    public:
-      explicit Ed25519_Pure_Sign_Operation(const Ed25519_PrivateKey& key) : m_key(key.raw_private_key_bits()) {}
+      explicit Ed25519_Pure_Sign_Operation(std::shared_ptr<const Ed25519_PrivateKey_Data> key) :
+            m_key(std::move(key)) {}
 
       void update(std::span<const uint8_t> msg) override { m_msg.insert(m_msg.end(), msg.begin(), msg.end()); }
 
       std::vector<uint8_t> sign(RandomNumberGenerator& /*rng*/) override {
          std::vector<uint8_t> sig(64);
-         ed25519_sign(sig.data(), m_msg.data(), m_msg.size(), m_key.data(), nullptr, 0);
+         const auto& key = m_key->key();
+         ed25519_sign(sig.data(), m_msg.data(), m_msg.size(), key.data(), nullptr, 0);
          m_msg.clear();
          return sig;
       }
@@ -232,7 +290,7 @@ class Ed25519_Pure_Sign_Operation final : public PK_Ops::Signature {
 
    private:
       std::vector<uint8_t> m_msg;
-      secure_vector<uint8_t> m_key;
+      std::shared_ptr<const Ed25519_PrivateKey_Data> m_key;
 };
 
 AlgorithmIdentifier Ed25519_Pure_Sign_Operation::algorithm_identifier() const {
@@ -244,8 +302,10 @@ AlgorithmIdentifier Ed25519_Pure_Sign_Operation::algorithm_identifier() const {
 */
 class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
    public:
-      Ed25519_Hashed_Sign_Operation(const Ed25519_PrivateKey& key, std::string_view hash, bool rfc8032) :
-            PK_Ops::Signature_with_Hash(hash), m_key(key.raw_private_key_bits()) {
+      Ed25519_Hashed_Sign_Operation(std::shared_ptr<const Ed25519_PrivateKey_Data> key,
+                                    std::string_view hash,
+                                    bool rfc8032) :
+            PK_Ops::Signature_with_Hash(hash), m_key(std::move(key)) {
          if(rfc8032) {
             m_domain_sep = std::vector<uint8_t>{0x53, 0x69, 0x67, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x6E,
                                                 0x6F, 0x20, 0x45, 0x64, 0x32, 0x35, 0x35, 0x31, 0x39, 0x20, 0x63, 0x6F,
@@ -257,12 +317,13 @@ class Ed25519_Hashed_Sign_Operation final : public PK_Ops::Signature_with_Hash {
 
       std::vector<uint8_t> raw_sign(std::span<const uint8_t> ph, RandomNumberGenerator& /*rng*/) override {
          std::vector<uint8_t> sig(64);
-         ed25519_sign(sig.data(), ph.data(), ph.size(), m_key.data(), m_domain_sep.data(), m_domain_sep.size());
+         const auto& key = m_key->key();
+         ed25519_sign(sig.data(), ph.data(), ph.size(), key.data(), m_domain_sep.data(), m_domain_sep.size());
          return sig;
       }
 
    private:
-      secure_vector<uint8_t> m_key;
+      std::shared_ptr<const Ed25519_PrivateKey_Data> m_key;
       std::vector<uint8_t> m_domain_sep;
 };
 
@@ -272,11 +333,11 @@ std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_verification_op(
                                                                                 std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
       if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Verify_Operation>(*this);
+         return std::make_unique<Ed25519_Pure_Verify_Operation>(m_public);
       } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, "SHA-512", true);
+         return std::make_unique<Ed25519_Hashed_Verify_Operation>(m_public, "SHA-512", true);
       } else {
-         return std::make_unique<Ed25519_Hashed_Verify_Operation>(*this, params, false);
+         return std::make_unique<Ed25519_Hashed_Verify_Operation>(m_public, params, false);
       }
    }
    throw Provider_Not_Found(algo_name(), provider);
@@ -289,7 +350,7 @@ std::unique_ptr<PK_Ops::Verification> Ed25519_PublicKey::create_x509_verificatio
          throw Decoding_Error("Unexpected AlgorithmIdentifier for Ed25519 X509 signature");
       }
 
-      return std::make_unique<Ed25519_Pure_Verify_Operation>(*this);
+      return std::make_unique<Ed25519_Pure_Verify_Operation>(m_public);
    }
    throw Provider_Not_Found(algo_name(), provider);
 }
@@ -299,11 +360,11 @@ std::unique_ptr<PK_Ops::Signature> Ed25519_PrivateKey::create_signature_op(Rando
                                                                            std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
       if(params.empty() || params == "Identity" || params == "Pure") {
-         return std::make_unique<Ed25519_Pure_Sign_Operation>(*this);
+         return std::make_unique<Ed25519_Pure_Sign_Operation>(m_private);
       } else if(params == "Ed25519ph") {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, "SHA-512", true);
+         return std::make_unique<Ed25519_Hashed_Sign_Operation>(m_private, "SHA-512", true);
       } else {
-         return std::make_unique<Ed25519_Hashed_Sign_Operation>(*this, params, false);
+         return std::make_unique<Ed25519_Hashed_Sign_Operation>(m_private, params, false);
       }
    }
    throw Provider_Not_Found(algo_name(), provider);

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.cpp
@@ -83,7 +83,7 @@ namespace {
 
 class Frodo_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      Frodo_KEM_Encryptor(std::shared_ptr<FrodoKEM_PublicKeyInternal> key, std::string_view kdf) :
+      Frodo_KEM_Encryptor(std::shared_ptr<const FrodoKEM_PublicKeyInternal> key, std::string_view kdf) :
             KEM_Encryption_with_KDF(kdf), m_public_key(std::move(key)) {}
 
       size_t raw_kem_shared_key_length() const override { return m_public_key->constants().len_sec_bytes(); }
@@ -147,13 +147,13 @@ class Frodo_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
       }
 
    private:
-      std::shared_ptr<FrodoKEM_PublicKeyInternal> m_public_key;
+      std::shared_ptr<const FrodoKEM_PublicKeyInternal> m_public_key;
 };
 
 class Frodo_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF {
    public:
-      Frodo_KEM_Decryptor(std::shared_ptr<FrodoKEM_PublicKeyInternal> public_key,
-                          std::shared_ptr<FrodoKEM_PrivateKeyInternal> private_key,
+      Frodo_KEM_Decryptor(std::shared_ptr<const FrodoKEM_PublicKeyInternal> public_key,
+                          std::shared_ptr<const FrodoKEM_PrivateKeyInternal> private_key,
                           std::string_view kdf) :
             KEM_Decryption_with_KDF(kdf), m_public_key(std::move(public_key)), m_private_key(std::move(private_key)) {}
 
@@ -232,8 +232,8 @@ class Frodo_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF {
       }
 
    private:
-      std::shared_ptr<FrodoKEM_PublicKeyInternal> m_public_key;
-      std::shared_ptr<FrodoKEM_PrivateKeyInternal> m_private_key;
+      std::shared_ptr<const FrodoKEM_PublicKeyInternal> m_public_key;
+      std::shared_ptr<const FrodoKEM_PrivateKeyInternal> m_private_key;
 };
 
 }  // namespace

--- a/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodokem.h
@@ -72,7 +72,7 @@ class BOTAN_PUBLIC_API(3, 3) FrodoKEM_PublicKey : public virtual Public_Key {
       FrodoKEM_PublicKey() = default;
 
    protected:
-      std::shared_ptr<FrodoKEM_PublicKeyInternal> m_public;  // NOLINT(*-non-private-member-variable*)
+      std::shared_ptr<const FrodoKEM_PublicKeyInternal> m_public;  // NOLINT(*-non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -100,7 +100,7 @@ class BOTAN_PUBLIC_API(3, 3) FrodoKEM_PrivateKey final : public virtual FrodoKEM
                                                                        std::string_view provider) const override;
 
    private:
-      std::shared_ptr<FrodoKEM_PrivateKeyInternal> m_private;
+      std::shared_ptr<const FrodoKEM_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/hss_lms/hss.cpp
+++ b/src/lib/pubkey/hss_lms/hss.cpp
@@ -236,7 +236,7 @@ HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::remaining_operations() const {
    return HSS_Sig_Idx(Stateful_Key_Index_Registry::global().remaining_operations(m_keyid));
 }
 
-void HSS_LMS_PrivateKeyInternal::set_idx(HSS_Sig_Idx idx) {
+void HSS_LMS_PrivateKeyInternal::set_idx(HSS_Sig_Idx idx) const {
    // An index equal to max_sig_count is valid and denotes an exhausted key
    if(idx > m_hss_params.max_sig_count()) {
       throw Decoding_Error("HSS-LMS private key index out of bounds");
@@ -244,7 +244,7 @@ void HSS_LMS_PrivateKeyInternal::set_idx(HSS_Sig_Idx idx) {
    Stateful_Key_Index_Registry::global().set_index_lower_bound(m_keyid, idx.get());
 }
 
-HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::reserve_next_idx() {
+HSS_Sig_Idx HSS_LMS_PrivateKeyInternal::reserve_next_idx() const {
    const auto idx = Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid);
    if(!idx.has_value()) {
       throw Invalid_State("HSS private key is exhausted");
@@ -260,7 +260,7 @@ size_t HSS_LMS_PrivateKeyInternal::size() const {
    return sk_size;
 }
 
-std::vector<uint8_t> HSS_LMS_PrivateKeyInternal::sign(std::span<const uint8_t> msg) {
+std::vector<uint8_t> HSS_LMS_PrivateKeyInternal::sign(std::span<const uint8_t> msg) const {
    std::vector<uint8_t> sig(HSS_Signature::size(hss_params()));
    BufferStuffer sig_stuffer(sig);
    sig_stuffer.append(store_be(hss_params().L() - 1));

--- a/src/lib/pubkey/hss_lms/hss.h
+++ b/src/lib/pubkey/hss_lms/hss.h
@@ -165,8 +165,12 @@ class HSS_LMS_PrivateKeyInternal final {
        * The index must be lower than or equal to hss_params().max_sig_count(),
        * with an index == max indicating the key is completely exhausted.
        * The index will never go backward (highest value wins).
+       *
+       * The signing state lives in the process-wide
+       * Stateful_Key_Index_Registry keyed by the key identity, not in this
+       * object, so this leaves *this unchanged and is therefore const.
        */
-      void set_idx(HSS_Sig_Idx idx);
+      void set_idx(HSS_Sig_Idx idx) const;
 
       /**
        * @brief Create a HSS-LMS signature.
@@ -180,7 +184,7 @@ class HSS_LMS_PrivateKeyInternal final {
        *
        * @param msg The message to sign.
        */
-      std::vector<uint8_t> sign(std::span<const uint8_t> msg);
+      std::vector<uint8_t> sign(std::span<const uint8_t> msg) const;
 
       /**
        * @brief Create the HSS root LMS tree's LMS_PrivateKey using the HSS-LMS private key.
@@ -208,7 +212,7 @@ class HSS_LMS_PrivateKeyInternal final {
        * @brief Get the index of the next signature to generate and
        *        increase the counter by one.
        */
-      HSS_Sig_Idx reserve_next_idx();
+      HSS_Sig_Idx reserve_next_idx() const;
 
       /**
        * @brief Returns the size in bytes the key would have in its encoded format.

--- a/src/lib/pubkey/hss_lms/hss_lms.cpp
+++ b/src/lib/pubkey/hss_lms/hss_lms.cpp
@@ -73,7 +73,7 @@ namespace {
 
 class HSS_LMS_Verification_Operation final : public PK_Ops::Verification {
    public:
-      explicit HSS_LMS_Verification_Operation(std::shared_ptr<HSS_LMS_PublicKeyInternal> pub_key) :
+      explicit HSS_LMS_Verification_Operation(std::shared_ptr<const HSS_LMS_PublicKeyInternal> pub_key) :
             m_public(std::move(pub_key)) {}
 
       void update(std::span<const uint8_t> msg) override {
@@ -94,7 +94,7 @@ class HSS_LMS_Verification_Operation final : public PK_Ops::Verification {
       std::string hash_function() const override { return m_public->lms_pub_key().lms_params().hash_name(); }
 
    private:
-      std::shared_ptr<HSS_LMS_PublicKeyInternal> m_public;
+      std::shared_ptr<const HSS_LMS_PublicKeyInternal> m_public;
       std::vector<uint8_t> m_msg_buffer;
 };
 
@@ -195,8 +195,8 @@ namespace {
 
 class HSS_LMS_Signature_Operation final : public PK_Ops::Signature {
    public:
-      HSS_LMS_Signature_Operation(std::shared_ptr<HSS_LMS_PrivateKeyInternal> private_key,
-                                  std::shared_ptr<HSS_LMS_PublicKeyInternal> public_key) :
+      HSS_LMS_Signature_Operation(std::shared_ptr<const HSS_LMS_PrivateKeyInternal> private_key,
+                                  std::shared_ptr<const HSS_LMS_PublicKeyInternal> public_key) :
             m_private(std::move(private_key)), m_public(std::move(public_key)) {}
 
       void update(std::span<const uint8_t> msg) override {
@@ -216,8 +216,8 @@ class HSS_LMS_Signature_Operation final : public PK_Ops::Signature {
       std::string hash_function() const override { return m_public->lms_pub_key().lms_params().hash_name(); }
 
    private:
-      std::shared_ptr<HSS_LMS_PrivateKeyInternal> m_private;
-      std::shared_ptr<HSS_LMS_PublicKeyInternal> m_public;
+      std::shared_ptr<const HSS_LMS_PrivateKeyInternal> m_private;
+      std::shared_ptr<const HSS_LMS_PublicKeyInternal> m_public;
       std::vector<uint8_t> m_msg_buffer;
 };
 

--- a/src/lib/pubkey/hss_lms/hss_lms.h
+++ b/src/lib/pubkey/hss_lms/hss_lms.h
@@ -77,7 +77,7 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PublicKey : public virtual Public_Key {
    protected:
       HSS_LMS_PublicKey() = default;
 
-      std::shared_ptr<HSS_LMS_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const HSS_LMS_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -173,7 +173,7 @@ class BOTAN_PUBLIC_API(3, 5) HSS_LMS_PrivateKey final : public virtual HSS_LMS_P
    private:
       explicit HSS_LMS_PrivateKey(std::shared_ptr<HSS_LMS_PrivateKeyInternal> sk);
 
-      std::shared_ptr<HSS_LMS_PrivateKeyInternal> m_private;
+      std::shared_ptr<const HSS_LMS_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.cpp
@@ -111,10 +111,12 @@ std::unique_ptr<Public_Key> maybe_get_public_key(const std::unique_ptr<Private_K
 
 class KEX_to_KEM_Adapter_Encryption_Operation final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      KEX_to_KEM_Adapter_Encryption_Operation(const Public_Key& key, std::string_view kdf, std::string_view provider) :
-            PK_Ops::KEM_Encryption_with_KDF(kdf), m_provider(provider), m_public_key(key) {}
+      KEX_to_KEM_Adapter_Encryption_Operation(std::shared_ptr<const Public_Key> key,
+                                              std::string_view kdf,
+                                              std::string_view provider) :
+            PK_Ops::KEM_Encryption_with_KDF(kdf), m_provider(provider), m_public_key(std::move(key)) {}
 
-      size_t raw_kem_shared_key_length() const override { return kex_shared_key_length(m_public_key); }
+      size_t raw_kem_shared_key_length() const override { return kex_shared_key_length(*m_public_key); }
 
       size_t encapsulated_key_length() const override {
          // Serializing the public value into a short-lived heap-allocated
@@ -122,15 +124,15 @@ class KEX_to_KEM_Adapter_Encryption_Operation final : public PK_Ops::KEM_Encrypt
          //
          // TODO: Find a way to get the public value length without copying
          //       the public value into a vector. See GH #3706 (point 5).
-         return m_public_key.raw_public_key_bits().size();
+         return m_public_key->raw_public_key_bits().size();
       }
 
       void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                            std::span<uint8_t> raw_shared_key,
                            Botan::RandomNumberGenerator& rng) override {
-         const auto sk = generate_key_agreement_private_key(m_public_key, rng);
+         const auto sk = generate_key_agreement_private_key(*m_public_key, rng);
          const auto shared_key = PK_Key_Agreement(*sk, rng, "Raw", m_provider)
-                                    .derive_key(0 /* no KDF */, m_public_key.raw_public_key_bits())
+                                    .derive_key(0 /* no KDF */, m_public_key->raw_public_key_bits())
                                     .bits_of();
 
          const auto public_value = sk->public_value();
@@ -149,7 +151,7 @@ class KEX_to_KEM_Adapter_Encryption_Operation final : public PK_Ops::KEM_Encrypt
 
    private:
       std::string m_provider;
-      const Public_Key& m_public_key;
+      std::shared_ptr<const Public_Key> m_public_key;
 };
 
 class KEX_to_KEM_Decryption_Operation final : public PK_Ops::KEM_Decryption_with_KDF {
@@ -259,7 +261,7 @@ bool KEX_to_KEM_Adapter_PrivateKey::check_key(RandomNumberGenerator& rng, bool s
 
 std::unique_ptr<PK_Ops::KEM_Encryption> KEX_to_KEM_Adapter_PublicKey::create_kem_encryption_op(
    std::string_view kdf, std::string_view provider) const {
-   return std::make_unique<KEX_to_KEM_Adapter_Encryption_Operation>(*m_public_key, kdf, provider);
+   return std::make_unique<KEX_to_KEM_Adapter_Encryption_Operation>(m_public_key, kdf, provider);
 }
 
 std::unique_ptr<PK_Ops::KEM_Decryption> KEX_to_KEM_Adapter_PrivateKey::create_kem_decryption_op(

--- a/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
+++ b/src/lib/pubkey/kex_to_kem_adapter/kex_to_kem_adapter.h
@@ -40,7 +40,7 @@ class BOTAN_TEST_API KEX_to_KEM_Adapter_PublicKey : public virtual Public_Key {
          std::string_view kdf, std::string_view provider = "base") const override;
 
    private:
-      std::unique_ptr<Public_Key> m_public_key;
+      std::shared_ptr<const Public_Key> m_public_key;
 };
 
 BOTAN_DIAGNOSTIC_PUSH

--- a/src/lib/pubkey/kyber/kyber_common/kyber.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.h
@@ -141,7 +141,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PublicKey : public virtual Public_Key {
       friend class Kyber_KEM_Encryptor;
       friend class Kyber_KEM_Decryptor;
 
-      std::shared_ptr<Kyber_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const Kyber_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -209,7 +209,7 @@ class BOTAN_PUBLIC_API(3, 0) Kyber_PrivateKey final : public virtual Kyber_Publi
    private:
       friend class Kyber_KEM_Decryptor;
 
-      std::shared_ptr<Kyber_PrivateKeyInternal> m_private;
+      std::shared_ptr<const Kyber_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_algos.cpp
@@ -341,6 +341,11 @@ KyberInternalKeypair expand_keypair(KyberPrivateKeySeed seed, KyberConstants mod
    t += e;
    t.reduce();
 
+   // Bring s into canonical [0,Q) form (as ByteEncode_12 requires), matching
+   // the representation produced when decoding a private key. This lets the
+   // secret key be serialized directly, without reducing a copy at encode time.
+   s.reduce();
+
    // End Algorithm 13 ---------------------------
 
    CT::unpoison_all(d, t, s);

--- a/src/lib/pubkey/kyber/kyber_common/kyber_keys.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_keys.cpp
@@ -76,7 +76,7 @@ secure_vector<uint8_t> Expanded_Keypair_Codec::encode_keypair(KyberInternalKeypa
    BOTAN_ASSERT_NONNULL(keypair.second);
    const auto& mode = keypair.first->mode();
    auto scope = CT::scoped_poison(*keypair.second);
-   auto result = concat(Kyber_Algos::encode_polynomial_vector(keypair.second->s().reduce(), mode),
+   auto result = concat(Kyber_Algos::encode_polynomial_vector(keypair.second->s(), mode),
                         keypair.first->public_key_bits_raw(),
                         keypair.first->H_public_key_bits_raw(),
                         keypair.second->z());

--- a/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_keys.h
@@ -87,8 +87,6 @@ class Kyber_PrivateKeyInternal final {
 
       KyberMessage indcpa_decrypt(StrongSpan<const KyberCompressedCiphertext> ct) const;
 
-      KyberPolyVecNTT& s() { return m_s; }
-
       const KyberPolyVecNTT& s() const { return m_s; }
 
       const KyberPrivateKeySeed& seed() const { return m_seed; }

--- a/src/lib/pubkey/kyber/kyber_common/kyber_types.h
+++ b/src/lib/pubkey/kyber/kyber_common/kyber_types.h
@@ -71,7 +71,7 @@ using KyberSigmaOrEncryptionRandomness =
    std::variant<StrongSpan<const KyberSeedSigma>, StrongSpan<const KyberEncryptionRandomness>>;
 
 using KyberInternalKeypair =
-   std::pair<std::shared_ptr<Kyber_PublicKeyInternal>, std::shared_ptr<Kyber_PrivateKeyInternal>>;
+   std::pair<std::shared_ptr<const Kyber_PublicKeyInternal>, std::shared_ptr<const Kyber_PrivateKeyInternal>>;
 
 /// NIST FIPS 203, Section 3
 ///   The seed (𝑑,𝑧) generated in steps 1 and 2 of ML-KEM.KeyGen can be stored

--- a/src/lib/pubkey/mce/goppa_code.cpp
+++ b/src/lib/pubkey/mce/goppa_code.cpp
@@ -115,7 +115,7 @@ secure_vector<gf2m> goppa_decode(const polyn_gf2m& syndrome_polyn,
 void mceliece_decrypt(secure_vector<uint8_t>& plaintext_out,
                       secure_vector<uint8_t>& error_mask_out,
                       const secure_vector<uint8_t>& ciphertext,
-                      const McEliece_PrivateKey& key) {
+                      const McEliece_PrivateKeyInternal& key) {
    mceliece_decrypt(plaintext_out, error_mask_out, ciphertext.data(), ciphertext.size(), key);
 }
 
@@ -123,11 +123,11 @@ void mceliece_decrypt(secure_vector<uint8_t>& plaintext,
                       secure_vector<uint8_t>& error_mask,
                       const uint8_t ciphertext[],
                       size_t ciphertext_len,
-                      const McEliece_PrivateKey& key) {
+                      const McEliece_PrivateKeyInternal& key) {
    secure_vector<gf2m> error_pos;
    plaintext = mceliece_decrypt(error_pos, ciphertext, ciphertext_len, key);
 
-   const size_t code_length = key.get_code_length();
+   const size_t code_length = key.code_length();
    secure_vector<uint8_t> result((code_length + 7) / 8);
    for(auto&& pos : error_pos) {
       if(pos > code_length) {
@@ -146,26 +146,26 @@ void mceliece_decrypt(secure_vector<uint8_t>& plaintext,
 secure_vector<uint8_t> mceliece_decrypt(secure_vector<gf2m>& error_pos,
                                         const uint8_t* ciphertext,
                                         size_t ciphertext_len,
-                                        const McEliece_PrivateKey& key) {
-   const size_t dimension = key.get_dimension();
-   const size_t codimension = key.get_codimension();
-   const uint32_t t = key.get_goppa_polyn().get_degree();
-   polyn_gf2m syndrome_polyn(key.get_goppa_polyn().get_sp_field());  // init as zero polyn
+                                        const McEliece_PrivateKeyInternal& key) {
+   const size_t dimension = key.dimension();
+   const size_t codimension = key.codimension();
+   const uint32_t t = key.goppa_polyn().get_degree();
+   polyn_gf2m syndrome_polyn(key.goppa_polyn().get_sp_field());  // init as zero polyn
    const unsigned unused_pt_bits = dimension % 8;
    const uint8_t unused_pt_bits_mask = (1 << unused_pt_bits) - 1;
 
-   if(ciphertext_len != (key.get_code_length() + 7) / 8) {
+   if(ciphertext_len != (key.code_length() + 7) / 8) {
       throw Invalid_Argument("wrong size of McEliece ciphertext");
    }
-   const size_t cleartext_len = (key.get_message_word_bit_length() + 7) / 8;
+   const size_t cleartext_len = (key.message_word_bit_length() + 7) / 8;
 
    if(cleartext_len != bit_size_to_byte_size(dimension)) {
       throw Invalid_Argument("mce-decryption: wrong length of cleartext buffer");
    }
 
    secure_vector<uint32_t> syndrome_vec(bit_size_to_32bit_size(codimension));
-   matrix_arr_mul(key.get_H_coeffs(),
-                  key.get_code_length(),
+   matrix_arr_mul(key.H_coeffs(),
+                  key.code_length(),
                   bit_size_to_32bit_size(codimension),
                   ciphertext,
                   syndrome_vec.data(),
@@ -177,11 +177,11 @@ secure_vector<uint8_t> mceliece_decrypt(secure_vector<gf2m>& error_pos,
       syndrome_byte_vec[i] = static_cast<uint8_t>(syndrome_vec[i / 4] >> (8 * (i % 4)));
    }
 
-   syndrome_polyn = polyn_gf2m(
-      t - 1, syndrome_byte_vec.data(), bit_size_to_byte_size(codimension), key.get_goppa_polyn().get_sp_field());
+   syndrome_polyn =
+      polyn_gf2m(t - 1, syndrome_byte_vec.data(), bit_size_to_byte_size(codimension), key.goppa_polyn().get_sp_field());
 
    syndrome_polyn.get_degree();
-   error_pos = goppa_decode(syndrome_polyn, key.get_goppa_polyn(), key.get_sqrtmod(), key.get_Linv());
+   error_pos = goppa_decode(syndrome_polyn, key.goppa_polyn(), key.sqrtmod(), key.Linv());
 
    const size_t nb_err = error_pos.size();
 

--- a/src/lib/pubkey/mce/mce_internal.h
+++ b/src/lib/pubkey/mce/mce_internal.h
@@ -18,26 +18,89 @@
 
 namespace Botan {
 
+class McEliece_PublicKeyInternal final {
+   public:
+      McEliece_PublicKeyInternal(std::vector<uint8_t> public_matrix, size_t t, size_t code_length) :
+            m_public_matrix(std::move(public_matrix)), m_t(t), m_code_length(code_length) {}
+
+      const std::vector<uint8_t>& public_matrix() const { return m_public_matrix; }
+
+      size_t t() const { return m_t; }
+
+      size_t code_length() const { return m_code_length; }
+
+      size_t message_word_bit_length() const;
+
+      secure_vector<uint8_t> random_plaintext_element(RandomNumberGenerator& rng) const;
+
+   private:
+      std::vector<uint8_t> m_public_matrix;
+      size_t m_t;
+      size_t m_code_length;
+};
+
+class McEliece_PrivateKeyInternal final {
+   public:
+      McEliece_PrivateKeyInternal(std::vector<polyn_gf2m> g,
+                                  std::vector<polyn_gf2m> sqrtmod,
+                                  std::vector<gf2m> support_inverse,
+                                  std::vector<uint32_t> parity_check_coeffs,
+                                  size_t codimension,
+                                  size_t dimension) :
+            m_g(std::move(g)),
+            m_sqrtmod(std::move(sqrtmod)),
+            m_Linv(std::move(support_inverse)),
+            m_coeffs(std::move(parity_check_coeffs)),
+            m_codimension(codimension),
+            m_dimension(dimension) {}
+
+      const polyn_gf2m& goppa_polyn() const { return m_g[0]; }
+
+      const std::vector<polyn_gf2m>& goppa_polyn_vec() const { return m_g; }
+
+      const std::vector<polyn_gf2m>& sqrtmod() const { return m_sqrtmod; }
+
+      const std::vector<gf2m>& Linv() const { return m_Linv; }
+
+      const std::vector<uint32_t>& H_coeffs() const { return m_coeffs; }
+
+      size_t codimension() const { return m_codimension; }
+
+      size_t dimension() const { return m_dimension; }
+
+      size_t code_length() const { return m_dimension + m_codimension; }
+
+      size_t message_word_bit_length() const { return m_dimension; }
+
+   private:
+      std::vector<polyn_gf2m> m_g;  // single element
+      std::vector<polyn_gf2m> m_sqrtmod;
+      std::vector<gf2m> m_Linv;
+      std::vector<uint32_t> m_coeffs;
+      size_t m_codimension;
+      size_t m_dimension;
+};
+
 void mceliece_decrypt(secure_vector<uint8_t>& plaintext_out,
                       secure_vector<uint8_t>& error_mask_out,
                       const uint8_t ciphertext[],
                       size_t ciphertext_len,
-                      const McEliece_PrivateKey& key);
+                      const McEliece_PrivateKeyInternal& key);
 
 void mceliece_decrypt(secure_vector<uint8_t>& plaintext_out,
                       secure_vector<uint8_t>& error_mask_out,
                       const secure_vector<uint8_t>& ciphertext,
-                      const McEliece_PrivateKey& key);
+                      const McEliece_PrivateKeyInternal& key);
 
 secure_vector<uint8_t> mceliece_decrypt(secure_vector<gf2m>& error_pos,
                                         const uint8_t* ciphertext,
                                         size_t ciphertext_len,
-                                        const McEliece_PrivateKey& key);
+                                        const McEliece_PrivateKeyInternal& key);
 
 void mceliece_encrypt(secure_vector<uint8_t>& ciphertext_out,
                       secure_vector<uint8_t>& error_mask_out,
                       const secure_vector<uint8_t>& plaintext,
-                      const McEliece_PublicKey& key,
+                      const McEliece_PublicKeyInternal& key,
                       RandomNumberGenerator& rng);
 
 McEliece_PrivateKey generate_mceliece_key(RandomNumberGenerator& rng, size_t ext_deg, size_t code_length, size_t t);

--- a/src/lib/pubkey/mce/mceliece.cpp
+++ b/src/lib/pubkey/mce/mceliece.cpp
@@ -109,14 +109,13 @@ secure_vector<uint8_t> create_random_error_vector(size_t code_length, size_t err
 void mceliece_encrypt(secure_vector<uint8_t>& ciphertext_out,
                       secure_vector<uint8_t>& error_mask_out,
                       const secure_vector<uint8_t>& plaintext,
-                      const McEliece_PublicKey& key,
+                      const McEliece_PublicKeyInternal& key,
                       RandomNumberGenerator& rng) {
-   const uint16_t code_length = static_cast<uint16_t>(key.get_code_length());
+   const uint16_t code_length = static_cast<uint16_t>(key.code_length());
 
-   secure_vector<uint8_t> error_mask = create_random_error_vector(code_length, key.get_t(), rng);
+   secure_vector<uint8_t> error_mask = create_random_error_vector(code_length, key.t(), rng);
 
-   secure_vector<uint8_t> ciphertext =
-      mult_by_pubkey(plaintext, key.get_public_matrix(), key.get_code_length(), key.get_t());
+   secure_vector<uint8_t> ciphertext = mult_by_pubkey(plaintext, key.public_matrix(), key.code_length(), key.t());
 
    ciphertext ^= error_mask;
 

--- a/src/lib/pubkey/mce/mceliece.h
+++ b/src/lib/pubkey/mce/mceliece.h
@@ -14,6 +14,8 @@
 
 #include <botan/pk_keys.h>
 
+#include <memory>
+
 BOTAN_DEPRECATED_HEADER("mceliece.h")
 
 namespace Botan {
@@ -21,6 +23,8 @@ namespace Botan {
 typedef uint16_t gf2m;
 
 class polyn_gf2m;
+class McEliece_PublicKeyInternal;
+class McEliece_PrivateKeyInternal;
 
 class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key /* NOLINT(*-special-member-functions) */ {
    public:
@@ -29,8 +33,7 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key /* N
       BOTAN_DEPRECATED("Use the constructor taking an AlgorithmIdentifier")
       explicit McEliece_PublicKey(std::span<const uint8_t> key_bits);
 
-      McEliece_PublicKey(const std::vector<uint8_t>& pub_matrix, size_t t, size_t the_code_length) :
-            m_public_matrix(pub_matrix), m_t(t), m_code_length(the_code_length) {}
+      McEliece_PublicKey(const std::vector<uint8_t>& pub_matrix, size_t t, size_t the_code_length);
 
       McEliece_PublicKey(const McEliece_PublicKey& other) = default;
       McEliece_PublicKey& operator=(const McEliece_PublicKey& other) = default;
@@ -50,13 +53,13 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key /* N
 
       bool check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const override { return true; }
 
-      size_t get_t() const { return m_t; }
+      size_t get_t() const;
 
-      size_t get_code_length() const { return m_code_length; }
+      size_t get_code_length() const;
 
       size_t get_message_word_bit_length() const;
 
-      const std::vector<uint8_t>& get_public_matrix() const { return m_public_matrix; }
+      const std::vector<uint8_t>& get_public_matrix() const;
 
       bool operator==(const McEliece_PublicKey& other) const;
 
@@ -72,11 +75,9 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PublicKey : public virtual Public_Key /* N
                                                                        std::string_view provider) const override;
 
    protected:
-      McEliece_PublicKey() : m_t(0), m_code_length(0) {}
+      McEliece_PublicKey() = default;
 
-      std::vector<uint8_t> m_public_matrix;  // NOLINT(*non-private-member-variable*)
-      size_t m_t;                            // NOLINT(*non-private-member-variable*)
-      size_t m_code_length;                  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const McEliece_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -122,15 +123,15 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PrivateKey final : public virtual McEliece
 
       const polyn_gf2m& get_goppa_polyn() const;
 
-      const std::vector<uint32_t>& get_H_coeffs() const { return m_coeffs; }
+      const std::vector<uint32_t>& get_H_coeffs() const;
 
-      const std::vector<gf2m>& get_Linv() const { return m_Linv; }
+      const std::vector<gf2m>& get_Linv() const;
 
-      const std::vector<polyn_gf2m>& get_sqrtmod() const { return m_sqrtmod; }
+      const std::vector<polyn_gf2m>& get_sqrtmod() const;
 
-      inline size_t get_dimension() const { return m_dimension; }
+      size_t get_dimension() const;
 
-      inline size_t get_codimension() const { return m_codimension; }
+      size_t get_codimension() const;
 
       secure_vector<uint8_t> private_key_bits() const override;
 
@@ -145,13 +146,7 @@ class BOTAN_PUBLIC_API(2, 0) McEliece_PrivateKey final : public virtual McEliece
                                                                        std::string_view provider) const override;
 
    private:
-      std::vector<polyn_gf2m> m_g;  // single element
-      std::vector<polyn_gf2m> m_sqrtmod;
-      std::vector<gf2m> m_Linv;
-      std::vector<uint32_t> m_coeffs;
-
-      size_t m_codimension;
-      size_t m_dimension;
+      std::shared_ptr<const McEliece_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/mce/mceliece_key.cpp
+++ b/src/lib/pubkey/mce/mceliece_key.cpp
@@ -36,13 +36,16 @@ McEliece_PrivateKey::McEliece_PrivateKey(const polyn_gf2m& goppa_polyn,
                                          const std::vector<polyn_gf2m>& square_root_matrix,
                                          const std::vector<gf2m>& inverse_support,
                                          const std::vector<uint8_t>& public_matrix) :
-      McEliece_PublicKey(public_matrix, goppa_polyn.get_degree(), inverse_support.size()),
-      m_g{goppa_polyn},
-      m_sqrtmod(square_root_matrix),
-      m_Linv(inverse_support),
-      m_coeffs(parity_check_matrix_coeffs),
-      m_codimension(static_cast<size_t>(ceil_log2(inverse_support.size())) * goppa_polyn.get_degree()),
-      m_dimension(inverse_support.size() - m_codimension) {}
+      McEliece_PublicKey(public_matrix, goppa_polyn.get_degree(), inverse_support.size()) {
+   const size_t codimension = static_cast<size_t>(ceil_log2(inverse_support.size())) * goppa_polyn.get_degree();
+   const size_t dimension = inverse_support.size() - codimension;
+   m_private = std::make_shared<const McEliece_PrivateKeyInternal>(std::vector<polyn_gf2m>{goppa_polyn},
+                                                                   square_root_matrix,
+                                                                   inverse_support,
+                                                                   parity_check_matrix_coeffs,
+                                                                   codimension,
+                                                                   dimension);
+}
 
 // NOLINTNEXTLINE(*-member-init)
 McEliece_PrivateKey::McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code_length, size_t t) {
@@ -50,17 +53,13 @@ McEliece_PrivateKey::McEliece_PrivateKey(RandomNumberGenerator& rng, size_t code
    *this = generate_mceliece_key(rng, ext_deg, code_length, t);
 }
 
-const polyn_gf2m& McEliece_PrivateKey::get_goppa_polyn() const {
-   return m_g[0];
-}
-
-size_t McEliece_PublicKey::get_message_word_bit_length() const {
+size_t McEliece_PublicKeyInternal::message_word_bit_length() const {
    const size_t codimension = ceil_log2(m_code_length) * m_t;
    return m_code_length - codimension;
 }
 
-secure_vector<uint8_t> McEliece_PublicKey::random_plaintext_element(RandomNumberGenerator& rng) const {
-   const size_t bits = get_message_word_bit_length();
+secure_vector<uint8_t> McEliece_PublicKeyInternal::random_plaintext_element(RandomNumberGenerator& rng) const {
+   const size_t bits = message_word_bit_length();
 
    secure_vector<uint8_t> plaintext((bits + 7) / 8);
    rng.randomize(plaintext.data(), plaintext.size());
@@ -74,12 +73,59 @@ secure_vector<uint8_t> McEliece_PublicKey::random_plaintext_element(RandomNumber
    return plaintext;
 }
 
+McEliece_PublicKey::McEliece_PublicKey(const std::vector<uint8_t>& pub_matrix, size_t t, size_t the_code_length) :
+      m_public(std::make_shared<const McEliece_PublicKeyInternal>(pub_matrix, t, the_code_length)) {}
+
+size_t McEliece_PublicKey::get_t() const {
+   return m_public->t();
+}
+
+size_t McEliece_PublicKey::get_code_length() const {
+   return m_public->code_length();
+}
+
+const std::vector<uint8_t>& McEliece_PublicKey::get_public_matrix() const {
+   return m_public->public_matrix();
+}
+
+size_t McEliece_PublicKey::get_message_word_bit_length() const {
+   return m_public->message_word_bit_length();
+}
+
+secure_vector<uint8_t> McEliece_PublicKey::random_plaintext_element(RandomNumberGenerator& rng) const {
+   return m_public->random_plaintext_element(rng);
+}
+
+const polyn_gf2m& McEliece_PrivateKey::get_goppa_polyn() const {
+   return m_private->goppa_polyn();
+}
+
+const std::vector<uint32_t>& McEliece_PrivateKey::get_H_coeffs() const {
+   return m_private->H_coeffs();
+}
+
+const std::vector<gf2m>& McEliece_PrivateKey::get_Linv() const {
+   return m_private->Linv();
+}
+
+const std::vector<polyn_gf2m>& McEliece_PrivateKey::get_sqrtmod() const {
+   return m_private->sqrtmod();
+}
+
+size_t McEliece_PrivateKey::get_dimension() const {
+   return m_private->dimension();
+}
+
+size_t McEliece_PrivateKey::get_codimension() const {
+   return m_private->codimension();
+}
+
 AlgorithmIdentifier McEliece_PublicKey::algorithm_identifier() const {
    return AlgorithmIdentifier(object_identifier(), AlgorithmIdentifier::USE_EMPTY_PARAM);
 }
 
 std::vector<uint8_t> McEliece_PublicKey::raw_public_key_bits() const {
-   return m_public_matrix;
+   return m_public->public_matrix();
 }
 
 std::vector<uint8_t> McEliece_PublicKey::public_key_bits() const {
@@ -90,17 +136,17 @@ std::vector<uint8_t> McEliece_PublicKey::public_key_bits() const {
       .encode(get_code_length())
       .encode(get_t())
       .end_cons()
-      .encode(m_public_matrix, ASN1_Type::OctetString)
+      .encode(m_public->public_matrix(), ASN1_Type::OctetString)
       .end_cons();
    return output;
 }
 
 size_t McEliece_PublicKey::key_length() const {
-   return m_code_length;
+   return m_public->code_length();
 }
 
 size_t McEliece_PublicKey::estimated_strength() const {
-   return mceliece_work_factor(m_code_length, m_t);
+   return mceliece_work_factor(m_public->code_length(), m_public->t());
 }
 
 McEliece_PublicKey::McEliece_PublicKey(std::span<const uint8_t> key_bits) :
@@ -116,12 +162,13 @@ McEliece_PublicKey::McEliece_PublicKey(const AlgorithmIdentifier& alg_id, std::s
    BER_Decoder dec(key_bits, BER_Decoder::Limits::DER());
    size_t n = 0;
    size_t t = 0;
+   std::vector<uint8_t> public_matrix;
    dec.start_sequence()
       .start_sequence()
       .decode(n)
       .decode(t)
       .end_cons()
-      .decode(m_public_matrix, ASN1_Type::OctetString)
+      .decode(public_matrix, ASN1_Type::OctetString)
       .end_cons()
       .verify_end();
 
@@ -151,12 +198,11 @@ McEliece_PublicKey::McEliece_PublicKey(const AlgorithmIdentifier& alg_id, std::s
 
    // public matrix is a dimension x codimension binary matrix stored as uint32_t rows
    const size_t expected_pubmat_size = dimension * bit_size_to_32bit_size(codimension) * sizeof(uint32_t);
-   if(m_public_matrix.size() != expected_pubmat_size) {
+   if(public_matrix.size() != expected_pubmat_size) {
       throw Decoding_Error("McEliece public matrix size does not match parameters");
    }
 
-   m_t = t;
-   m_code_length = n;
+   m_public = std::make_shared<const McEliece_PublicKeyInternal>(std::move(public_matrix), t, n);
 }
 
 secure_vector<uint8_t> McEliece_PrivateKey::private_key_bits() const {
@@ -166,22 +212,22 @@ secure_vector<uint8_t> McEliece_PrivateKey::private_key_bits() const {
       .encode(get_code_length())
       .encode(get_t())
       .end_cons()
-      .encode(m_public_matrix, ASN1_Type::OctetString)
-      .encode(m_g[0].encode(), ASN1_Type::OctetString);  // g as octet string
+      .encode(m_public->public_matrix(), ASN1_Type::OctetString)
+      .encode(m_private->goppa_polyn().encode(), ASN1_Type::OctetString);  // g as octet string
    enc.start_sequence();
-   for(const auto& x : m_sqrtmod) {
+   for(const auto& x : m_private->sqrtmod()) {
       enc.encode(x.encode(), ASN1_Type::OctetString);
    }
    enc.end_cons();
    secure_vector<uint8_t> enc_support;
 
-   for(const uint16_t Linv : m_Linv) {
+   for(const uint16_t Linv : m_private->Linv()) {
       enc_support.push_back(get_byte<0>(Linv));
       enc_support.push_back(get_byte<1>(Linv));
    }
    enc.encode(enc_support, ASN1_Type::OctetString);
    secure_vector<uint8_t> enc_H;
-   for(const uint32_t coef : m_coeffs) {
+   for(const uint32_t coef : m_private->H_coeffs()) {
       enc_H.push_back(get_byte<0>(coef));
       enc_H.push_back(get_byte<1>(coef));
       enc_H.push_back(get_byte<2>(coef));
@@ -197,11 +243,11 @@ bool McEliece_PrivateKey::check_key(RandomNumberGenerator& rng, bool /*unused*/)
 
    secure_vector<uint8_t> ciphertext;
    secure_vector<uint8_t> errors;
-   mceliece_encrypt(ciphertext, errors, plaintext, *this, rng);
+   mceliece_encrypt(ciphertext, errors, plaintext, *m_public, rng);
 
    secure_vector<uint8_t> plaintext_out;
    secure_vector<uint8_t> errors_out;
-   mceliece_decrypt(plaintext_out, errors_out, ciphertext, *this);
+   mceliece_decrypt(plaintext_out, errors_out, ciphertext, *m_private);
 
    if(errors != errors_out || plaintext != plaintext_out) {
       return false;
@@ -222,11 +268,12 @@ McEliece_PrivateKey::McEliece_PrivateKey(const AlgorithmIdentifier& alg_id, std:
 
    size_t n = 0;
    size_t t = 0;
+   std::vector<uint8_t> public_matrix;
    secure_vector<uint8_t> enc_g;
    BER_Decoder dec_base(key_bits, BER_Decoder::Limits::DER());
    BER_Decoder dec = dec_base.start_sequence();
    dec.start_sequence().decode(n).decode(t).end_cons();
-   dec.decode(m_public_matrix, ASN1_Type::OctetString).decode(enc_g, ASN1_Type::OctetString);
+   dec.decode(public_matrix, ASN1_Type::OctetString).decode(enc_g, ASN1_Type::OctetString);
 
    if(t == 0 || n == 0) {
       throw Decoding_Error("invalid McEliece parameters");
@@ -251,20 +298,16 @@ McEliece_PrivateKey::McEliece_PrivateKey(const AlgorithmIdentifier& alg_id, std:
 
    const size_t dimension = n - codimension;
    const size_t expected_pubmat_size = dimension * bit_size_to_32bit_size(codimension) * sizeof(uint32_t);
-   if(m_public_matrix.size() != expected_pubmat_size) {
+   if(public_matrix.size() != expected_pubmat_size) {
       throw Decoding_Error("McEliece public matrix size does not match parameters");
    }
 
-   m_code_length = n;
-   m_t = t;
-   m_codimension = codimension;
-   m_dimension = dimension;
-
    auto sp_field = std::make_shared<GF2m_Field>(ext_deg);
-   m_g = {polyn_gf2m(enc_g, sp_field)};
-   if(m_g[0].get_degree() != static_cast<int>(t)) {
+   std::vector<polyn_gf2m> g = {polyn_gf2m(enc_g, sp_field)};
+   if(g[0].get_degree() != static_cast<int>(t)) {
       throw Decoding_Error("degree of decoded Goppa polynomial is incorrect");
    }
+   std::vector<polyn_gf2m> sqrtmod;
    BER_Decoder dec2 = dec.start_sequence();
    for(uint32_t i = 0; i < t / 2; i++) {
       secure_vector<uint8_t> sqrt_enc;
@@ -277,7 +320,7 @@ McEliece_PrivateKey::McEliece_PrivateKey(const AlgorithmIdentifier& alg_id, std:
       if(sqrt_enc.size() != t * 2) {
          throw Decoding_Error("length of square root polynomial entry is too large");
       }
-      m_sqrtmod.push_back(polyn_gf2m(sqrt_enc, sp_field));
+      sqrtmod.push_back(polyn_gf2m(sqrt_enc, sp_field));
    }
    secure_vector<uint8_t> enc_support;
    dec2.end_cons();
@@ -288,44 +331,51 @@ McEliece_PrivateKey::McEliece_PrivateKey(const AlgorithmIdentifier& alg_id, std:
    if(enc_support.size() / 2 != n) {
       throw Decoding_Error("encoded support has length different from code length");
    }
+   std::vector<gf2m> Linv;
    for(uint32_t i = 0; i < n * 2; i += 2) {
       const gf2m el = (enc_support[i] << 8) | enc_support[i + 1];
-      m_Linv.push_back(el);
+      Linv.push_back(el);
    }
    secure_vector<uint8_t> enc_H;
    dec.decode(enc_H, ASN1_Type::OctetString).end_cons().verify_end();
    if(enc_H.size() % 4 != 0) {
       throw Decoding_Error("encoded parity check matrix has length which is not a multiple of four");
    }
-   if(enc_H.size() / 4 != bit_size_to_32bit_size(m_codimension) * m_code_length) {
+   if(enc_H.size() / 4 != bit_size_to_32bit_size(codimension) * n) {
       throw Decoding_Error("encoded parity check matrix has wrong length");
    }
 
+   std::vector<uint32_t> coeffs;
    for(uint32_t i = 0; i < enc_H.size(); i += 4) {
       const uint32_t coeff = (enc_H[i] << 24) | (enc_H[i + 1] << 16) | (enc_H[i + 2] << 8) | enc_H[i + 3];
-      m_coeffs.push_back(coeff);
+      coeffs.push_back(coeff);
    }
+
+   m_public = std::make_shared<const McEliece_PublicKeyInternal>(std::move(public_matrix), t, n);
+   m_private = std::make_shared<const McEliece_PrivateKeyInternal>(
+      std::move(g), std::move(sqrtmod), std::move(Linv), std::move(coeffs), codimension, dimension);
 }
 
 bool McEliece_PrivateKey::operator==(const McEliece_PrivateKey& other) const {
    if(*static_cast<const McEliece_PublicKey*>(this) != *static_cast<const McEliece_PublicKey*>(&other)) {
       return false;
    }
-   if(m_g != other.m_g) {
+   if(m_private->goppa_polyn_vec() != other.m_private->goppa_polyn_vec()) {
       return false;
    }
 
-   if(m_sqrtmod != other.m_sqrtmod) {
+   if(m_private->sqrtmod() != other.m_private->sqrtmod()) {
       return false;
    }
-   if(m_Linv != other.m_Linv) {
+   if(m_private->Linv() != other.m_private->Linv()) {
       return false;
    }
-   if(m_coeffs != other.m_coeffs) {
+   if(m_private->H_coeffs() != other.m_private->H_coeffs()) {
       return false;
    }
 
-   if(m_codimension != other.m_codimension || m_dimension != other.m_dimension) {
+   if(m_private->codimension() != other.m_private->codimension() ||
+      m_private->dimension() != other.m_private->dimension()) {
       return false;
    }
 
@@ -337,13 +387,13 @@ std::unique_ptr<Public_Key> McEliece_PrivateKey::public_key() const {
 }
 
 bool McEliece_PublicKey::operator==(const McEliece_PublicKey& other) const {
-   if(m_public_matrix != other.m_public_matrix) {
+   if(m_public->public_matrix() != other.m_public->public_matrix()) {
       return false;
    }
-   if(m_t != other.m_t) {
+   if(m_public->t() != other.m_public->t()) {
       return false;
    }
-   if(m_code_length != other.m_code_length) {
+   if(m_public->code_length() != other.m_public->code_length()) {
       return false;
    }
    return true;
@@ -353,26 +403,26 @@ namespace {
 
 class MCE_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
    public:
-      MCE_KEM_Encryptor(const McEliece_PublicKey& key, std::string_view kdf) :
-            KEM_Encryption_with_KDF(kdf), m_key(key) {}
+      MCE_KEM_Encryptor(std::shared_ptr<const McEliece_PublicKeyInternal> key, std::string_view kdf) :
+            KEM_Encryption_with_KDF(kdf), m_key(std::move(key)) {}
 
    private:
       size_t raw_kem_shared_key_length() const override {
-         const size_t err_sz = (m_key.get_code_length() + 7) / 8;
-         const size_t ptext_sz = (m_key.get_message_word_bit_length() + 7) / 8;
+         const size_t err_sz = (m_key->code_length() + 7) / 8;
+         const size_t ptext_sz = (m_key->message_word_bit_length() + 7) / 8;
          return ptext_sz + err_sz;
       }
 
-      size_t encapsulated_key_length() const override { return (m_key.get_code_length() + 7) / 8; }
+      size_t encapsulated_key_length() const override { return (m_key->code_length() + 7) / 8; }
 
       void raw_kem_encrypt(std::span<uint8_t> out_encapsulated_key,
                            std::span<uint8_t> raw_shared_key,
                            RandomNumberGenerator& rng) override {
-         secure_vector<uint8_t> plaintext = m_key.random_plaintext_element(rng);
+         secure_vector<uint8_t> plaintext = m_key->random_plaintext_element(rng);
 
          secure_vector<uint8_t> ciphertext;
          secure_vector<uint8_t> error_mask;
-         mceliece_encrypt(ciphertext, error_mask, plaintext, m_key, rng);
+         mceliece_encrypt(ciphertext, error_mask, plaintext, *m_key, rng);
 
          // TODO: Perhaps avoid the copies below
          BOTAN_ASSERT_NOMSG(out_encapsulated_key.size() == ciphertext.size());
@@ -384,27 +434,27 @@ class MCE_KEM_Encryptor final : public PK_Ops::KEM_Encryption_with_KDF {
          bs.append(error_mask);
       }
 
-      const McEliece_PublicKey& m_key;
+      std::shared_ptr<const McEliece_PublicKeyInternal> m_key;
 };
 
 class MCE_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF {
    public:
-      MCE_KEM_Decryptor(const McEliece_PrivateKey& key, std::string_view kdf) :
-            KEM_Decryption_with_KDF(kdf), m_key(key) {}
+      MCE_KEM_Decryptor(std::shared_ptr<const McEliece_PrivateKeyInternal> key, std::string_view kdf) :
+            KEM_Decryption_with_KDF(kdf), m_key(std::move(key)) {}
 
    private:
       size_t raw_kem_shared_key_length() const override {
-         const size_t err_sz = (m_key.get_code_length() + 7) / 8;
-         const size_t ptext_sz = (m_key.get_message_word_bit_length() + 7) / 8;
+         const size_t err_sz = (m_key->code_length() + 7) / 8;
+         const size_t ptext_sz = (m_key->message_word_bit_length() + 7) / 8;
          return ptext_sz + err_sz;
       }
 
-      size_t encapsulated_key_length() const override { return (m_key.get_code_length() + 7) / 8; }
+      size_t encapsulated_key_length() const override { return (m_key->code_length() + 7) / 8; }
 
       void raw_kem_decrypt(std::span<uint8_t> out_shared_key, std::span<const uint8_t> encapsulated_key) override {
          secure_vector<uint8_t> plaintext;
          secure_vector<uint8_t> error_mask;
-         mceliece_decrypt(plaintext, error_mask, encapsulated_key.data(), encapsulated_key.size(), m_key);
+         mceliece_decrypt(plaintext, error_mask, encapsulated_key.data(), encapsulated_key.size(), *m_key);
 
          // TODO: perhaps avoid the copies below
          BOTAN_ASSERT_NOMSG(out_shared_key.size() == plaintext.size() + error_mask.size());
@@ -413,7 +463,7 @@ class MCE_KEM_Decryptor final : public PK_Ops::KEM_Decryption_with_KDF {
          bs.append(error_mask);
       }
 
-      const McEliece_PrivateKey& m_key;
+      std::shared_ptr<const McEliece_PrivateKeyInternal> m_key;
 };
 
 }  // namespace
@@ -425,7 +475,7 @@ std::unique_ptr<Private_Key> McEliece_PublicKey::generate_another(RandomNumberGe
 std::unique_ptr<PK_Ops::KEM_Encryption> McEliece_PublicKey::create_kem_encryption_op(std::string_view params,
                                                                                      std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
-      return std::make_unique<MCE_KEM_Encryptor>(*this, params);
+      return std::make_unique<MCE_KEM_Encryptor>(m_public, params);
    }
    throw Provider_Not_Found(algo_name(), provider);
 }
@@ -434,7 +484,7 @@ std::unique_ptr<PK_Ops::KEM_Decryption> McEliece_PrivateKey::create_kem_decrypti
                                                                                       std::string_view params,
                                                                                       std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
-      return std::make_unique<MCE_KEM_Decryptor>(*this, params);
+      return std::make_unique<MCE_KEM_Decryptor>(m_private, params);
    }
    throw Provider_Not_Found(algo_name(), provider);
 }

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.cpp
@@ -191,7 +191,7 @@ namespace {
 
 class SphincsPlus_Verification_Operation final : public PK_Ops::Verification {
    public:
-      explicit SphincsPlus_Verification_Operation(std::shared_ptr<SphincsPlus_PublicKeyInternal> pub_key) :
+      explicit SphincsPlus_Verification_Operation(std::shared_ptr<const SphincsPlus_PublicKeyInternal> pub_key) :
             m_public(std::move(pub_key)),
             m_hashes(Botan::Sphincs_Hash_Functions::create(m_public->parameters(), m_public->seed())),
             m_context(/* TODO: Add API */ {}) {
@@ -246,7 +246,7 @@ class SphincsPlus_Verification_Operation final : public PK_Ops::Verification {
          return ht_verify(fors_root, ht_sig_s, m_public->root(), tree_idx, leaf_idx, p, *m_hashes);
       }
 
-      std::shared_ptr<SphincsPlus_PublicKeyInternal> m_public;
+      std::shared_ptr<const SphincsPlus_PublicKeyInternal> m_public;
       std::unique_ptr<Sphincs_Hash_Functions> m_hashes;
       SphincsInputMessage m_msg_buffer;
       SphincsContext m_context;
@@ -360,8 +360,8 @@ namespace {
 
 class SphincsPlus_Signature_Operation final : public PK_Ops::Signature {
    public:
-      SphincsPlus_Signature_Operation(std::shared_ptr<SphincsPlus_PrivateKeyInternal> private_key,
-                                      std::shared_ptr<SphincsPlus_PublicKeyInternal> public_key,
+      SphincsPlus_Signature_Operation(std::shared_ptr<const SphincsPlus_PrivateKeyInternal> private_key,
+                                      std::shared_ptr<const SphincsPlus_PublicKeyInternal> public_key,
                                       bool randomized) :
             m_private(std::move(private_key)),
             m_public(std::move(public_key)),
@@ -439,8 +439,8 @@ class SphincsPlus_Signature_Operation final : public PK_Ops::Signature {
          return sphincs_sig_buffer;
       }
 
-      std::shared_ptr<SphincsPlus_PrivateKeyInternal> m_private;
-      std::shared_ptr<SphincsPlus_PublicKeyInternal> m_public;
+      std::shared_ptr<const SphincsPlus_PrivateKeyInternal> m_private;
+      std::shared_ptr<const SphincsPlus_PublicKeyInternal> m_public;
       std::unique_ptr<Sphincs_Hash_Functions> m_hashes;
       SphincsInputMessage m_msg_buffer;
       bool m_randomized;

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus.h
@@ -65,7 +65,7 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PublicKey : public virtual Public_Key {
    protected:
       SphincsPlus_PublicKey() = default;
 
-      std::shared_ptr<SphincsPlus_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const SphincsPlus_PublicKeyInternal> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -117,7 +117,7 @@ class BOTAN_PUBLIC_API(3, 1) SphincsPlus_PrivateKey final : public virtual Sphin
                                                              std::string_view provider) const override;
 
    private:
-      std::shared_ptr<SphincsPlus_PrivateKeyInternal> m_private;
+      std::shared_ptr<const SphincsPlus_PrivateKeyInternal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/x25519/x25519.cpp
+++ b/src/lib/pubkey/x25519/x25519.cpp
@@ -16,6 +16,34 @@
 
 namespace Botan {
 
+class X25519_PublicKey_Data final {
+   public:
+      explicit X25519_PublicKey_Data(std::vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const std::vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      std::vector<uint8_t> m_key;
+};
+
+class X25519_PrivateKey_Data final {
+   public:
+      explicit X25519_PrivateKey_Data(secure_vector<uint8_t> key) : m_key(std::move(key)) {}
+
+      const secure_vector<uint8_t>& key() const { return m_key; }
+
+   private:
+      secure_vector<uint8_t> m_key;
+};
+
+const secure_vector<uint8_t>& X25519_PrivateKey::get_x() const {
+   return m_private->key();
+}
+
+secure_vector<uint8_t> X25519_PrivateKey::raw_private_key_bits() const {
+   return m_private->key();
+}
+
 void curve25519_basepoint(uint8_t mypublic[32], const uint8_t secret[32]) {
    const uint8_t basepoint[32] = {9};
    curve25519_donna(mypublic, secret, basepoint);
@@ -33,6 +61,18 @@ secure_vector<uint8_t> curve25519(const secure_vector<uint8_t>& secret, const ui
    secure_vector<uint8_t> out(32);
    curve25519_donna(out.data(), secret.data(), pubval);
    return out;
+}
+
+// Given a 32-byte secret key compute the public value and build the immutable
+// public and private key data objects.
+void load_x25519_keypair(secure_vector<uint8_t> secret,
+                         std::shared_ptr<const X25519_PublicKey_Data>& pk_out,
+                         std::shared_ptr<const X25519_PrivateKey_Data>& sk_out) {
+   BOTAN_ASSERT_NOMSG(secret.size() == 32);
+   std::vector<uint8_t> pub(32);
+   curve25519_basepoint(pub.data(), secret.data());
+   pk_out = std::make_shared<const X25519_PublicKey_Data>(std::move(pub));
+   sk_out = std::make_shared<const X25519_PrivateKey_Data>(std::move(secret));
 }
 
 }  // namespace
@@ -54,13 +94,12 @@ X25519_PublicKey::X25519_PublicKey(const AlgorithmIdentifier& alg_id, std::span<
 }
 
 X25519_PublicKey::X25519_PublicKey(std::span<const uint8_t> pub) {
-   m_public.assign(pub.begin(), pub.end());
-
-   size_check(m_public.size(), "public key");
+   size_check(pub.size(), "public key");
+   m_public = std::make_shared<const X25519_PublicKey_Data>(std::vector<uint8_t>(pub.begin(), pub.end()));
 }
 
 std::vector<uint8_t> X25519_PublicKey::raw_public_key_bits() const {
-   return m_public;
+   return m_public->key();
 }
 
 std::vector<uint8_t> X25519_PublicKey::public_key_bits() const {
@@ -76,15 +115,11 @@ X25519_PrivateKey::X25519_PrivateKey(std::span<const uint8_t> secret_key) {
       throw Decoding_Error("Invalid size for X25519 private key");
    }
 
-   m_public.resize(32);
-   m_private.assign(secret_key.begin(), secret_key.end());
-   curve25519_basepoint(m_public.data(), m_private.data());
+   load_x25519_keypair(secure_vector<uint8_t>(secret_key.begin(), secret_key.end()), m_public, m_private);
 }
 
 X25519_PrivateKey::X25519_PrivateKey(RandomNumberGenerator& rng) {
-   m_private = rng.random_vec(32);
-   m_public.resize(32);
-   curve25519_basepoint(m_public.data(), m_private.data());
+   load_x25519_keypair(rng.random_vec(32), m_public, m_private);
 }
 
 X25519_PrivateKey::X25519_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) {
@@ -93,11 +128,11 @@ X25519_PrivateKey::X25519_PrivateKey(const AlgorithmIdentifier& alg_id, std::spa
       throw Decoding_Error("Unexpected parameters for X25519 private key");
    }
 
-   BER_Decoder(key_bits, BER_Decoder::Limits::DER()).decode(m_private, ASN1_Type::OctetString).discard_remaining();
+   secure_vector<uint8_t> secret_key;
+   BER_Decoder(key_bits, BER_Decoder::Limits::DER()).decode(secret_key, ASN1_Type::OctetString).discard_remaining();
 
-   size_check(m_private.size(), "private key");
-   m_public.resize(32);
-   curve25519_basepoint(m_public.data(), m_private.data());
+   size_check(secret_key.size(), "private key");
+   load_x25519_keypair(std::move(secret_key), m_public, m_private);
 }
 
 std::unique_ptr<Public_Key> X25519_PrivateKey::public_key() const {
@@ -105,18 +140,18 @@ std::unique_ptr<Public_Key> X25519_PrivateKey::public_key() const {
 }
 
 secure_vector<uint8_t> X25519_PrivateKey::private_key_bits() const {
-   return DER_Encoder().encode(m_private, ASN1_Type::OctetString).get_contents();
+   return DER_Encoder().encode(m_private->key(), ASN1_Type::OctetString).get_contents();
 }
 
 bool X25519_PrivateKey::check_key(RandomNumberGenerator& /*rng*/, bool /*strong*/) const {
    std::vector<uint8_t> public_point(32);
-   curve25519_basepoint(public_point.data(), m_private.data());
-   return public_point == m_public;
+   curve25519_basepoint(public_point.data(), m_private->key().data());
+   return public_point == m_public->key();
 }
 
 secure_vector<uint8_t> X25519_PrivateKey::agree(const uint8_t w[], size_t w_len) const {
    size_check(w_len, "public value");
-   return curve25519(m_private, w);
+   return curve25519(m_private->key(), w);
 }
 
 namespace {
@@ -126,13 +161,14 @@ namespace {
 */
 class X25519_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
    public:
-      X25519_KA_Operation(const X25519_PrivateKey& key, std::string_view kdf) :
-            PK_Ops::Key_Agreement_with_KDF(kdf), m_key(key) {}
+      X25519_KA_Operation(std::shared_ptr<const X25519_PrivateKey_Data> key, std::string_view kdf) :
+            PK_Ops::Key_Agreement_with_KDF(kdf), m_key(std::move(key)) {}
 
       size_t agreed_value_size() const override { return 32; }
 
       secure_vector<uint8_t> raw_agree(const uint8_t w[], size_t w_len) override {
-         auto shared_key = m_key.agree(w, w_len);
+         size_check(w_len, "public value");
+         auto shared_key = curve25519(m_key->key(), w);
 
          // RFC 7748 Section 6.1
          //    Both [parties] MAY check, without leaking extra information about
@@ -151,7 +187,7 @@ class X25519_KA_Operation final : public PK_Ops::Key_Agreement_with_KDF {
       }
 
    private:
-      const X25519_PrivateKey& m_key;
+      std::shared_ptr<const X25519_PrivateKey_Data> m_key;
 };
 
 }  // namespace
@@ -160,7 +196,7 @@ std::unique_ptr<PK_Ops::Key_Agreement> X25519_PrivateKey::create_key_agreement_o
                                                                                   std::string_view params,
                                                                                   std::string_view provider) const {
    if(provider == "base" || provider.empty()) {
-      return std::make_unique<X25519_KA_Operation>(*this, params);
+      return std::make_unique<X25519_KA_Operation>(m_private, params);
    }
    throw Provider_Not_Found(algo_name(), provider);
 }

--- a/src/lib/pubkey/x25519/x25519.h
+++ b/src/lib/pubkey/x25519/x25519.h
@@ -8,8 +8,13 @@
 #define BOTAN_X25519_H_
 
 #include <botan/pk_keys.h>
+#include <memory>
+#include <vector>
 
 namespace Botan {
+
+class X25519_PublicKey_Data;
+class X25519_PrivateKey_Data;
 
 class BOTAN_PUBLIC_API(2, 0) X25519_PublicKey : public virtual Public_Key {
    public:
@@ -50,7 +55,7 @@ class BOTAN_PUBLIC_API(2, 0) X25519_PublicKey : public virtual Public_Key {
 
    protected:
       X25519_PublicKey() = default;
-      std::vector<uint8_t> m_public;  // NOLINT(*non-private-member-variable*)
+      std::shared_ptr<const X25519_PublicKey_Data> m_public;  // NOLINT(*non-private-member-variable*)
 };
 
 BOTAN_DIAGNOSTIC_PUSH
@@ -83,9 +88,9 @@ class BOTAN_PUBLIC_API(2, 0) X25519_PrivateKey final : public X25519_PublicKey,
 
       secure_vector<uint8_t> agree(const uint8_t w[], size_t w_len) const;
 
-      secure_vector<uint8_t> raw_private_key_bits() const override { return m_private; }
+      secure_vector<uint8_t> raw_private_key_bits() const override;
 
-      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_x() const { return m_private; }
+      BOTAN_DEPRECATED("Use raw_private_key_bits") const secure_vector<uint8_t>& get_x() const;
 
       secure_vector<uint8_t> private_key_bits() const override;
 
@@ -98,7 +103,7 @@ class BOTAN_PUBLIC_API(2, 0) X25519_PrivateKey final : public X25519_PublicKey,
                                                                      std::string_view provider) const override;
 
    private:
-      secure_vector<uint8_t> m_private;
+      std::shared_ptr<const X25519_PrivateKey_Data> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/xmss/xmss.h
+++ b/src/lib/pubkey/xmss/xmss.h
@@ -128,10 +128,8 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PublicKey : public virtual Public_Key {
 
       const XMSS_Parameters& xmss_parameters() const;
 
-      void set_root(secure_vector<uint8_t> root);
-
    private:
-      std::shared_ptr<XMSS_PublicKey_Internal> m_public_key;
+      std::shared_ptr<const XMSS_PublicKey_Internal> m_public_key;
 };
 
 template <typename>
@@ -270,11 +268,23 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
    private:
       friend class XMSS_Signature_Operation;
 
+      // The seeds and the precomputed Merkle root produced during key
+      // generation, used to construct the (immutable) public key before the
+      // derived private key body runs.
+      struct Keygen_Material;
+
+      XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
+                      WOTS_Derivation_Method wots_derivation_method,
+                      Keygen_Material material);
+
+      static Keygen_Material generate_keygen_material(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
+                                                      RandomNumberGenerator& rng,
+                                                      WOTS_Derivation_Method wots_derivation_method);
+
       size_t reserve_unused_leaf_index();
 
       const secure_vector<uint8_t>& prf_value() const;
 
-      XMSS_WOTS_PublicKey wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
       XMSS_WOTS_PrivateKey wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
 
       /**
@@ -295,13 +305,7 @@ class BOTAN_PUBLIC_API(2, 0) XMSS_PrivateKey final : public virtual XMSS_PublicK
                                        const XMSS_Address& adrs,
                                        XMSS_Hash& hash) const;
 
-      void tree_hash_subtree(secure_vector<uint8_t>& result,
-                             size_t start_idx,
-                             size_t target_node_height,
-                             XMSS_Address& adrs,
-                             XMSS_Hash& hash) const;
-
-      std::shared_ptr<XMSS_PrivateKey_Internal> m_private;
+      std::shared_ptr<const XMSS_PrivateKey_Internal> m_private;
 };
 
 BOTAN_DIAGNOSTIC_POP

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -54,6 +54,51 @@ secure_vector<uint8_t> extract_raw_private_key(std::span<const uint8_t> key_bits
    return raw_key;
 }
 
+/**
+ * Bundles the inputs needed to compute the internal nodes (and root) of the
+ * XMSS Merkle tree: the parameters and the public/private seeds. The same
+ * computation is needed both during key generation (before the immutable
+ * public key exists) and during signing (auth path computation), so it is
+ * factored out here and shared via thin wrappers on XMSS_PrivateKey.
+ */
+class XMSS_Tree_Builder final {
+   public:
+      XMSS_Tree_Builder(const XMSS_Parameters& xmss_params,
+                        WOTS_Derivation_Method wots_derivation_method,
+                        const secure_vector<uint8_t>& public_seed,
+                        const secure_vector<uint8_t>& private_seed) :
+            m_xmss_params(xmss_params),
+            m_wots_params(xmss_params.wots_parameters()),
+            m_wots_derivation_method(wots_derivation_method),
+            m_public_seed(public_seed),
+            m_private_seed(private_seed) {}
+
+      secure_vector<uint8_t> tree_hash(size_t start_idx,
+                                       size_t target_node_height,
+                                       const XMSS_Address& adrs,
+                                       XMSS_Hash& hash) const;
+
+      void tree_hash_subtree(secure_vector<uint8_t>& result,
+                             size_t start_idx,
+                             size_t target_node_height,
+                             XMSS_Address& adrs,
+                             XMSS_Hash& hash) const;
+
+      XMSS_WOTS_PublicKey wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
+      XMSS_WOTS_PrivateKey wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
+
+      const XMSS_Parameters& xmss_parameters() const { return m_xmss_params; }
+
+      const secure_vector<uint8_t>& public_seed() const { return m_public_seed; }
+
+   private:
+      const XMSS_Parameters& m_xmss_params;
+      XMSS_WOTS_Parameters m_wots_params;
+      WOTS_Derivation_Method m_wots_derivation_method;
+      const secure_vector<uint8_t>& m_public_seed;
+      const secure_vector<uint8_t>& m_private_seed;
+};
+
 }  // namespace
 
 class XMSS_PrivateKey_Internal final {
@@ -147,13 +192,16 @@ class XMSS_PrivateKey_Internal final {
 
       const secure_vector<uint8_t>& prf_value() const { return m_prf; }
 
-      const secure_vector<uint8_t>& private_seed() { return m_private_seed; }
+      const secure_vector<uint8_t>& private_seed() const { return m_private_seed; }
 
-      const XMSS_WOTS_Parameters& wots_parameters() { return m_wots_params; }
+      const XMSS_WOTS_Parameters& wots_parameters() const { return m_wots_params; }
 
       WOTS_Derivation_Method wots_derivation_method() const { return m_wots_derivation_method; }
 
-      void set_unused_leaf_index(size_t idx) {
+      // The signing state (leaf index) lives in the process-wide
+      // Stateful_Key_Index_Registry keyed by m_keyid, not in this object, so the
+      // methods that advance it leave *this unchanged and are therefore const.
+      void set_unused_leaf_index(size_t idx) const {
          // An index equal to 2^h is valid and denotes an exhausted key
          if(idx > (1ULL << m_xmss_params.tree_height())) {
             throw Decoding_Error("XMSS private key leaf index out of bounds");
@@ -162,7 +210,7 @@ class XMSS_PrivateKey_Internal final {
          }
       }
 
-      size_t reserve_unused_leaf_index() {
+      size_t reserve_unused_leaf_index() const {
          const auto idx = Stateful_Key_Index_Registry::global().reserve_next_index(m_keyid);
          if(!idx.has_value()) {
             throw Invalid_State("XMSS private key, one time signatures exhausted");
@@ -197,15 +245,47 @@ XMSS_PrivateKey::XMSS_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<co
       XMSS_PublicKey(alg_id, key_bits),
       m_private(std::make_shared<XMSS_PrivateKey_Internal>(xmss_parameters().oid(), key_bits)) {}
 
+struct XMSS_PrivateKey::Keygen_Material {
+      secure_vector<uint8_t> private_seed;
+      secure_vector<uint8_t> prf;
+      secure_vector<uint8_t> public_seed;
+      secure_vector<uint8_t> root;
+};
+
+XMSS_PrivateKey::Keygen_Material XMSS_PrivateKey::generate_keygen_material(
+   XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
+   RandomNumberGenerator& rng,
+   WOTS_Derivation_Method wots_derivation_method) {
+   const auto params = XMSS_Parameters::from_id(xmss_algo_id);
+   const size_t n = params.element_size();
+
+   // The order in which the seeds are drawn from the RNG (public seed, then
+   // prf, then private seed) must match the historical two-phase construction
+   // so that a deterministic RNG reproduces the same key material.
+   auto public_seed = rng.random_vec(n);
+   auto prf = rng.random_vec(n);
+   auto private_seed = rng.random_vec(n);
+
+   const XMSS_Address adrs;
+   XMSS_Hash hash(params);
+   const XMSS_Tree_Builder builder(params, wots_derivation_method, public_seed, private_seed);
+   auto root = builder.tree_hash(0, params.tree_height(), adrs, hash);
+
+   return Keygen_Material{std::move(private_seed), std::move(prf), std::move(public_seed), std::move(root)};
+}
+
 XMSS_PrivateKey::XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                                  RandomNumberGenerator& rng,
                                  WOTS_Derivation_Method wots_derivation_method) :
-      XMSS_PublicKey(xmss_algo_id, rng),
-      m_private(std::make_shared<XMSS_PrivateKey_Internal>(xmss_algo_id, wots_derivation_method, rng)) {
-   const XMSS_Address adrs;
-   XMSS_Hash hash(xmss_parameters());
-   set_root(tree_hash(0, xmss_parameters().tree_height(), adrs, hash));
-}
+      XMSS_PrivateKey(
+         xmss_algo_id, wots_derivation_method, generate_keygen_material(xmss_algo_id, rng, wots_derivation_method)) {}
+
+XMSS_PrivateKey::XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
+                                 WOTS_Derivation_Method wots_derivation_method,
+                                 Keygen_Material material) :
+      XMSS_PublicKey(xmss_algo_id, std::move(material.root), std::move(material.public_seed)),
+      m_private(std::make_shared<XMSS_PrivateKey_Internal>(
+         xmss_algo_id, wots_derivation_method, std::move(material.private_seed), std::move(material.prf))) {}
 
 XMSS_PrivateKey::XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                                  size_t idx_leaf,
@@ -224,10 +304,12 @@ XMSS_PrivateKey::XMSS_PrivateKey(XMSS_Parameters::xmss_algorithm_t xmss_algo_id,
                    "XMSS: unexpected byte length of private seed");
 }
 
-secure_vector<uint8_t> XMSS_PrivateKey::tree_hash(size_t start_idx,
-                                                  size_t target_node_height,
-                                                  const XMSS_Address& adrs,
-                                                  XMSS_Hash& hash) const {
+namespace {
+
+secure_vector<uint8_t> XMSS_Tree_Builder::tree_hash(size_t start_idx,
+                                                    size_t target_node_height,
+                                                    const XMSS_Address& adrs,
+                                                    XMSS_Hash& hash) const {
    BOTAN_ASSERT_NOMSG(target_node_height <= 30);
    BOTAN_ASSERT((start_idx % (static_cast<size_t>(1) << target_node_height)) == 0,
                 "Start index must be divisible by 2^{target node height}.");
@@ -265,9 +347,9 @@ secure_vector<uint8_t> XMSS_PrivateKey::tree_hash(size_t start_idx,
    // Calculate multiple subtrees in parallel.
    for(size_t i = 0; i < subtrees; i++) {
       using tree_hash_subtree_fn_t =
-         void (XMSS_PrivateKey::*)(secure_vector<uint8_t>&, size_t, size_t, XMSS_Address&, XMSS_Hash&) const;
+         void (XMSS_Tree_Builder::*)(secure_vector<uint8_t>&, size_t, size_t, XMSS_Address&, XMSS_Hash&) const;
 
-      const tree_hash_subtree_fn_t work_fn = &XMSS_PrivateKey::tree_hash_subtree;
+      const tree_hash_subtree_fn_t work_fn = &XMSS_Tree_Builder::tree_hash_subtree;
 
       work.push_back(thread_pool.run(work_fn,
                                      this,
@@ -324,11 +406,11 @@ secure_vector<uint8_t> XMSS_PrivateKey::tree_hash(size_t start_idx,
 #endif
 }
 
-void XMSS_PrivateKey::tree_hash_subtree(secure_vector<uint8_t>& result,
-                                        size_t start_idx,
-                                        size_t target_node_height,
-                                        XMSS_Address& adrs,
-                                        XMSS_Hash& hash) const {
+void XMSS_Tree_Builder::tree_hash_subtree(secure_vector<uint8_t>& result,
+                                          size_t start_idx,
+                                          size_t target_node_height,
+                                          XMSS_Address& adrs,
+                                          XMSS_Hash& hash) const {
    const secure_vector<uint8_t>& seed = this->public_seed();
 
    std::vector<secure_vector<uint8_t>> nodes(target_node_height + 1,
@@ -371,21 +453,35 @@ void XMSS_PrivateKey::tree_hash_subtree(secure_vector<uint8_t>& result,
    result = nodes[level - 1];
 }
 
-XMSS_WOTS_PublicKey XMSS_PrivateKey::wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
+XMSS_WOTS_PublicKey XMSS_Tree_Builder::wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
    const auto private_key = wots_private_key_for(adrs, hash);
-   return XMSS_WOTS_PublicKey(m_private->wots_parameters(), public_seed(), private_key, adrs, hash);
+   return XMSS_WOTS_PublicKey(m_wots_params, public_seed(), private_key, adrs, hash);
 }
 
-XMSS_WOTS_PrivateKey XMSS_PrivateKey::wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
-   switch(wots_derivation_method()) {
+XMSS_WOTS_PrivateKey XMSS_Tree_Builder::wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
+   switch(m_wots_derivation_method) {
       case WOTS_Derivation_Method::NIST_SP800_208:
-         return XMSS_WOTS_PrivateKey(
-            m_private->wots_parameters(), public_seed(), m_private->private_seed(), adrs, hash);
+         return XMSS_WOTS_PrivateKey(m_wots_params, public_seed(), m_private_seed, adrs, hash);
       case WOTS_Derivation_Method::Botan2x:
-         return XMSS_WOTS_PrivateKey(m_private->wots_parameters(), m_private->private_seed(), adrs, hash);
+         return XMSS_WOTS_PrivateKey(m_wots_params, m_private_seed, adrs, hash);
    }
 
    throw Invalid_State("WOTS derivation method is out of the enum's range");
+}
+
+}  // namespace
+
+secure_vector<uint8_t> XMSS_PrivateKey::tree_hash(size_t start_idx,
+                                                  size_t target_node_height,
+                                                  const XMSS_Address& adrs,
+                                                  XMSS_Hash& hash) const {
+   return XMSS_Tree_Builder(xmss_parameters(), wots_derivation_method(), public_seed(), m_private->private_seed())
+      .tree_hash(start_idx, target_node_height, adrs, hash);
+}
+
+XMSS_WOTS_PrivateKey XMSS_PrivateKey::wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
+   return XMSS_Tree_Builder(xmss_parameters(), wots_derivation_method(), public_seed(), m_private->private_seed())
+      .wots_private_key_for(adrs, hash);
 }
 
 secure_vector<uint8_t> XMSS_PrivateKey::private_key_bits() const {

--- a/src/lib/pubkey/xmss/xmss_publickey.cpp
+++ b/src/lib/pubkey/xmss/xmss_publickey.cpp
@@ -85,8 +85,6 @@ class XMSS_PublicKey_Internal final {
 
       const secure_vector<uint8_t>& public_seed() const { return m_public_seed; }
 
-      void set_root(secure_vector<uint8_t> root) { m_root = std::move(root); }
-
       std::vector<uint8_t> raw_public_key_bits() const {
          return concat<std::vector<uint8_t>>(
             store_be(static_cast<uint32_t>(m_xmss_params.oid())), m_root, m_public_seed);
@@ -148,10 +146,6 @@ const secure_vector<uint8_t>& XMSS_PublicKey::root() const {
 
 const XMSS_Parameters& XMSS_PublicKey::xmss_parameters() const {
    return m_public_key->xmss_parameters();
-}
-
-void XMSS_PublicKey::set_root(secure_vector<uint8_t> root) {
-   m_public_key->set_root(std::move(root));
 }
 
 size_t XMSS_PublicKey::estimated_strength() const {


### PR DESCRIPTION
This was done already for most implementations but Ed25519, X25519, Ed448, and X448 had data directly as class members, and many PQC schemes used shared_ptr to non-const pointers.

This also refactors XMSS keygen so that it does not require being able to mutate the public key after the fact.