### PR TITLE
Require that RSA ciphertexts are the exact length of the modulus

### DIFF
--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -702,6 +702,15 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption_with_Padding,
       size_t plaintext_length(size_t /*ctext_len*/) const override { return public_modulus_bytes(); }
 
       secure_vector<uint8_t> raw_decrypt(std::span<const uint8_t> input) override {
+         /*
+         * RFC 8017 7.1.2 and 7.2.2
+         *
+         *  If the length of the ciphertext C is not k octets, output
+         *  "decryption error" and stop.
+         */
+         if(input.size() != public_modulus_bytes()) {
+            throw Decoding_Error("RSA ciphertext is an incorrect size for this public key");
+         }
          secure_vector<uint8_t> out(public_modulus_bytes());
          raw_op(out, input);
          return out;

--- a/src/tests/test_rsa.cpp
+++ b/src/tests/test_rsa.cpp
@@ -318,9 +318,10 @@ class RSA_DecryptOrRandom_Tests : public Test {
          const Botan::PK_Decryptor_EME dec(private_key, rng, padding);
 
          const BigInt modulus = public_key->get_int_field("n");
+         const size_t modulus_bytes = modulus.bytes();
 
          for(size_t i = 0; i != trials; ++i) {
-            auto bad_ctext = (BigInt::from_bytes(mutate_vec(ctext, rng, false, 0)) % modulus).serialize();
+            auto bad_ctext = (BigInt::from_bytes(mutate_vec(ctext, rng, false, 0)) % modulus).serialize(modulus_bytes);
 
             auto rec = dec.decrypt_or_random(bad_ctext.data(), bad_ctext.size(), pt_len, rng);
 


### PR DESCRIPTION
This check is required by RFC 8017