### PR TITLE
Add OID::registered_name

### DIFF
--- a/src/cli/asn1.cpp
+++ b/src/cli/asn1.cpp
@@ -96,11 +96,10 @@ class OID_Info final : public Command {
          try {
             const Botan::OID oid(oid_str);
 
-            const std::string name = oid.human_name_or_empty();
-            if(name.empty()) {
-               output() << "OID " << oid_str << " is not recognized\n";
+            if(const auto name = oid.registered_name()) {
+               output() << "OID " << oid_str << " is associated with " << *name << "\n";
             } else {
-               output() << "OID " << oid_str << " is associated with " << name << "\n";
+               output() << "OID " << oid_str << " is not recognized\n";
             }
 
             return;

--- a/src/cli/pk_crypt.cpp
+++ b/src/cli/pk_crypt.cpp
@@ -135,8 +135,8 @@ class PK_Decrypt final : public Command {
             return set_return_code(1);
          }
 
-         const std::string aead_algo = aead_oid.human_name_or_empty();
-         if(aead_algo.empty()) {
+         const auto aead_algo = aead_oid.registered_name();
+         if(!aead_algo.has_value()) {
             error_output() << "Ciphertext was encrypted with an unknown algorithm";
             return set_return_code(1);
          }
@@ -149,9 +149,9 @@ class PK_Decrypt final : public Command {
          Botan::AlgorithmIdentifier oaep_hash_id;
          Botan::BER_Decoder(pk_alg_id.parameters(), Botan::BER_Decoder::Limits::DER()).decode(oaep_hash_id);
 
-         const std::string oaep_hash = oaep_hash_id.oid().human_name_or_empty();
+         const auto oaep_hash = oaep_hash_id.oid().registered_name();
 
-         if(oaep_hash.empty()) {
+         if(!oaep_hash.has_value()) {
             error_output() << "Unknown hash function used with OAEP, OID " << oaep_hash_id.oid().to_string() << "\n";
             return set_return_code(1);
          }
@@ -162,11 +162,11 @@ class PK_Decrypt final : public Command {
          }
 
          std::unique_ptr<Botan::AEAD_Mode> aead =
-            Botan::AEAD_Mode::create_or_throw(aead_algo, Botan::Cipher_Dir::Decryption);
+            Botan::AEAD_Mode::create_or_throw(*aead_algo, Botan::Cipher_Dir::Decryption);
 
          const size_t expected_keylen = aead->key_spec().maximum_keylength();
 
-         const Botan::PK_Decryptor_EME dec(*key, rng(), "OAEP(" + oaep_hash + ")");
+         const Botan::PK_Decryptor_EME dec(*key, rng(), "OAEP(" + *oaep_hash + ")");
 
          const Botan::secure_vector<uint8_t> file_key =
             dec.decrypt_or_random(encrypted_key.data(), encrypted_key.size(), expected_keylen, rng());

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -291,6 +291,12 @@ class BOTAN_PUBLIC_API(2, 0) OID final : public ASN1_Object {
       std::string human_name_or_empty() const;
 
       /**
+      * If there is a known name associated with this OID, return that.
+      * Otherwise return nullopt.
+      */
+      std::optional<std::string> registered_name() const;
+
+      /**
       * Return true if the OID in *this is registered in the internal
       * set of constants as a known OID.
       */

--- a/src/lib/asn1/asn1_oid.cpp
+++ b/src/lib/asn1/asn1_oid.cpp
@@ -135,19 +135,23 @@ std::string OID::to_string() const {
 }
 
 std::string OID::to_formatted_string() const {
-   std::string s = this->human_name_or_empty();
-   if(!s.empty()) {
-      return s;
+   if(auto name = this->registered_name()) {
+      return *name;
+   } else {
+      return this->to_string();
    }
-   return this->to_string();
 }
 
 std::string OID::human_name_or_empty() const {
+   return this->registered_name().value_or("");
+}
+
+std::optional<std::string> OID::registered_name() const {
    return OID_Map::global_registry().oid2str(*this);
 }
 
 bool OID::registered_oid() const {
-   return !human_name_or_empty().empty();
+   return this->registered_name().has_value();
 }
 
 bool OID::matches(std::initializer_list<uint32_t> other) const {

--- a/src/lib/asn1/asn1_print.cpp
+++ b/src/lib/asn1/asn1_print.cpp
@@ -142,13 +142,12 @@ void ASN1_Formatter::decode(std::ostream& output, BER_Decoder& decoder, size_t l
          OID oid;
          data.decode(oid);
 
-         const std::string name = oid.human_name_or_empty();
          const std::string oid_str = oid.to_string();
 
-         if(name.empty()) {
-            output << format(type_tag, class_tag, level, length, oid_str);
+         if(const auto name = oid.registered_name()) {
+            output << format(type_tag, class_tag, level, length, fmt("{} [{}]", *name, oid_str));
          } else {
-            output << format(type_tag, class_tag, level, length, fmt("{} [{}]", name, oid_str));
+            output << format(type_tag, class_tag, level, length, oid_str);
          }
       } else if(type_tag == ASN1_Type::Integer || type_tag == ASN1_Type::Enumerated) {
          BigInt number;

--- a/src/lib/asn1/oid_map.cpp
+++ b/src/lib/asn1/oid_map.cpp
@@ -19,6 +19,10 @@ OID_Map& OID_Map::global_registry() {
 }
 
 void OID_Map::add_oid(const OID& oid, std::string_view str) {
+   if(str.empty()) {
+      throw Invalid_Argument("Cannot register an empty name for an OID");
+   }
+
    if(auto name = lookup_static_oid(oid)) {
       if(*name != str) {
          throw Invalid_State("Cannot register two different names to a single OID");
@@ -66,7 +70,7 @@ void OID_Map::add_oid2str(const OID& oid, std::string_view str) {
    }
 }
 
-std::string OID_Map::oid2str(const OID& oid) {
+std::optional<std::string> OID_Map::oid2str(const OID& oid) {
    if(auto name = lookup_static_oid(oid)) {
       return std::string(*name);
    }
@@ -78,7 +82,7 @@ std::string OID_Map::oid2str(const OID& oid) {
       return i->second;
    }
 
-   return "";
+   return {};
 }
 
 OID OID_Map::str2oid(std::string_view str) {

--- a/src/lib/asn1/oid_map.h
+++ b/src/lib/asn1/oid_map.h
@@ -26,7 +26,7 @@ class OID_Map final {
       // TODO(Botan4) remove this function when oids.h is removed
       void add_oid2str(const OID& oid, std::string_view str);
 
-      std::string oid2str(const OID& oid);
+      std::optional<std::string> oid2str(const OID& oid);
 
       OID str2oid(std::string_view str);
 

--- a/src/lib/asn1/oids.h
+++ b/src/lib/asn1/oids.h
@@ -36,8 +36,8 @@ BOTAN_DEPRECATED("Use OID::register_oid") inline void add_oidstr(const char* oid
 * @param oid the OID to look up
 * @return name associated with this OID, or an empty string
 */
-BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string oid2str_or_empty(const OID& oid) {
-   return oid.human_name_or_empty();
+BOTAN_DEPRECATED("Use OID::registered_name") inline std::string oid2str_or_empty(const OID& oid) {
+   return oid.registered_name().value_or("");
 }
 
 /**
@@ -50,15 +50,15 @@ BOTAN_DEPRECATED("Use OID::from_name") inline OID str2oid_or_empty(std::string_v
    return OID::from_name(name).value_or(OID());
 }
 
-BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string oid2str_or_throw(const OID& oid) {
-   std::string s = oid.human_name_or_empty();
-   if(s.empty()) {
+BOTAN_DEPRECATED("Use OID::registered_name") inline std::string oid2str_or_throw(const OID& oid) {
+   if(const auto name = oid.registered_name()) {
+      return *name;
+   } else {
       throw Lookup_Error("No name associated with OID " + oid.to_string());
    }
-   return s;
 }
 
-BOTAN_DEPRECATED("Use OID::human_name_or_empty") inline std::string lookup(const OID& oid) {
+BOTAN_DEPRECATED("Use OID::registered_name") inline std::string lookup(const OID& oid) {
    return oid.human_name_or_empty();
 }
 

--- a/src/lib/prov/tpm2/tpm2_algo_mappings.h
+++ b/src/lib/prov/tpm2/tpm2_algo_mappings.h
@@ -241,7 +241,7 @@ namespace Botan::TPM2 {
    // Currently, tpm2-tss does not include support for Brainpool curves or 25519/448.
    // Once the corresponding PR (https://github.com/tpm2-software/tpm2-tss/pull/2897) is merged and released,
    // this function should be updated.
-   const std::string curve_name = curve_oid.to_formatted_string();
+   const auto curve_name = curve_oid.registered_name();
    if(curve_name == "secp192r1") {
       return TPM2_ECC_NIST_P192;
    } else if(curve_name == "secp224r1") {

--- a/src/lib/pubkey/classic_mceliece/cmce_parameter_set.cpp
+++ b/src/lib/pubkey/classic_mceliece/cmce_parameter_set.cpp
@@ -108,7 +108,11 @@ std::string Classic_McEliece_Parameter_Set::to_string() const {
 }
 
 Classic_McEliece_Parameter_Set Classic_McEliece_Parameter_Set::from_oid(const OID& oid) {
-   return from_string(oid.to_formatted_string());
+   if(const auto name = oid.registered_name()) {
+      return from_string(*name);
+   } else {
+      throw Invalid_Argument(fmt("OID '{}' is not registered as a Classic McEliece parameter set", oid));
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
+++ b/src/lib/pubkey/dilithium/dilithium_common/dilithium.cpp
@@ -61,9 +61,17 @@ DilithiumMode::Mode dilithium_mode_from_string(std::string_view str) {
    throw Invalid_Argument(fmt("'{}' is not a valid Dilithium mode name", str));
 }
 
+DilithiumMode::Mode dilithium_mode_from_oid(const OID& oid) {
+   if(const auto name = oid.registered_name()) {
+      return dilithium_mode_from_string(*name);
+   }
+
+   throw Invalid_Argument(fmt("OID '{}' is not registered as a Dilithium/ML-DSA mode", oid));
+}
+
 }  // namespace
 
-DilithiumMode::DilithiumMode(const OID& oid) : m_mode(dilithium_mode_from_string(oid.to_formatted_string())) {}
+DilithiumMode::DilithiumMode(const OID& oid) : m_mode(dilithium_mode_from_oid(oid)) {}
 
 DilithiumMode::DilithiumMode(std::string_view str) : m_mode(dilithium_mode_from_string(str)) {}
 
@@ -342,7 +350,7 @@ std::string Dilithium_PublicKey::algo_name() const {
    //               there might be other code locations that identify Dilithium
    //               by std::string::starts_with("Dilithium-").
    //               (Above assumes that Dilithium won't be removed entirely!)
-   return (m_public->mode().is_ml_dsa()) ? std::string("ML-DSA") : object_identifier().to_formatted_string();
+   return (m_public->mode().is_ml_dsa()) ? std::string("ML-DSA") : m_public->mode().mode().to_string();
 }
 
 AlgorithmIdentifier Dilithium_PublicKey::algorithm_identifier() const {

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -71,10 +71,9 @@ EC_Group_Data::EC_Group_Data(const BigInt& p,
       DER_Encoder der(m_der_named_curve);
       der.encode(m_oid);
 
-      const std::string name = m_oid.human_name_or_empty();
-      if(!name.empty()) {
+      if(const auto name = m_oid.registered_name()) {
          // returns nullptr if unknown or not supported
-         m_pcurve = PCurve::PrimeOrderCurve::for_named_curve(name);
+         m_pcurve = PCurve::PrimeOrderCurve::for_named_curve(*name);
       }
       if(m_pcurve) {
          m_engine = EC_Group_Engine::Optimized;

--- a/src/lib/pubkey/eckcdsa/eckcdsa.cpp
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.cpp
@@ -60,17 +60,19 @@ std::unique_ptr<HashFunction> eckcdsa_signature_hash(std::string_view padding) {
 }
 
 std::unique_ptr<HashFunction> eckcdsa_signature_hash(const AlgorithmIdentifier& alg_id) {
-   const auto oid_info = split_on(alg_id.oid().to_formatted_string(), '/');
+   if(const auto name = alg_id.oid().registered_name()) {
+      const auto alg_info = split_on(*name, '/');
 
-   if(oid_info.size() != 2 || oid_info[0] != "ECKCDSA") {
-      throw Decoding_Error(fmt("Unexpected AlgorithmIdentifier OID {} in association with ECKCDSA key", alg_id.oid()));
+      if(alg_info.size() == 2 && alg_info[0] == "ECKCDSA") {
+         if(!alg_id.parameters_are_empty()) {
+            throw Decoding_Error("Unexpected non-empty AlgorithmIdentifier parameters for ECKCDSA");
+         }
+
+         return HashFunction::create_or_throw(alg_info[1]);
+      }
    }
 
-   if(!alg_id.parameters_are_empty()) {
-      throw Decoding_Error("Unexpected non-empty AlgorithmIdentifier parameters for ECKCDSA");
-   }
-
-   return HashFunction::create_or_throw(oid_info[1]);
+   throw Decoding_Error(fmt("Unexpected AlgorithmIdentifier OID {} in association with ECKCDSA key", alg_id.oid()));
 }
 
 std::vector<uint8_t> eckcdsa_prefix(const EC_AffinePoint& point, size_t hash_block_size) {

--- a/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.cpp
+++ b/src/lib/pubkey/frodokem/frodokem_common/frodo_mode.cpp
@@ -59,11 +59,19 @@ FrodoKEMMode::Mode FrodoKEM_mode_from_string(std::string_view str) {
    throw Invalid_Argument(fmt("'{}' is not a valid FrodoKEM mode name", str));
 }
 
+FrodoKEMMode::Mode FrodoKEM_mode_from_oid(const OID& oid) {
+   if(const auto name = oid.registered_name()) {
+      return FrodoKEM_mode_from_string(*name);
+   }
+
+   throw Invalid_Argument(fmt("OID '{}' is not registered as a FrodoKEM mode", oid));
+}
+
 }  // anonymous namespace
 
 FrodoKEMMode::FrodoKEMMode(Mode mode) : m_mode(mode) {}
 
-FrodoKEMMode::FrodoKEMMode(const OID& oid) : m_mode(FrodoKEM_mode_from_string(oid.to_formatted_string())) {}
+FrodoKEMMode::FrodoKEMMode(const OID& oid) : m_mode(FrodoKEM_mode_from_oid(oid)) {}
 
 FrodoKEMMode::FrodoKEMMode(std::string_view str) : m_mode(FrodoKEM_mode_from_string(str)) {}
 

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -189,21 +189,21 @@ std::string gost_hash_from_algid(const AlgorithmIdentifier& alg_id) {
       throw Decoding_Error("Unexpected non-empty AlgorithmIdentifier parameters for GOST 34.10 signature");
    }
 
-   const std::string oid_str = alg_id.oid().to_formatted_string();
-   if(oid_str == "GOST-34.10/GOST-R-34.11-94") {
-      return "GOST-R-34.11-94";
+   if(const auto name = alg_id.oid().registered_name()) {
+      if(*name == "GOST-34.10/GOST-R-34.11-94") {
+         return "GOST-R-34.11-94";
+      } else if(*name == "GOST-34.10-2012-256/Streebog-256") {
+         return "Streebog-256";
+      } else if(*name == "GOST-34.10-2012-512/Streebog-512") {
+         return "Streebog-512";
+      } else if(*name == "GOST-34.10-2012-256/SHA-256") {
+         return "SHA-256";
+      } else {
+         throw Decoding_Error(fmt("Unknown OID ({}, {}) for GOST 34.10 signatures", alg_id.oid(), *name));
+      }
+   } else {
+      throw Decoding_Error(fmt("Unknown OID ({}) for GOST 34.10 signatures", alg_id.oid()));
    }
-   if(oid_str == "GOST-34.10-2012-256/Streebog-256") {
-      return "Streebog-256";
-   }
-   if(oid_str == "GOST-34.10-2012-512/Streebog-512") {
-      return "Streebog-512";
-   }
-   if(oid_str == "GOST-34.10-2012-256/SHA-256") {
-      return "SHA-256";
-   }
-
-   throw Decoding_Error(fmt("Unknown OID ({}) for GOST 34.10 signatures", alg_id.oid()));
 }
 
 /**

--- a/src/lib/pubkey/kyber/kyber_common/kyber.cpp
+++ b/src/lib/pubkey/kyber/kyber_common/kyber.cpp
@@ -71,11 +71,19 @@ KyberMode::Mode kyber_mode_from_string(std::string_view str) {
    throw Invalid_Argument(fmt("'{}' is not a valid Kyber mode name", str));
 }
 
+KyberMode::Mode kyber_mode_from_oid(const OID& oid) {
+   if(const auto name = oid.registered_name()) {
+      return kyber_mode_from_string(*name);
+   }
+
+   throw Invalid_Argument(fmt("OID '{}' is not registered as a Kyber/ML-KEM mode", oid));
+}
+
 }  // namespace
 
 KyberMode::KyberMode(Mode mode) : m_mode(mode) {}
 
-KyberMode::KyberMode(const OID& oid) : m_mode(kyber_mode_from_string(oid.to_formatted_string())) {}
+KyberMode::KyberMode(const OID& oid) : m_mode(kyber_mode_from_oid(oid)) {}
 
 KyberMode::KyberMode(std::string_view str) : m_mode(kyber_mode_from_string(str)) {}
 

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -208,10 +208,15 @@ std::unique_ptr<Pbes2Pbkdf2Parameters> Pbes2Pbkdf2Parameters::decode(const Algor
    validate_pbes2_params(salt.size(), key_length);
    validate_params(iterations);
 
-   const std::string prf = prf_algo.oid().human_name_or_empty();
-   if(prf.empty() || !prf.starts_with("HMAC")) {
+   const std::string prf = [&]() {
+      if(const auto name = prf_algo.oid().registered_name()) {
+         if(name->starts_with("HMAC")) {
+            return *name;
+         }
+      }
+
       throw Decoding_Error(fmt("Unknown PBES2 PRF '{}'", prf_algo.oid()));
-   }
+   }();
 
    // RFC 8018 A.2 defines the PBKDF2 PRFs with NULL parameters; accept NULL or
    // absent and reject any other parameter encoding rather than ignoring it.
@@ -416,11 +421,16 @@ secure_vector<uint8_t> pbes2_decrypt(std::span<const uint8_t> key_bits,
       .end_cons()
       .verify_end();
 
-   const std::string cipher = enc_algo.oid().human_name_or_empty();
-   const auto cipher_spec = split_on(cipher, '/');
-   if(cipher_spec.size() != 2 || !known_pbes_cipher_mode(cipher_spec[1])) {
+   const std::string cipher = [&]() -> std::string {
+      if(const auto name = enc_algo.oid().registered_name()) {
+         const auto cipher_spec = split_on(*name, '/');
+         if(cipher_spec.size() == 2 && known_pbes_cipher_mode(cipher_spec[1])) {
+            return *name;
+         }
+      }
+
       throw Decoding_Error(fmt("PBES2: Unknown/invalid cipher OID {}", enc_algo.oid()));
-   }
+   }();
 
    std::vector<uint8_t> iv;
    BER_Decoder(enc_algo.parameters(), BER_Decoder::Limits::DER()).decode(iv, ASN1_Type::OctetString).verify_end();

--- a/src/lib/pubkey/pk_algs.cpp
+++ b/src/lib/pubkey/pk_algs.cpp
@@ -129,9 +129,17 @@ namespace Botan {
 
 std::unique_ptr<Public_Key> load_public_key(const AlgorithmIdentifier& alg_id,
                                             [[maybe_unused]] std::span<const uint8_t> key_bits) {
-   const std::string oid_str = alg_id.oid().to_formatted_string();
-   const std::vector<std::string> alg_info = split_on(oid_str, '/');
-   const std::string_view alg_name = alg_info[0];
+   const std::string alg_name = [&]() -> std::string {
+      if(const auto name = alg_id.oid().registered_name()) {
+         const std::vector<std::string> alg_info = split_on(*name, '/');
+         if(!alg_info.empty()) {
+            return alg_info[0];
+         }
+      }
+
+      throw Decoding_Error(
+         fmt("Public key decoding failed, no algorithm associated with {}", alg_id.oid().to_string()));
+   }();
 
 #if defined(BOTAN_HAS_RSA)
    if(alg_name == "RSA") {
@@ -288,9 +296,17 @@ std::unique_ptr<Public_Key> load_public_key(const AlgorithmIdentifier& alg_id,
 
 std::unique_ptr<Private_Key> load_private_key(const AlgorithmIdentifier& alg_id,
                                               [[maybe_unused]] std::span<const uint8_t> key_bits) {
-   const std::string oid_str = alg_id.oid().to_formatted_string();
-   const std::vector<std::string> alg_info = split_on(oid_str, '/');
-   const std::string_view alg_name = alg_info[0];
+   const std::string alg_name = [&]() -> std::string {
+      if(const auto name = alg_id.oid().registered_name()) {
+         const std::vector<std::string> alg_info = split_on(*name, '/');
+         if(!alg_info.empty()) {
+            return alg_info[0];
+         }
+      }
+
+      throw Decoding_Error(
+         fmt("Private key decoding failed, no algorithm associated with {}", alg_id.oid().to_string()));
+   }();
 
 #if defined(BOTAN_HAS_RSA)
    if(alg_name == "RSA") {

--- a/src/lib/pubkey/pk_ops.cpp
+++ b/src/lib/pubkey/pk_ops.cpp
@@ -170,7 +170,13 @@ std::string PK_Ops::Verification_with_Hash::hash_function() const {
 PK_Ops::Verification_with_Hash::Verification_with_Hash(const AlgorithmIdentifier& alg_id,
                                                        std::string_view pk_algo,
                                                        bool allow_null_parameters) {
-   const auto oid_info = split_on(alg_id.oid().to_formatted_string(), '/');
+   const auto oid_name = alg_id.oid().registered_name();
+   if(!oid_name) {
+      throw Decoding_Error(
+         fmt("Unexpected AlgorithmIdentifier OID {} in association with {} key", alg_id.oid(), pk_algo));
+   }
+
+   const auto oid_info = split_on(*oid_name, '/');
 
    if(oid_info.size() != 2 || oid_info[0] != pk_algo) {
       throw Decoding_Error(

--- a/src/lib/pubkey/pkcs8.cpp
+++ b/src/lib/pubkey/pkcs8.cpp
@@ -86,7 +86,7 @@ secure_vector<uint8_t> PKCS8_decode(DataSource& source,
 
    try {
       if(is_encrypted) {
-         if(pbe_alg_id.oid().to_formatted_string() != "PBE-PKCS5v20") {
+         if(pbe_alg_id.oid().registered_name() != "PBE-PKCS5v20") {
             throw PKCS8_Exception(fmt("Unknown PBE type {}", pbe_alg_id.oid()));
          }
 
@@ -304,12 +304,11 @@ std::unique_ptr<Private_Key> load_key(DataSource& source,
    AlgorithmIdentifier alg_id;
    secure_vector<uint8_t> pkcs8_key = PKCS8_decode(source, get_pass, alg_id, is_encrypted);
 
-   const std::string alg_name = alg_id.oid().human_name_or_empty();
-   if(alg_name.empty()) {
+   if(const auto alg_name = alg_id.oid().registered_name()) {
+      return load_private_key(alg_id, pkcs8_key);
+   } else {
       throw PKCS8_Exception(fmt("Unknown algorithm OID {}", alg_id.oid()));
    }
-
-   return load_private_key(alg_id, pkcs8_key);
 }
 
 }  // namespace

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -168,7 +168,7 @@ RSA_PublicKey::RSA_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const 
    // reasons make that difficult to enforce, so absent is also accepted.
    //
    // This only checks rsaEncryption; PSS/OAEP key identifiers have their own parameter encoding
-   if(alg_id.oid().to_formatted_string() == "RSA" && !alg_id.parameters_are_null_or_empty()) {
+   if(alg_id.oid().registered_name() == "RSA" && !alg_id.parameters_are_null_or_empty()) {
       throw Decoding_Error("Unexpected parameters for RSA public key");
    }
 
@@ -280,7 +280,7 @@ void RSA_PrivateKey::init(BigInt&& d, BigInt&& p, BigInt&& q, BigInt&& d1, BigIn
 }
 
 RSA_PrivateKey::RSA_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) {
-   if(alg_id.oid().to_formatted_string() == "RSA" && !alg_id.parameters_are_null_or_empty()) {
+   if(alg_id.oid().registered_name() == "RSA" && !alg_id.parameters_are_null_or_empty()) {
       throw Decoding_Error("Unexpected parameters for RSA private key");
    }
 
@@ -850,7 +850,12 @@ std::unique_ptr<PK_Ops::Verification> RSA_PublicKey::create_verification_op(std:
 namespace {
 
 std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
-   const auto sig_info = split_on(alg_id.oid().to_formatted_string(), '/');
+   const auto oid_name = alg_id.oid().registered_name();
+   if(!oid_name) {
+      throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
+   }
+
+   const auto sig_info = split_on(*oid_name, '/');
 
    if(sig_info.empty() || sig_info.size() != 2 || sig_info[0] != "RSA") {
       throw Decoding_Error("Unknown AlgorithmIdentifier for RSA X.509 signatures");
@@ -874,14 +879,14 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
 
       // hash_algo must be SHA1, SHA2-224, SHA2-256, SHA2-384 or SHA2-512
       // We also support SHA-3 (is also supported by e.g. OpenSSL and bouncycastle)
-      const std::string hash_algo = pss_params.hash_function();
+      const auto hash_algo = pss_params.hash_algid().oid().registered_name();
       if(hash_algo != "SHA-1" && hash_algo != "SHA-224" && hash_algo != "SHA-256" && hash_algo != "SHA-384" &&
          hash_algo != "SHA-512" && hash_algo != "SHA-3(224)" && hash_algo != "SHA-3(256)" &&
          hash_algo != "SHA-3(384)" && hash_algo != "SHA-3(512)") {
          throw Decoding_Error("Unacceptable hash for PSS signatures");
       }
 
-      if(pss_params.mgf_function() != "MGF1") {
+      if(pss_params.mgf_algid().oid().registered_name() != "MGF1") {
          throw Decoding_Error("Unacceptable MGF for PSS signatures");
       }
 
@@ -895,7 +900,7 @@ std::string parse_rsa_signature_algorithm(const AlgorithmIdentifier& alg_id) {
          throw Decoding_Error("Unacceptable trailer field for PSS signatures");
       }
 
-      padding += fmt("({},MGF1,{})", hash_algo, pss_params.salt_length());
+      padding += fmt("({},MGF1,{})", *hash_algo, pss_params.salt_length());
    }
 
    return padding;

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_parameters.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_parameters.cpp
@@ -398,7 +398,11 @@ std::string Sphincs_Parameters::to_string() const {
 }
 
 Sphincs_Parameters Sphincs_Parameters::create(const OID& oid) {
-   return Sphincs_Parameters::create(oid.to_formatted_string());
+   if(const auto name = oid.registered_name()) {
+      return Sphincs_Parameters::create(*name);
+   }
+
+   throw Lookup_Error(fmt("No SLH-DSA (or SPHINCS+) parameter registered for OID {}", oid));
 }
 
 OID Sphincs_Parameters::object_identifier() const {

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -42,7 +42,7 @@ bool CertID::is_id_for(const X509_Certificate& issuer, const X509_Certificate& s
          return false;
       }
 
-      const std::string hash_algo = m_hash_id.oid().to_formatted_string();
+      const auto hash_algo = m_hash_id.oid().registered_name();
 
       /*
       RFC 6960 4.1.1

--- a/src/tests/test_oid.cpp
+++ b/src/tests/test_oid.cpp
@@ -48,6 +48,8 @@ Test::Result test_OID_to_string() {
    Test::Result result("OID::to_string");
 
    result.test_str_eq("OID::to_string behaves as we expect", oid.to_string(), "1.2.1000.1001.1002000");
+   result.test_str_eq(
+      "OID::to_formatted_string falls back to dotted decimal", oid.to_formatted_string(), oid.to_string());
 
    return result;
 }
@@ -64,7 +66,7 @@ Test::Result test_oid_registration() {
 
    result.test_is_true("named OID found", Botan::OID::from_name(name).has_value());
 
-   result.test_str_eq("name of OID matches expected", oid.to_formatted_string(), name);
+   result.test_opt_str_eq("name of OID matches expected", oid.registered_name(), name);
 
    return result;
 }
@@ -82,7 +84,7 @@ Test::Result test_add_and_lookup() {
    Botan::OID::register_oid(oid, name);
 
    result.test_is_true("named OID found", Botan::OID::from_name(name).value_or(Botan::OID()) == oid);
-   result.test_str_eq("name of OID matches expected", oid.to_formatted_string(), name);
+   result.test_opt_str_eq("name of OID matches expected", oid.registered_name(), name);
 
    // completely redundant, nothing happens:
    Botan::OID::register_oid(oid, name);
@@ -96,9 +98,9 @@ Test::Result test_add_and_lookup() {
    // name->oid map is unchanged:
    result.test_is_true("named OID found after second insert",
                        Botan::OID::from_name(name).value_or(Botan::OID()) == oid);
-   result.test_str_eq("name of OID matches expected", oid.to_formatted_string(), name);
+   result.test_opt_str_eq("name of OID matches expected", oid.registered_name(), name);
    // now second OID maps back to the string as expected:
-   result.test_str_eq("name of OID matches expected", oid2.to_formatted_string(), name);
+   result.test_opt_str_eq("name of OID matches expected", oid2.registered_name(), name);
 
    try {
       Botan::OID::register_oid(oid2, name2);
@@ -106,6 +108,11 @@ Test::Result test_add_and_lookup() {
    } catch(Botan::Invalid_State&) {
       result.test_success("Registration of second name to the same OID fails");
    }
+
+   const Botan::OID oid3("1.3.6.1.4.1.25258.1001.3");
+   result.test_throws<Botan::Invalid_Argument>("Registration of an empty name is rejected",
+                                               [&]() { Botan::OID::register_oid(oid3, ""); });
+   result.test_is_false("OID with rejected empty name remains unregistered", oid3.registered_oid());
 
    return result;
 }

--- a/src/tests/tests.cpp
+++ b/src/tests/tests.cpp
@@ -455,6 +455,20 @@ bool Test::Result::test_opt_u64_eq(std::string_view what,
    }
 }
 
+bool Test::Result::test_opt_str_eq(std::string_view what,
+                                   std::optional<std::string> produced,
+                                   std::optional<std::string> expected) {
+   if(produced.has_value() and !expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced value {} but nullopt was expected", what, *produced));
+   } else if(!produced.has_value() && expected.has_value()) {
+      return test_failure(Botan::fmt("Assertion {} produced nullopt but {} was expected", what, *expected));
+   } else if(produced.has_value() && expected.has_value()) {
+      return test_str_eq(what, *produced, *expected);
+   } else {
+      return test_success();
+   }
+}
+
 #if defined(BOTAN_HAS_BIGINT)
 bool Test::Result::test_bn_eq(std::string_view what, const BigInt& produced, const BigInt& expected) {
    if(produced == expected) {

--- a/src/tests/tests.h
+++ b/src/tests/tests.h
@@ -361,6 +361,10 @@ class Test {
                                  std::optional<uint64_t> produced,
                                  std::optional<uint64_t> expected);
 
+            bool test_opt_str_eq(std::string_view what,
+                                 std::optional<std::string> produced,
+                                 std::optional<std::string> expected);
+
 #if defined(BOTAN_HAS_BIGINT)
             /* Test predicates for BigInt */
             bool test_bn_eq(std::string_view what, const BigInt& produced, const BigInt& expected);

--- a/src/tests/unit_ecdsa.cpp
+++ b/src/tests/unit_ecdsa.cpp
@@ -37,8 +37,8 @@ Test::Result test_decode_ecdsa_X509() {
       try {
          const Botan::X509_Certificate cert(Test::data_file("x509/ecc/CSCA.CSCA.csca-germany.1.crt"));
 
-         result.test_str_eq(
-            "correct signature oid", cert.signature_algorithm().oid().to_formatted_string(), "ECDSA/SHA-224");
+         result.test_opt_str_eq(
+            "correct signature oid", cert.signature_algorithm().oid().registered_name(), "ECDSA/SHA-224");
 
          result.test_bin_eq("serial number", cert.serial_number(), std::vector<uint8_t>{1});
          result.test_bin_eq("authority key id", cert.authority_key_id(), cert.subject_key_id());

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -877,16 +877,16 @@ Test::Result test_padding_config() {
    opt.CA_key();
 
    const Botan::X509_Certificate ca_cert_def = Botan::X509::create_self_signed_cert(opt, (*sk), "SHA-512", *rng);
-   test_result.test_str_eq("CA certificate signature algorithm (default)",
-                           ca_cert_def.signature_algorithm().oid().to_formatted_string(),
-                           "RSA/PKCS1v15(SHA-512)");
+   test_result.test_opt_str_eq("CA certificate signature algorithm (default)",
+                               ca_cert_def.signature_algorithm().oid().registered_name(),
+                               "RSA/PKCS1v15(SHA-512)");
 
    // Create X509 CA certificate; RSA-PSS is explicitly set
    opt.set_padding_scheme("PSSR");
    const Botan::X509_Certificate ca_cert_exp = Botan::X509::create_self_signed_cert(opt, (*sk), "SHA-512", *rng);
-   test_result.test_str_eq("CA certificate signature algorithm (explicit)",
-                           ca_cert_exp.signature_algorithm().oid().to_formatted_string(),
-                           "RSA/PSS");
+   test_result.test_opt_str_eq("CA certificate signature algorithm (explicit)",
+                               ca_cert_exp.signature_algorithm().oid().registered_name(),
+                               "RSA/PSS");
 
          #if defined(BOTAN_HAS_EMSA_X931)
    // Try to set a padding scheme that is not supported for signing with the given key type
@@ -902,9 +902,9 @@ Test::Result test_padding_config() {
    }
          #endif
 
-   test_result.test_str_eq("CA certificate signature algorithm (explicit)",
-                           ca_cert_exp.signature_algorithm().oid().to_formatted_string(),
-                           "RSA/PSS");
+   test_result.test_opt_str_eq("CA certificate signature algorithm (explicit)",
+                               ca_cert_exp.signature_algorithm().oid().registered_name(),
+                               "RSA/PSS");
 
    const Botan::X509_Time not_before = from_date(-1, 1, 1);
    const Botan::X509_Time not_after = from_date(2, 1, 2);
@@ -913,8 +913,8 @@ Test::Result test_padding_config() {
    Botan::X509_Cert_Options req_opt("endpoint");
    req_opt.set_padding_scheme("PSS(SHA-512,MGF1,64)");
    const Botan::PKCS10_Request end_req = Botan::X509::create_cert_req(req_opt, (*sk), "SHA-512", *rng);
-   test_result.test_str_eq(
-      "Certificate request signature algorithm", end_req.signature_algorithm().oid().to_formatted_string(), "RSA/PSS");
+   test_result.test_opt_str_eq(
+      "Certificate request signature algorithm", end_req.signature_algorithm().oid().registered_name(), "RSA/PSS");
 
    // Create X509 CA object: will fail as the chosen hash functions differ
    try {
@@ -930,26 +930,26 @@ Test::Result test_padding_config() {
    // Create X509 CA object: its signer will use the padding scheme from the CA certificate, i.e. PKCS1v15
    const Botan::X509_CA ca_def(ca_cert_def, (*sk), "SHA-512", *rng);
    const Botan::X509_Certificate end_cert_pkcs1 = ca_def.sign_request(end_req, *rng, not_before, not_after);
-   test_result.test_str_eq("End certificate signature algorithm",
-                           end_cert_pkcs1.signature_algorithm().oid().to_formatted_string(),
-                           "RSA/PKCS1v15(SHA-512)");
+   test_result.test_opt_str_eq("End certificate signature algorithm",
+                               end_cert_pkcs1.signature_algorithm().oid().registered_name(),
+                               "RSA/PKCS1v15(SHA-512)");
 
    // Create X509 CA object: its signer will use the explicitly configured padding scheme, which is different from the CA certificate's scheme
    const Botan::X509_CA ca_diff(ca_cert_def, (*sk), "SHA-512", "PSS", *rng);
    const Botan::X509_Certificate end_cert_diff_pss = ca_diff.sign_request(end_req, *rng, not_before, not_after);
-   test_result.test_str_eq("End certificate signature algorithm",
-                           end_cert_diff_pss.signature_algorithm().oid().to_formatted_string(),
-                           "RSA/PSS");
+   test_result.test_opt_str_eq("End certificate signature algorithm",
+                               end_cert_diff_pss.signature_algorithm().oid().registered_name(),
+                               "RSA/PSS");
 
    // Create X509 CA object: its signer will use the explicitly configured padding scheme, which is identical to the CA certificate's scheme
    const Botan::X509_CA ca_exp(ca_cert_exp, (*sk), "SHA-512", "PSS(SHA-512,MGF1,64)", *rng);
    const Botan::X509_Certificate end_cert_pss = ca_exp.sign_request(end_req, *rng, not_before, not_after);
-   test_result.test_str_eq(
-      "End certificate signature algorithm", end_cert_pss.signature_algorithm().oid().to_formatted_string(), "RSA/PSS");
+   test_result.test_opt_str_eq(
+      "End certificate signature algorithm", end_cert_pss.signature_algorithm().oid().registered_name(), "RSA/PSS");
 
    // Check CRL signature algorithm
    const Botan::X509_CRL crl = ca_exp.new_crl(*rng);
-   test_result.test_str_eq("CRL signature algorithm", crl.signature_algorithm().oid().to_formatted_string(), "RSA/PSS");
+   test_result.test_opt_str_eq("CRL signature algorithm", crl.signature_algorithm().oid().registered_name(), "RSA/PSS");
 
    // sanity check for verification, the heavy lifting is done in the other unit tests
    const Botan::Certificate_Store_In_Memory trusted(ca_exp.ca_certificate());


### PR DESCRIPTION
This is cleaner than the old name-or-empty implementation.

Avoid using to_formatted_string in cases where we can't effectively use the dotted-decimal fallback.