### PR TITLE
Precheck length in raw variants of PSS and PKCS signature padding

### DIFF
--- a/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pkcs1/pkcs1_sig_padding.cpp
@@ -108,11 +108,13 @@ PKCS1v15_Raw_SignaturePaddingScheme::PKCS1v15_Raw_SignaturePaddingScheme(std::st
 }
 
 void PKCS1v15_Raw_SignaturePaddingScheme::update(const uint8_t input[], size_t length) {
-   m_message += std::make_pair(input, length);
-   // A sanity check to prevent someone from accidentally feeding an entire message
-   // into PKCS1v15(Raw), which would have to be buffered in memory
-   if(m_message.size() > 16384 / 8) {
-      throw Invalid_Argument("PKCS1v15(Raw) message too long");
+   if(length > 0) {
+      // A sanity check to prevent someone from accidentally feeding an entire message
+      // into PKCS1v15(Raw), which would have to be buffered in memory
+      if(m_message.size() + length > 16384 / 8) {
+         throw Invalid_Argument("PKCS1v15(Raw) message too long");
+      }
+      m_message.insert(m_message.end(), input, input + length);
    }
 }
 

--- a/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
+++ b/src/lib/pk_pad/sig_padding/emsa_pssr/pssr.cpp
@@ -203,10 +203,11 @@ PSS_Raw::PSS_Raw(std::unique_ptr<HashFunction> hash, size_t salt_size) :
 * PSS_Raw Update Operation
 */
 void PSS_Raw::update(const uint8_t input[], size_t length) {
-   m_msg.insert(m_msg.end(), input, input + length);
-
-   if(m_msg.size() > m_hash->output_length()) {
-      throw Encoding_Error("PSS_Raw: Input length exceeded hash output");
+   if(length > 0) {
+      if(m_msg.size() + length > m_hash->output_length()) {
+         throw Encoding_Error("PSS_Raw: Input length exceeded hash output");
+      }
+      m_msg.insert(m_msg.end(), input, input + length);
    }
 }
 


### PR DESCRIPTION
This would first copy the input then check the length.