### PR TITLE
Improve X509 CRL decoding checks and encoding logic

### DIFF
--- a/src/lib/x509/crl_ent.cpp
+++ b/src/lib/x509/crl_ent.cpp
@@ -70,13 +70,13 @@ bool operator!=(const CRL_Entry& a1, const CRL_Entry& a2) {
 * DER encode a CRL_Entry
 */
 void CRL_Entry::encode_into(DER_Encoder& der) const {
-   der.start_sequence()
-      .encode(BigInt::from_bytes(serial_number()))
-      .encode(expire_time())
-      .start_sequence()
-      .encode(extensions())
-      .end_cons()
-      .end_cons();
+   der.start_sequence().encode(BigInt::from_bytes(serial_number())).encode(expire_time());
+
+   if(extensions().count() > 0) {
+      der.start_sequence().encode(extensions()).end_cons();
+   }
+
+   der.end_cons();
 }
 
 /*
@@ -95,6 +95,10 @@ void CRL_Entry::decode_from(BER_Decoder& source) {
 
    if(entry.more_items()) {
       data->m_extensions.decode_from(entry, Extension_Context::CRL_Entry);
+
+      // TODO(Botan4) start checking that CRLEntry extensions is not empty
+      // Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
+
       if(const auto* ext = data->m_extensions.get_extension_object_as<Cert_Extension::CRL_ReasonCode>()) {
          data->m_reason = ext->get_reason();
       } else {

--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -900,6 +900,8 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
       */
       std::map<OID, std::pair<std::vector<uint8_t>, bool>> extensions_raw() const;
 
+      size_t count() const { return m_extension_oids.size(); }
+
       Extensions() = default;
 
       Extensions(const Extensions&) = default;

--- a/src/lib/x509/x509_crl.cpp
+++ b/src/lib/x509/x509_crl.cpp
@@ -136,6 +136,9 @@ std::unique_ptr<CRL_Data> decode_crl_body(const std::vector<uint8_t>& body, cons
       throw Decoding_Error("Unknown X.509 CRL version " + std::to_string(data->m_version));
    }
 
+   // Extensions are only defined for v2 CRLs
+   const bool supports_extensions = data->m_version > 1;
+
    AlgorithmIdentifier sig_algo_inner;
    tbs_crl.decode(sig_algo_inner);
 
@@ -172,26 +175,43 @@ std::unique_ptr<CRL_Data> decode_crl_body(const std::vector<uint8_t>& body, cons
             data->m_has_unknown_critical_extension = true;
          }
 
+         if(!supports_extensions && entry.extensions().count() > 0) {
+            throw Decoding_Error("X509 CRL included extensions in a version that doesn't support them");
+         }
+
          data->m_entries.push_back(std::move(entry));
       }
+
+      /*
+      RFC 5280 Section 5.1.2.6
+         When there are no revoked certificates, the revoked certificates list MUST be absent.
+
+      So strictly speaking we should be checking that m_entries is not empty. But practically,
+      it seems nearly all implementations accept a present-but-empty SEQUENCE as equivalent
+      to an absent one, and several major ones (including GnuTLS) will emit it. Considering
+      this situation, and the benign nature of the deviation, accept the non-conforming encoding.
+      */
+
       next = tbs_crl.get_next_object();
    }
 
    if(next.is_a(0, ASN1_Class::Constructed | ASN1_Class::ContextSpecific)) {
+      if(!supports_extensions) {
+         throw Decoding_Error("X509 CRL included extensions in a version that doesn't support them");
+      }
       BER_Decoder crl_options(next, tbs_crl.limits());
       data->m_extensions.decode_from(crl_options, Extension_Context::CRL);
       crl_options.verify_end();
-      next = tbs_crl.get_next_object();
       if(data->m_extensions.has_unknown_critical_extension()) {
          data->m_has_unknown_critical_extension = true;
       }
+
+      if(tbs_crl.get_next_object().is_set()) {
+         throw Decoding_Error("Unknown tag following extensions in CRL");
+      }
    }
 
-   if(next.is_set()) {
-      throw Decoding_Error("Unknown tag following extensions in CRL");
-   }
-
-   tbs_crl.verify_end();
+   tbs_crl.verify_end("Unexpected trailing data after CRL");
 
    // Now cache some fields from the extensions
    if(const auto* ext = data->m_extensions.get_extension_object_as<Cert_Extension::CRL_Number>()) {


### PR DESCRIPTION
Reject extensions in a v1 CRL, for which they are not defined.

~Reject a present-but-empty revoked list; RFC 5280 explicitly states this is not an acceptable encoding.~

Avoid encoding an empty extensions list for CRL entries; RFC 5280 is clear that an Extensions is always non-empty. Don't prohibit it when decoding since we ourselves violated the rule, but leave a note for the future.