### PR TITLE
Improve validation of algorithm identifiers in keys and signatures

### DIFF
--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -51,23 +51,12 @@ bool AlgorithmIdentifier::parameters_are_null() const {
    return (m_parameters.size() == 2 && (m_parameters[0] == 0x05) && (m_parameters[1] == 0x00));
 }
 
-bool operator==(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2) {
-   if(a1.oid() != a2.oid()) {
-      return false;
-   }
-
-   /*
-   * Treat NULL and empty as equivalent
-   */
-   if(a1.parameters_are_null_or_empty() && a2.parameters_are_null_or_empty()) {
-      return true;
-   }
-
-   return (a1.parameters() == a2.parameters());
+bool operator==(const AlgorithmIdentifier& x, const AlgorithmIdentifier& y) {
+   return (x.oid() == y.oid() && x.parameters() == y.parameters());
 }
 
-bool operator!=(const AlgorithmIdentifier& a1, const AlgorithmIdentifier& a2) {
-   return !(a1 == a2);
+bool operator!=(const AlgorithmIdentifier& x, const AlgorithmIdentifier& y) {
+   return !(x == y);
 }
 
 /*

--- a/src/lib/asn1/asn1_obj.h
+++ b/src/lib/asn1/asn1_obj.h
@@ -732,9 +732,6 @@ class BOTAN_PUBLIC_API(2, 0) AlgorithmIdentifier final : public ASN1_Object {
 /**
 * Compare two AlgorithmIdentifiers
 *
-* An absent parameters field and a parameters field consisting of a DER NULL are
-* treated as equivalent.
-*
 * @param x the first AlgorithmIdentifier
 * @param y the second AlgorithmIdentifier
 * @return true if x is equal to y

--- a/src/lib/asn1/pss_params.cpp
+++ b/src/lib/asn1/pss_params.cpp
@@ -76,6 +76,10 @@ void PSS_Params::decode_from(BER_Decoder& from) {
       .end_cons();
 
    BER_Decoder(m_mgf.parameters(), from.limits()).decode(m_mgf_hash).verify_end();
+
+   if(!m_hash.parameters_are_null_or_empty() || !m_mgf_hash.parameters_are_null_or_empty()) {
+      throw Decoding_Error("Unexpected parameters for PSS hash algorithm identifier");
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -186,7 +186,7 @@ class RSA_Signature_Operation final : public Signature_Operation {
          try {
             const std::string full_name = "RSA/" + padding_name;
             const OID oid = OID::from_string(full_name);
-            return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_EMPTY_PARAM);
+            return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_NULL_PARAM);
          } catch(Lookup_Error&) {}
 
          if(padding_name.starts_with("PSS(")) {

--- a/src/lib/pubkey/ecc_key/ecc_key.cpp
+++ b/src/lib/pubkey/ecc_key/ecc_key.cpp
@@ -45,6 +45,16 @@ EC_Group_Encoding default_encoding_for(const EC_Group& group) {
 
 }  // namespace
 
+const AlgorithmIdentifier& EC_PublicKey::assert_algorithm_identifier(const AlgorithmIdentifier& alg_id,
+                                                                     std::string_view alg_name) {
+   if(alg_id.oid() != OID::from_string(alg_name)) {
+      throw Decoding_Error(
+         fmt("Unexpected AlgorithmIdentifier OID {} in association with {} key", alg_id.oid(), alg_name));
+   }
+
+   return alg_id;  // NOLINT(*-return-const-ref-from-parameter)
+}
+
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
 EC_PublicKey::EC_PublicKey(const EC_Group& group, const EC_Point& pub_point) {
    auto pt = EC_AffinePoint(group, pub_point);

--- a/src/lib/pubkey/ecc_key/ecc_key.h
+++ b/src/lib/pubkey/ecc_key/ecc_key.h
@@ -134,6 +134,9 @@ class BOTAN_PUBLIC_API(2, 0) EC_PublicKey : public virtual Public_Key {
       */
       EC_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
+      static const AlgorithmIdentifier& assert_algorithm_identifier(const AlgorithmIdentifier& alg_id,
+                                                                    std::string_view alg_name);
+
       EC_PublicKey() = default;
 
       std::shared_ptr<const EC_PublicKey_Data> m_public_key;                // NOLINT(*non-private-member-variable*)

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -218,6 +218,18 @@ class ECDSA_Verification_Operation final : public PK_Ops::Verification_with_Hash
             PK_Ops::Verification_with_Hash(padding), m_group(ecdsa.domain()), m_gy_mul(ecdsa._public_ec_point()) {}
 
       ECDSA_Verification_Operation(const ECDSA_PublicKey& ecdsa, const AlgorithmIdentifier& alg_id) :
+            /*
+            * RFC 5758 Section 3.2 is clear that for ECDSA signatures the parameters field is empty
+            *
+            *    When the [ecdsa-with-SHA*] algorithm identifier appears in the algorithm
+            *    field as an AlgorithmIdentifier, the encoding MUST omit the parameters
+            *    field. That is, the AlgorithmIdentifier SHALL be a SEQUENCE of one
+            *    component, the OID [ecdsa-with-SHA*].
+            *
+            * However ECDSA is old enough and widely implemented enough that many non-conformant
+            * implementations which emit X509 signatures using an explicit NULL parameter do exist,
+            * so accept it here.
+            */
             PK_Ops::Verification_with_Hash(alg_id, "ECDSA", true),
             m_group(ecdsa.domain()),
             m_gy_mul(ecdsa._public_ec_point()) {}

--- a/src/lib/pubkey/ecdsa/ecdsa.h
+++ b/src/lib/pubkey/ecdsa/ecdsa.h
@@ -41,7 +41,7 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PublicKey : public virtual EC_PublicKey {
       * @param key_bits DER encoded public key bits
       */
       ECDSA_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PublicKey(alg_id, key_bits) {}
+            EC_PublicKey(assert_algorithm_identifier(alg_id, "ECDSA"), key_bits) {}
 
       /**
       * Recover a public key from a signature/msg pair
@@ -95,7 +95,7 @@ class BOTAN_PUBLIC_API(2, 0) ECDSA_PrivateKey final : public ECDSA_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECDSA_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PrivateKey(alg_id, key_bits) {}
+            EC_PrivateKey(assert_algorithm_identifier(alg_id, "ECDSA"), key_bits) {}
 
       /**
       * Create a private key from a given secret @p x

--- a/src/lib/pubkey/ecgdsa/ecgdsa.h
+++ b/src/lib/pubkey/ecgdsa/ecgdsa.h
@@ -39,7 +39,7 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PublicKey : public virtual EC_PublicKey {
       * @param key_bits DER encoded public key bits
       */
       ECGDSA_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PublicKey(alg_id, key_bits) {}
+            EC_PublicKey(assert_algorithm_identifier(alg_id, "ECGDSA"), key_bits) {}
 
       /**
       * Get this keys algorithm name.
@@ -79,7 +79,7 @@ class BOTAN_PUBLIC_API(2, 0) ECGDSA_PrivateKey final : public ECGDSA_PublicKey,
       * @param key_bits ECPrivateKey bits
       */
       ECGDSA_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PrivateKey(alg_id, key_bits, true) {}
+            EC_PrivateKey(assert_algorithm_identifier(alg_id, "ECGDSA"), key_bits, true) {}
 
       /**
       * Create a private key from a given secret @p x

--- a/src/lib/pubkey/eckcdsa/eckcdsa.h
+++ b/src/lib/pubkey/eckcdsa/eckcdsa.h
@@ -39,7 +39,7 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PublicKey : public virtual EC_PublicKey {
       * @param key_bits DER encoded public key bits
       */
       ECKCDSA_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PublicKey(alg_id, key_bits) {}
+            EC_PublicKey(assert_algorithm_identifier(alg_id, "ECKCDSA"), key_bits) {}
 
       /**
       * Get this keys algorithm name.
@@ -78,7 +78,7 @@ class BOTAN_PUBLIC_API(2, 0) ECKCDSA_PrivateKey final : public ECKCDSA_PublicKey
       * @param key_bits ECPrivateKey bits
       */
       ECKCDSA_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PrivateKey(alg_id, key_bits, true) {}
+            EC_PrivateKey(assert_algorithm_identifier(alg_id, "ECKCDSA"), key_bits, true) {}
 
       /**
       * Create a private key from a given secret @p x

--- a/src/lib/pubkey/gost_3410/gost_3410.cpp
+++ b/src/lib/pubkey/gost_3410/gost_3410.cpp
@@ -27,6 +27,84 @@ EC_Group check_domain(EC_Group domain) {
    return domain;
 }
 
+bool is_gost_3410_key_oid(const OID& oid) {
+   return oid == OID::from_string("GOST-34.10") || oid == OID::from_string("GOST-34.10-2012-256") ||
+          oid == OID::from_string("GOST-34.10-2012-512");
+}
+
+const AlgorithmIdentifier& assert_gost_algorithm_identifier(const AlgorithmIdentifier& alg_id) {
+   if(!is_gost_3410_key_oid(alg_id.oid())) {
+      throw Decoding_Error(
+         fmt("Unexpected AlgorithmIdentifier OID {} in association with GOST 34.10 key", alg_id.oid()));
+   }
+
+   return alg_id;  // NOLINT(*-return-const-ref-from-parameter)
+}
+
+OID decode_gost_key_parameters(const AlgorithmIdentifier& alg_id) {
+   OID ecc_param_id;
+
+   auto outer = BER_Decoder(alg_id.parameters(), BER_Decoder::Limits::DER());
+   auto params = outer.start_sequence();
+   params.decode(ecc_param_id);
+
+   if(params.more_items()) {
+      OID digest_param_id;
+      params.decode(digest_param_id);
+
+      if(alg_id.oid() == OID::from_string("GOST-34.10-2012-256") &&
+         digest_param_id != OID::from_string("Streebog-256")) {
+         throw Decoding_Error("Unexpected digest parameters for GOST-34.10-2012-256 public key");
+      }
+
+      if(alg_id.oid() == OID::from_string("GOST-34.10-2012-512") &&
+         digest_param_id != OID::from_string("Streebog-512")) {
+         throw Decoding_Error("Unexpected digest parameters for GOST-34.10-2012-512 public key");
+      }
+   }
+
+   if(params.more_items()) {
+      if(alg_id.oid() != OID::from_string("GOST-34.10")) {
+         throw Decoding_Error("Unexpected extra parameters for GOST-34.10-2012 public key");
+      }
+
+      OID encryption_param_id;
+      params.decode(encryption_param_id);
+   }
+
+   params.verify_end();
+   outer.verify_end();
+
+   return ecc_param_id;
+}
+
+void check_gost_key_oid_matches_group(const OID& key_oid, const EC_Group& group) {
+   if(key_oid == OID::from_string("GOST-34.10-2012-256") && group.get_p_bits() != 256) {
+      throw Decoding_Error("GOST-34.10-2012-256 public key has unexpected parameters");
+   }
+
+   if(key_oid == OID::from_string("GOST-34.10-2012-512") && group.get_p_bits() != 512) {
+      throw Decoding_Error("GOST-34.10-2012-512 public key has unexpected parameters");
+   }
+}
+
+AlgorithmIdentifier gost_private_key_alg_id(const AlgorithmIdentifier& alg_id) {
+   assert_gost_algorithm_identifier(alg_id);
+
+   OID ecc_param_id;
+   BER_Decoder decoder(alg_id.parameters(), BER_Decoder::Limits::DER());
+   if(decoder.peek_next_object().type_tag() == ASN1_Type::ObjectId) {
+      decoder.decode(ecc_param_id).verify_end();
+   } else {
+      ecc_param_id = decode_gost_key_parameters(alg_id);
+   }
+
+   auto group = check_domain(EC_Group::from_OID(ecc_param_id));
+   check_gost_key_oid_matches_group(alg_id.oid(), group);
+
+   return AlgorithmIdentifier(alg_id.oid(), group.DER_encode());
+}
+
 }  // namespace
 
 std::optional<size_t> GOST_3410_PublicKey::_signature_element_size_for_DER_encoding() const {
@@ -71,17 +149,12 @@ AlgorithmIdentifier GOST_3410_PublicKey::algorithm_identifier() const {
 }
 
 GOST_3410_PublicKey::GOST_3410_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) {
-   OID ecc_param_id;
+   assert_gost_algorithm_identifier(alg_id);
 
-   // The parameters also includes hash and cipher OIDs
-   BER_Decoder(alg_id.parameters(), BER_Decoder::Limits::DER())
-      .start_sequence()
-      .decode(ecc_param_id)
-      .discard_remaining()
-      .end_cons()
-      .verify_end();
+   const OID ecc_param_id = decode_gost_key_parameters(alg_id);
 
    auto group = check_domain(EC_Group::from_OID(ecc_param_id));
+   check_gost_key_oid_matches_group(alg_id.oid(), group);
 
    std::vector<uint8_t> bits;
    BER_Decoder(key_bits, BER_Decoder::Limits::DER()).decode(bits, ASN1_Type::OctetString).verify_end();
@@ -110,6 +183,9 @@ GOST_3410_PrivateKey::GOST_3410_PrivateKey(RandomNumberGenerator& rng, EC_Group 
 
 GOST_3410_PrivateKey::GOST_3410_PrivateKey(RandomNumberGenerator& rng, const EC_Group& domain, const BigInt& x) :
       EC_PrivateKey(rng, check_domain(domain), x) {}
+
+GOST_3410_PrivateKey::GOST_3410_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
+      EC_PrivateKey(gost_private_key_alg_id(alg_id), key_bits) {}
 
 std::unique_ptr<Public_Key> GOST_3410_PrivateKey::public_key() const {
    return std::make_unique<GOST_3410_PublicKey>(domain(), _public_ec_point());

--- a/src/lib/pubkey/gost_3410/gost_3410.h
+++ b/src/lib/pubkey/gost_3410/gost_3410.h
@@ -87,8 +87,7 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PrivateKey final : public GOST_3410_Publi
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits ECPrivateKey bits
       */
-      GOST_3410_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PrivateKey(alg_id, key_bits) {}
+      GOST_3410_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
       /**
       * Create a private key from a given secret @p x
@@ -116,7 +115,7 @@ class BOTAN_PUBLIC_API(2, 0) GOST_3410_PrivateKey final : public GOST_3410_Publi
       std::unique_ptr<Public_Key> public_key() const override;
 
       AlgorithmIdentifier pkcs8_algorithm_identifier() const override {
-         return EC_PublicKey::algorithm_identifier();  // NOLINT(bugprone-parent-virtual-call)
+         return GOST_3410_PublicKey::algorithm_identifier();
       }
 
       std::unique_ptr<PK_Ops::Signature> create_signature_op(RandomNumberGenerator& rng,

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -682,7 +682,8 @@ AlgorithmIdentifier RSA_Signature_Operation::algorithm_identifier() const {
    try {
       const std::string full_name = "RSA/" + padding_name;
       const OID oid = OID::from_string(full_name);
-      return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_EMPTY_PARAM);
+      // RFC 8017 Appendix A.2 specifies RSA signatures for most hashes use NULL parameter
+      return AlgorithmIdentifier(oid, AlgorithmIdentifier::USE_NULL_PARAM);
    } catch(Lookup_Error&) {}
 
    if(padding_name.starts_with("PSS(")) {

--- a/src/lib/pubkey/sm2/sm2.cpp
+++ b/src/lib/pubkey/sm2/sm2.cpp
@@ -10,6 +10,7 @@
 
 #include <botan/ec_group.h>
 #include <botan/hash.h>
+#include <botan/internal/fmt.h>
 #include <botan/internal/keypair.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/pk_ops_impl.h>
@@ -19,6 +20,23 @@ namespace Botan {
 std::string SM2_PublicKey::algo_name() const {
    return "SM2";
 }
+
+namespace {
+
+const AlgorithmIdentifier& assert_sm2_algorithm_identifier(const AlgorithmIdentifier& alg_id) {
+   const auto alg_name = alg_id.oid().registered_name();
+   // OpenSSL uses ECDSA's OID for SM2
+   if(alg_name != "SM2" && alg_name != "SM2_Enc" && alg_name != "ECDSA") {
+      throw Decoding_Error(fmt("Unexpected AlgorithmIdentifier OID {} in association with SM2 key", alg_id.oid()));
+   }
+
+   return alg_id;  // NOLINT(*-return-const-ref-from-parameter)
+}
+
+}  // namespace
+
+SM2_PublicKey::SM2_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
+      EC_PublicKey(assert_sm2_algorithm_identifier(alg_id), key_bits) {}
 
 std::optional<size_t> SM2_PublicKey::_signature_element_size_for_DER_encoding() const {
    return domain().get_order_bytes();
@@ -50,7 +68,7 @@ bool SM2_PrivateKey::check_key(RandomNumberGenerator& rng, bool strong) const {
 }
 
 SM2_PrivateKey::SM2_PrivateKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-      EC_PrivateKey(alg_id, key_bits),
+      EC_PrivateKey(assert_sm2_algorithm_identifier(alg_id), key_bits),
       m_da_inv((this->_private_key() + EC_Scalar::one(domain())).invert()),
       m_da_inv_legacy(m_da_inv.to_bigint()) {
    if(m_da_inv.is_zero()) {

--- a/src/lib/pubkey/sm2/sm2.h
+++ b/src/lib/pubkey/sm2/sm2.h
@@ -40,8 +40,7 @@ class BOTAN_PUBLIC_API(2, 2) SM2_PublicKey : public virtual EC_PublicKey {
       * @param alg_id the X.509 algorithm identifier
       * @param key_bits DER encoded public key bits
       */
-      SM2_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits) :
-            EC_PublicKey(alg_id, key_bits) {}
+      SM2_PublicKey(const AlgorithmIdentifier& alg_id, std::span<const uint8_t> key_bits);
 
       /**
       * Get this keys algorithm name.


### PR DESCRIPTION
Some key types would for example completely ignore the OIDs in passed algorithm identifiers, on the assumption they were being called from one of the decoder factory functions. Likewise in some contexts where the algorithm identifier parameters are unused, any junk in there would be silently ignored.

Also there were some cases where either NULL or absent parameters was accepted, even though the relevant standard specifically requires one or the other.