### PR TITLE
During CRL parsing, reject if a CRL entry reason is RemoveFromCrl

### DIFF
--- a/src/lib/x509/crl_ent.cpp
+++ b/src/lib/x509/crl_ent.cpp
@@ -100,7 +100,19 @@ void CRL_Entry::decode_from(BER_Decoder& source) {
       // Extensions  ::=  SEQUENCE SIZE (1..MAX) OF Extension
 
       if(const auto* ext = data->m_extensions.get_extension_object_as<Cert_Extension::CRL_ReasonCode>()) {
-         data->m_reason = ext->get_reason();
+         const auto reason = ext->get_reason();
+
+         /*
+         * This reason code only makes sense in the context of delta CRL processing, which
+         * we do not currently support. Seeing it in a regular CRL suggests that something
+         * has gone very wrong (eg we are somehow processing a delta CRL, though that
+         * shouldn't happen since the delta CRL indicator extension should be a critical
+         * extension which we will reject.)
+         */
+         if(reason == CRL_Code::RemoveFromCrl) {
+            throw Decoding_Error("CRL entry ReasonCode extension included invalid RemoveFromCrl");
+         }
+         data->m_reason = reason;
       } else {
          data->m_reason = CRL_Code::Unspecified;
       }

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -1225,22 +1225,6 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
    result_u2 = Botan::x509_path_validate(user2_cert, restrictions, store);
    result.test_str_eq("user 1 revoked", result_u2.result_string(), revoked_str);
 
-   // RFC 5280 5.3.1: the removeFromCRL reason code MAY only appear in delta
-   // CRLs. Botan does not process delta CRLs, so a base CRL with this reason
-   // code is malformed; we keep the cert marked as revoked rather than honor
-   // the spec-violating "un-revoke" semantics.
-   revoked.clear();
-   revoked.push_back(Botan::CRL_Entry(user1_cert, Botan::CRL_Code::RemoveFromCrl));
-   const Botan::X509_CRL crl3 = ca.update_crl(crl2, revoked, rng);
-
-   store.add_crl(crl3);
-
-   result_u1 = Botan::x509_path_validate(user1_cert, restrictions, store);
-   result.test_str_eq("user 1 still revoked after RemoveFromCrl in base CRL", result_u1.result_string(), revoked_str);
-
-   result_u2 = Botan::x509_path_validate(user2_cert, restrictions, store);
-   result.test_str_eq("user 2 still revoked", result_u2.result_string(), revoked_str);
-
    return result;
 }
 


### PR DESCRIPTION
This reason code only makes sense in the context of delta CRLs, which we do not support. If seen, reject the CRL entirely rather than trying to interpret it.