### PR TITLE
[std::span] For TLS message and extension parsing and usage

### DIFF
--- a/src/lib/tls/msg_cert_status.cpp
+++ b/src/lib/tls/msg_cert_status.cpp
@@ -11,7 +11,7 @@
 
 namespace Botan::TLS {
 
-Certificate_Status::Certificate_Status(const std::vector<uint8_t>& buf, const Connection_Side /*side*/) {
+Certificate_Status::Certificate_Status(std::span<const uint8_t> buf, const Connection_Side /*side*/) {
    if(buf.size() < 5) {
       throw Decoding_Error("Invalid Certificate_Status message: too small");
    }

--- a/src/lib/tls/msg_cert_verify.cpp
+++ b/src/lib/tls/msg_cert_verify.cpp
@@ -17,7 +17,7 @@ namespace Botan::TLS {
 /*
 * Deserialize a Certificate Verify message
 */
-Certificate_Verify::Certificate_Verify(const std::vector<uint8_t>& buf) {
+Certificate_Verify::Certificate_Verify(std::span<const uint8_t> buf) {
    TLS_Data_Reader reader("CertificateVerify", buf);
 
    m_scheme = Signature_Scheme(reader.get_uint16_t());

--- a/src/lib/tls/msg_client_hello.cpp
+++ b/src/lib/tls/msg_client_hello.cpp
@@ -43,7 +43,7 @@ std::vector<uint8_t> make_hello_random(RandomNumberGenerator& rng, Callbacks& cb
    return buf;
 }
 
-Client_Hello_Internal::Client_Hello_Internal(const std::vector<uint8_t>& buf) {
+Client_Hello_Internal::Client_Hello_Internal(std::span<const uint8_t> buf) {
    /*
    Minimum possible client hello
 
@@ -287,7 +287,7 @@ const std::vector<uint8_t>& Client_Hello::cookie() const {
 Client_Hello_12_Shim::Client_Hello_12_Shim(std::unique_ptr<Client_Hello_Internal> data) :
       Client_Hello(std::move(data)) {}
 
-Client_Hello_12_Shim::Client_Hello_12_Shim(const std::vector<uint8_t>& buf) :
+Client_Hello_12_Shim::Client_Hello_12_Shim(std::span<const uint8_t> buf) :
       Client_Hello_12_Shim(std::make_unique<Client_Hello_Internal>(buf)) {}
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/msg_server_hello.cpp
+++ b/src/lib/tls/msg_server_hello.cpp
@@ -45,7 +45,7 @@ std::vector<uint8_t> make_server_hello_random(RandomNumberGenerator& rng,
    return random;
 }
 
-Server_Hello_Internal::Server_Hello_Internal(const std::vector<uint8_t>& buf) {
+Server_Hello_Internal::Server_Hello_Internal(std::span<const uint8_t> buf) {
    if(buf.size() < 38) {
       throw Decoding_Error("Server_Hello: Packet corrupted");
    }
@@ -153,7 +153,7 @@ const Extensions& Server_Hello::extensions() const {
    return m_data->extensions();
 }
 
-Server_Hello_12_Shim::Server_Hello_12_Shim(const std::vector<uint8_t>& buf) :
+Server_Hello_12_Shim::Server_Hello_12_Shim(std::span<const uint8_t> buf) :
       Server_Hello_12_Shim(std::make_unique<Server_Hello_Internal>(buf)) {}
 
 Server_Hello_12_Shim::Server_Hello_12_Shim(std::unique_ptr<Server_Hello_Internal> data) :

--- a/src/lib/tls/tls12/msg_certificate_12.cpp
+++ b/src/lib/tls/tls12/msg_certificate_12.cpp
@@ -24,15 +24,15 @@ Certificate_12::~Certificate_12() = default;
 /**
 * Create a new Certificate message
 */
-Certificate_12::Certificate_12(Handshake_IO& io, Handshake_Hash& hash, const std::vector<X509_Certificate>& cert_list) :
-      m_certs(cert_list) {
+Certificate_12::Certificate_12(Handshake_IO& io, Handshake_Hash& hash, std::vector<X509_Certificate> cert_list) :
+      m_certs(std::move(cert_list)) {
    hash.update(io.send(*this));
 }
 
 /**
 * Deserialize a Certificate message
 */
-Certificate_12::Certificate_12(const std::vector<uint8_t>& buf, const Policy& policy) {
+Certificate_12::Certificate_12(std::span<const uint8_t> buf, const Policy& policy) {
    if(buf.size() < 3) {
       throw Decoding_Error("Certificate: Message malformed");
    }

--- a/src/lib/tls/tls12/msg_certificate_req_12.cpp
+++ b/src/lib/tls/tls12/msg_certificate_req_12.cpp
@@ -59,8 +59,8 @@ uint8_t cert_type_name_to_code(std::string_view name) {
 Certificate_Request_12::Certificate_Request_12(Handshake_IO& io,
                                                Handshake_Hash& hash,
                                                const Policy& policy,
-                                               const std::vector<X509_DN>& ca_certs) :
-      m_names(ca_certs), m_cert_key_types({"RSA", "ECDSA"}) {
+                                               std::vector<X509_DN> ca_certs) :
+      m_names(std::move(ca_certs)), m_cert_key_types({"RSA", "ECDSA"}) {
    m_schemes = policy.acceptable_signature_schemes();
    // RFC 5246 7.4.4: supported_signature_algorithms<2..2^16-2>
    if(m_schemes.empty()) {
@@ -72,7 +72,7 @@ Certificate_Request_12::Certificate_Request_12(Handshake_IO& io,
 /**
 * Deserialize a Certificate Request message
 */
-Certificate_Request_12::Certificate_Request_12(const std::vector<uint8_t>& buf) {
+Certificate_Request_12::Certificate_Request_12(std::span<const uint8_t> buf) {
    if(buf.size() < 4) {
       throw Decoding_Error("Certificate_Req: Bad certificate request");
    }

--- a/src/lib/tls/tls12/msg_client_hello_12.cpp
+++ b/src/lib/tls/tls12/msg_client_hello_12.cpp
@@ -113,9 +113,9 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
                                  const Policy& policy,
                                  Callbacks& cb,
                                  RandomNumberGenerator& rng,
-                                 const std::vector<uint8_t>& reneg_info,
+                                 std::vector<uint8_t> reneg_info,
                                  const Client_Hello_12::Settings& client_settings,
-                                 const std::vector<std::string>& next_protocols) {
+                                 std::vector<std::string> next_protocols) {
    m_data->m_legacy_version = client_settings.protocol_version();
    m_data->m_random = make_hello_random(rng, cb, policy);
    m_data->m_suites = policy.ciphersuite_list(client_settings.protocol_version());
@@ -142,7 +142,8 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
 
    m_data->extensions().add(new Session_Ticket_Extension());
 
-   m_data->extensions().add(new Renegotiation_Extension(reneg_info));
+   const bool has_reneg_info = !reneg_info.empty();
+   m_data->extensions().add(new Renegotiation_Extension(std::move(reneg_info)));
 
    m_data->extensions().add(new Supported_Versions(m_data->legacy_version(), policy));
 
@@ -165,8 +166,8 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
       m_data->extensions().add(new Signature_Algorithms_Cert(std::move(cert_signing_prefs.value())));
    }
 
-   if(reneg_info.empty() && !next_protocols.empty()) {
-      m_data->extensions().add(new Application_Layer_Protocol_Notification(next_protocols));
+   if(!has_reneg_info && !next_protocols.empty()) {
+      m_data->extensions().add(new Application_Layer_Protocol_Notification(std::move(next_protocols)));
    }
 
    if(m_data->legacy_version().is_datagram_protocol()) {
@@ -188,9 +189,9 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
                                  const Policy& policy,
                                  Callbacks& cb,
                                  RandomNumberGenerator& rng,
-                                 const std::vector<uint8_t>& reneg_info,
+                                 std::vector<uint8_t> reneg_info,
                                  const Session_with_Handle& session,
-                                 const std::vector<std::string>& next_protocols) {
+                                 std::vector<std::string> next_protocols) {
    m_data->m_legacy_version = session.session.version();
    m_data->m_random = make_hello_random(rng, cb, policy);
 
@@ -228,7 +229,8 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
       m_data->extensions().add(new Session_Ticket_Extension(session.handle.ticket().value()));
    }
 
-   m_data->extensions().add(new Renegotiation_Extension(reneg_info));
+   const bool has_reneg_info = !reneg_info.empty();
+   m_data->extensions().add(new Renegotiation_Extension(std::move(reneg_info)));
 
    const std::string hostname = session.session.server_info().hostname();
 
@@ -251,8 +253,8 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
       m_data->extensions().add(new Signature_Algorithms_Cert(std::move(cert_signing_prefs.value())));
    }
 
-   if(reneg_info.empty() && !next_protocols.empty()) {
-      m_data->extensions().add(new Application_Layer_Protocol_Notification(next_protocols));
+   if(!has_reneg_info && !next_protocols.empty()) {
+      m_data->extensions().add(new Application_Layer_Protocol_Notification(std::move(next_protocols)));
    }
 
    // NOLINTEND(*-owning-memory)
@@ -262,7 +264,7 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
    hash.update(io.send(*this));
 }
 
-Client_Hello_12::Client_Hello_12(const std::vector<uint8_t>& buf) :
+Client_Hello_12::Client_Hello_12(std::span<const uint8_t> buf) :
       Client_Hello_12(std::make_unique<Client_Hello_Internal>(buf)) {}
 
 Client_Hello_12::Client_Hello_12(std::unique_ptr<Client_Hello_Internal> data) : Client_Hello_12_Shim(std::move(data)) {
@@ -284,7 +286,7 @@ Hello_Request::Hello_Request(Handshake_IO& io) {
    io.send(*this);
 }
 
-Hello_Request::Hello_Request(const std::vector<uint8_t>& buf) {
+Hello_Request::Hello_Request(std::span<const uint8_t> buf) {
    if(!buf.empty()) {
       throw Decoding_Error("Bad Hello_Request, has non-zero size");
    }

--- a/src/lib/tls/tls12/msg_client_kex.cpp
+++ b/src/lib/tls/tls12/msg_client_kex.cpp
@@ -236,7 +236,7 @@ Client_Key_Exchange::Client_Key_Exchange(Handshake_IO& io,
 /*
 * Read a Client Key Exchange message
 */
-Client_Key_Exchange::Client_Key_Exchange(const std::vector<uint8_t>& contents,
+Client_Key_Exchange::Client_Key_Exchange(std::span<const uint8_t> contents,
                                          const Handshake_State& state,
                                          const Private_Key* server_rsa_kex_key,
                                          Credentials_Manager& creds,

--- a/src/lib/tls/tls12/msg_hello_verify.cpp
+++ b/src/lib/tls/tls12/msg_hello_verify.cpp
@@ -12,7 +12,7 @@
 
 namespace Botan::TLS {
 
-Hello_Verify_Request::Hello_Verify_Request(const std::vector<uint8_t>& buf) {
+Hello_Verify_Request::Hello_Verify_Request(std::span<const uint8_t> buf) {
    if(buf.size() < 3) {
       throw Decoding_Error("Hello verify request too small");
    }
@@ -30,7 +30,7 @@ Hello_Verify_Request::Hello_Verify_Request(const std::vector<uint8_t>& buf) {
    m_cookie.assign(buf.begin() + 3, buf.end());
 }
 
-Hello_Verify_Request::Hello_Verify_Request(const std::vector<uint8_t>& client_hello_bits,
+Hello_Verify_Request::Hello_Verify_Request(std::span<const uint8_t> client_hello_bits,
                                            std::string_view client_identity,
                                            const SymmetricKey& secret_key) {
    auto hmac = MessageAuthenticationCode::create_or_throw("HMAC(SHA-256)");

--- a/src/lib/tls/tls12/msg_server_hello_12.cpp
+++ b/src/lib/tls/tls12/msg_server_hello_12.cpp
@@ -24,7 +24,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
                                  const Policy& policy,
                                  Callbacks& cb,
                                  RandomNumberGenerator& rng,
-                                 const std::vector<uint8_t>& reneg_info,
+                                 std::vector<uint8_t> reneg_info,
                                  const Client_Hello_12& client_hello,
                                  const Server_Hello_12::Settings& server_settings,
                                  std::string_view next_protocol) :
@@ -59,7 +59,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
    }
 
    if(client_hello.secure_renegotiation()) {
-      m_data->extensions().add(new Renegotiation_Extension(reneg_info));
+      m_data->extensions().add(new Renegotiation_Extension(std::move(reneg_info)));
    }
 
    if(client_hello.supports_session_ticket() && server_settings.offer_session_ticket()) {
@@ -99,7 +99,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
                                  const Policy& policy,
                                  Callbacks& cb,
                                  RandomNumberGenerator& rng,
-                                 const std::vector<uint8_t>& reneg_info,
+                                 std::vector<uint8_t> reneg_info,
                                  const Client_Hello_12& client_hello,
                                  const Session& resumed_session,
                                  bool offer_session_ticket,
@@ -132,7 +132,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
    }
 
    if(client_hello.secure_renegotiation()) {
-      m_data->extensions().add(new Renegotiation_Extension(reneg_info));
+      m_data->extensions().add(new Renegotiation_Extension(std::move(reneg_info)));
    }
 
    if(client_hello.supports_session_ticket() && offer_session_ticket) {
@@ -145,7 +145,7 @@ Server_Hello_12::Server_Hello_12(Handshake_IO& io,
    hash.update(io.send(*this));
 }
 
-Server_Hello_12::Server_Hello_12(const std::vector<uint8_t>& buf) :
+Server_Hello_12::Server_Hello_12(std::span<const uint8_t> buf) :
       Server_Hello_12(std::make_unique<Server_Hello_Internal>(buf)) {}
 
 Server_Hello_12::Server_Hello_12(std::unique_ptr<Server_Hello_Internal> data) : Server_Hello_12_Shim(std::move(data)) {}
@@ -213,7 +213,7 @@ Server_Hello_Done::Server_Hello_Done(Handshake_IO& io, Handshake_Hash& hash) {
 /*
 * Deserialize a Server Hello Done message
 */
-Server_Hello_Done::Server_Hello_Done(const std::vector<uint8_t>& buf) {
+Server_Hello_Done::Server_Hello_Done(std::span<const uint8_t> buf) {
    if(!buf.empty()) {
       throw Decoding_Error("Server_Hello_Done: Must be empty, and is not");
    }

--- a/src/lib/tls/tls12/msg_server_kex.cpp
+++ b/src/lib/tls/tls12/msg_server_kex.cpp
@@ -148,7 +148,7 @@ Server_Key_Exchange::Server_Key_Exchange(Handshake_IO& io,
 /**
 * Deserialize a Server Key Exchange message
 */
-Server_Key_Exchange::Server_Key_Exchange(const std::vector<uint8_t>& buf,
+Server_Key_Exchange::Server_Key_Exchange(std::span<const uint8_t> buf,
                                          const Kex_Algo kex_algo,
                                          const Auth_Method auth_method,
                                          Protocol_Version version) {

--- a/src/lib/tls/tls12/msg_session_ticket_12.cpp
+++ b/src/lib/tls/tls12/msg_session_ticket_12.cpp
@@ -25,7 +25,7 @@ New_Session_Ticket_12::New_Session_Ticket_12(Handshake_IO& io, Handshake_Hash& h
    hash.update(io.send(*this));
 }
 
-New_Session_Ticket_12::New_Session_Ticket_12(const std::vector<uint8_t>& buf) {
+New_Session_Ticket_12::New_Session_Ticket_12(std::span<const uint8_t> buf) {
    if(buf.size() < 6) {
       throw Decoding_Error("Session ticket message too short to be valid");
    }

--- a/src/lib/tls/tls12/tls_extensions_12.h
+++ b/src/lib/tls/tls12/tls_extensions_12.h
@@ -34,7 +34,7 @@ class BOTAN_UNSTABLE_API Renegotiation_Extension final : public Extension {
 
       Renegotiation_Extension() = default;
 
-      explicit Renegotiation_Extension(const std::vector<uint8_t>& bits) : m_reneg_data(bits) {}
+      explicit Renegotiation_Extension(std::vector<uint8_t> bits) : m_reneg_data(std::move(bits)) {}
 
       Renegotiation_Extension(TLS_Data_Reader& reader, uint16_t extension_size);
 

--- a/src/lib/tls/tls12/tls_messages_12.h
+++ b/src/lib/tls/tls12/tls_messages_12.h
@@ -40,20 +40,20 @@ class BOTAN_UNSTABLE_API Client_Hello_12 final : public Client_Hello_12_Shim {
                       const Policy& policy,
                       Callbacks& cb,
                       RandomNumberGenerator& rng,
-                      const std::vector<uint8_t>& reneg_info,
+                      std::vector<uint8_t> reneg_info,
                       const Settings& client_settings,
-                      const std::vector<std::string>& next_protocols);
+                      std::vector<std::string> next_protocols);
 
       Client_Hello_12(Handshake_IO& io,
                       Handshake_Hash& hash,
                       const Policy& policy,
                       Callbacks& cb,
                       RandomNumberGenerator& rng,
-                      const std::vector<uint8_t>& reneg_info,
+                      std::vector<uint8_t> reneg_info,
                       const Session_with_Handle& session_and_handle,
-                      const std::vector<std::string>& next_protocols);
+                      std::vector<std::string> next_protocols);
 
-      explicit Client_Hello_12(const std::vector<uint8_t>& buf);
+      explicit Client_Hello_12(std::span<const uint8_t> buf);
 
    private:
       explicit Client_Hello_12(std::unique_ptr<Client_Hello_Internal> data);
@@ -119,7 +119,7 @@ class BOTAN_UNSTABLE_API Server_Hello_12 final : public Server_Hello_12_Shim {
                       const Policy& policy,
                       Callbacks& cb,
                       RandomNumberGenerator& rng,
-                      const std::vector<uint8_t>& secure_reneg_info,
+                      std::vector<uint8_t> secure_reneg_info,
                       const Client_Hello_12& client_hello,
                       const Settings& settings,
                       std::string_view next_protocol);
@@ -129,13 +129,13 @@ class BOTAN_UNSTABLE_API Server_Hello_12 final : public Server_Hello_12_Shim {
                       const Policy& policy,
                       Callbacks& cb,
                       RandomNumberGenerator& rng,
-                      const std::vector<uint8_t>& secure_reneg_info,
+                      std::vector<uint8_t> secure_reneg_info,
                       const Client_Hello_12& client_hello,
                       const Session& resumed_session,
                       bool offer_session_ticket,
                       std::string_view next_protocol);
 
-      explicit Server_Hello_12(const std::vector<uint8_t>& buf);
+      explicit Server_Hello_12(std::span<const uint8_t> buf);
 
    private:
       explicit Server_Hello_12(std::unique_ptr<Server_Hello_Internal> data);
@@ -186,7 +186,7 @@ class BOTAN_UNSTABLE_API Client_Key_Exchange final : public Handshake_Message {
                           std::string_view hostname,
                           RandomNumberGenerator& rng);
 
-      Client_Key_Exchange(const std::vector<uint8_t>& buf,
+      Client_Key_Exchange(std::span<const uint8_t> buf,
                           const Handshake_State& state,
                           const Private_Key* server_rsa_kex_key,
                           Credentials_Manager& creds,
@@ -214,9 +214,9 @@ class BOTAN_UNSTABLE_API Certificate_12 final : public Handshake_Message /* NOLI
 
       bool empty() const { return m_certs.empty(); }
 
-      Certificate_12(Handshake_IO& io, Handshake_Hash& hash, const std::vector<X509_Certificate>& certs);
+      Certificate_12(Handshake_IO& io, Handshake_Hash& hash, std::vector<X509_Certificate> certs);
 
-      Certificate_12(const std::vector<uint8_t>& buf, const Policy& policy);
+      Certificate_12(std::span<const uint8_t> buf, const Policy& policy);
 
       ~Certificate_12() override;
 
@@ -242,9 +242,9 @@ class BOTAN_UNSTABLE_API Certificate_Request_12 final : public Handshake_Message
       Certificate_Request_12(Handshake_IO& io,
                              Handshake_Hash& hash,
                              const Policy& policy,
-                             const std::vector<X509_DN>& allowed_cas);
+                             std::vector<X509_DN> allowed_cas);
 
-      explicit Certificate_Request_12(const std::vector<uint8_t>& buf);
+      explicit Certificate_Request_12(std::span<const uint8_t> buf);
 
       ~Certificate_Request_12() override;
 
@@ -310,7 +310,7 @@ class BOTAN_UNSTABLE_API Hello_Request final : public Handshake_Message {
       Handshake_Type type() const override { return Handshake_Type::HelloRequest; }
 
       explicit Hello_Request(Handshake_IO& io);
-      explicit Hello_Request(const std::vector<uint8_t>& buf);
+      explicit Hello_Request(std::span<const uint8_t> buf);
 
    private:
       std::vector<uint8_t> serialize() const override;
@@ -343,7 +343,7 @@ class BOTAN_UNSTABLE_API Server_Key_Exchange final : public Handshake_Message {
                           RandomNumberGenerator& rng,
                           const Private_Key* signing_key = nullptr);
 
-      Server_Key_Exchange(const std::vector<uint8_t>& buf,
+      Server_Key_Exchange(std::span<const uint8_t> buf,
                           Kex_Algo kex_alg,
                           Auth_Method sig_alg,
                           Protocol_Version version);
@@ -375,7 +375,7 @@ class BOTAN_UNSTABLE_API Server_Hello_Done final : public Handshake_Message {
       Handshake_Type type() const override { return Handshake_Type::ServerHelloDone; }
 
       explicit Server_Hello_Done(Handshake_IO& io, Handshake_Hash& hash);
-      explicit Server_Hello_Done(const std::vector<uint8_t>& buf);
+      explicit Server_Hello_Done(std::span<const uint8_t> buf);
 
    private:
       std::vector<uint8_t> serialize() const override;
@@ -399,7 +399,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_12 final : public Handshake_Message 
 
       New_Session_Ticket_12(Handshake_IO& io, Handshake_Hash& hash);
 
-      explicit New_Session_Ticket_12(const std::vector<uint8_t>& buf);
+      explicit New_Session_Ticket_12(std::span<const uint8_t> buf);
 
       std::vector<uint8_t> serialize() const override;
 

--- a/src/lib/tls/tls13/msg_cert_verify_13.cpp
+++ b/src/lib/tls/tls13/msg_cert_verify_13.cpp
@@ -83,7 +83,7 @@ Certificate_Verify_13::Certificate_Verify_13(const Certificate_13& certificate_m
       *private_key, rng, m_scheme.padding_string(), m_scheme.format().value(), message(m_side, hash));
 }
 
-Certificate_Verify_13::Certificate_Verify_13(const std::vector<uint8_t>& buf, const Connection_Side side) :
+Certificate_Verify_13::Certificate_Verify_13(std::span<const uint8_t> buf, const Connection_Side side) :
       Certificate_Verify(buf), m_side(side) {
    if(!m_scheme.is_available()) {
       throw TLS_Exception(Alert::IllegalParameter, "Peer sent unknown signature scheme");

--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -361,7 +361,7 @@ std::vector<uint8_t> Certificate_13::Certificate_Entry::serialize() const {
 /**
 * Deserialize a Certificate message
 */
-Certificate_13::Certificate_13(const std::vector<uint8_t>& buf,
+Certificate_13::Certificate_13(std::span<const uint8_t> buf,
                                const Policy& policy,
                                Connection_Side side,
                                Certificate_Type cert_type) :

--- a/src/lib/tls/tls13/msg_certificate_req_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_req_13.cpp
@@ -22,7 +22,7 @@ Handshake_Type Certificate_Request_13::type() const {
    return TLS::Handshake_Type::CertificateRequest;
 }
 
-Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, const Connection_Side side) {
+Certificate_Request_13::Certificate_Request_13(std::span<const uint8_t> buf, const Connection_Side side) {
    TLS_Data_Reader reader("Certificate_Request_13", buf);
 
    // RFC 8446 4.3.2
@@ -70,7 +70,7 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<uint8_t>& buf, 
    reader.assert_done();
 }
 
-Certificate_Request_13::Certificate_Request_13(const std::vector<X509_DN>& acceptable_CAs,
+Certificate_Request_13::Certificate_Request_13(std::vector<X509_DN> acceptable_CAs,
                                                const Policy& policy,
                                                Callbacks& callbacks) {
    // RFC 8446 4.3.2
@@ -99,7 +99,7 @@ Certificate_Request_13::Certificate_Request_13(const std::vector<X509_DN>& accep
    }
 
    if(!acceptable_CAs.empty()) {
-      m_extensions.add(std::make_unique<Certificate_Authorities>(acceptable_CAs));
+      m_extensions.add(std::make_unique<Certificate_Authorities>(std::move(acceptable_CAs)));
    }
 
    // TODO: Support cert_status_request for OCSP stapling

--- a/src/lib/tls/tls13/msg_client_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_client_hello_13.cpp
@@ -155,7 +155,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
                                  Callbacks& cb,
                                  RandomNumberGenerator& rng,
                                  std::string_view hostname,
-                                 const std::vector<std::string>& next_protocols,
+                                 std::vector<std::string> next_protocols,
                                  std::optional<Session_with_Handle>& session,
                                  std::vector<ExternalPSK> psks) {
    // RFC 8446 4.1.2
@@ -231,7 +231,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
    }
 
    if(!next_protocols.empty()) {
-      m_data->extensions().add(new Application_Layer_Protocol_Notification(next_protocols));
+      m_data->extensions().add(new Application_Layer_Protocol_Notification(std::move(next_protocols)));
    }
 
 #if defined(BOTAN_HAS_TLS_12)
@@ -283,7 +283,7 @@ Client_Hello_13::Client_Hello_13(const Policy& policy,
    }
 }
 
-std::variant<Client_Hello_13, Client_Hello_12_Shim> Client_Hello_13::parse(const std::vector<uint8_t>& buf) {
+std::variant<Client_Hello_13, Client_Hello_12_Shim> Client_Hello_13::parse(std::span<const uint8_t> buf) {
    auto data = std::make_unique<Client_Hello_Internal>(buf);
    const auto version = data->version();
 

--- a/src/lib/tls/tls13/msg_client_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_client_hello_13.cpp
@@ -344,7 +344,7 @@ void Client_Hello_13::retry(const Hello_Retry_Request& hrr,
       // RFC 8446 4.2.11
       //    The "pre_shared_key" extension MUST be the last extension in the
       //    ClientHello (this facilitates implementation [...]).
-      m_data->extensions().reorder({Extension_Code::PresharedKey});
+      m_data->extensions().reorder(std::array{Extension_Code::PresharedKey});
 
       // Cipher suite should always be a known suite as this is checked upstream
       const auto cipher = Ciphersuite::by_id(hrr.ciphersuite());

--- a/src/lib/tls/tls13/msg_encrypted_extensions.cpp
+++ b/src/lib/tls/tls13/msg_encrypted_extensions.cpp
@@ -131,7 +131,7 @@ Encrypted_Extensions::Encrypted_Extensions(const Client_Hello_13& client_hello,
    }
 }
 
-Encrypted_Extensions::Encrypted_Extensions(const std::vector<uint8_t>& buf) {
+Encrypted_Extensions::Encrypted_Extensions(std::span<const uint8_t> buf) {
    TLS_Data_Reader reader("encrypted extensions reader", buf);
 
    // Encrypted Extensions contains a list of extensions. This list may legally

--- a/src/lib/tls/tls13/msg_key_update.cpp
+++ b/src/lib/tls/tls13/msg_key_update.cpp
@@ -14,7 +14,7 @@ namespace Botan::TLS {
 
 Key_Update::Key_Update(const bool request_peer_update) : m_update_requested(request_peer_update) {}
 
-Key_Update::Key_Update(const std::vector<uint8_t>& buf) {
+Key_Update::Key_Update(std::span<const uint8_t> buf) {
    if(buf.size() != 1) {
       throw TLS_Exception(Alert::DecodeError, "malformed key_update");
    }
@@ -22,7 +22,7 @@ Key_Update::Key_Update(const std::vector<uint8_t>& buf) {
    // RFC 8446 4.6.3
    //    If an implementation receives any other value [than 0 or 1], it MUST
    //    terminate the connection with an "illegal_parameter" alert.
-   const uint8_t update_requested = buf.at(0);
+   const uint8_t update_requested = buf[0];
    if(update_requested > 1) {
       throw TLS_Exception(Alert::IllegalParameter, "unexpected key_update parameter");
    }

--- a/src/lib/tls/tls13/msg_server_hello_13.cpp
+++ b/src/lib/tls/tls13/msg_server_hello_13.cpp
@@ -82,7 +82,7 @@ std::variant<Hello_Retry_Request, Server_Hello_13> Server_Hello_13::create(const
 }
 
 std::variant<Hello_Retry_Request, Server_Hello_13, Server_Hello_12_Shim> Server_Hello_13::parse(
-   const std::vector<uint8_t>& buf) {
+   std::span<const uint8_t> buf) {
    auto data = std::make_unique<Server_Hello_Internal>(buf);
    const auto version = data->version();
 

--- a/src/lib/tls/tls13/msg_session_ticket_13.cpp
+++ b/src/lib/tls/tls13/msg_session_ticket_13.cpp
@@ -42,7 +42,7 @@ New_Session_Ticket_13::New_Session_Ticket_13(Ticket_Nonce nonce,
    callbacks.tls_modify_extensions(m_extensions, Connection_Side::Server, type());
 }
 
-New_Session_Ticket_13::New_Session_Ticket_13(const std::vector<uint8_t>& buf, Connection_Side from) {
+New_Session_Ticket_13::New_Session_Ticket_13(std::span<const uint8_t> buf, Connection_Side from) {
    TLS_Data_Reader reader("New_Session_Ticket_13", buf);
 
    m_ticket_lifetime_hint = std::chrono::seconds(reader.get_uint32_t());

--- a/src/lib/tls/tls13/tls_extensions_13.cpp
+++ b/src/lib/tls/tls13/tls_extensions_13.cpp
@@ -21,7 +21,7 @@
 
 namespace Botan::TLS {
 
-Cookie::Cookie(const std::vector<uint8_t>& cookie) : m_cookie(cookie) {}
+Cookie::Cookie(std::vector<uint8_t> cookie) : m_cookie(std::move(cookie)) {}
 
 Cookie::Cookie(TLS_Data_Reader& reader, uint16_t extension_size) {
    // RFC 8446 4.2.2

--- a/src/lib/tls/tls13/tls_extensions_13.h
+++ b/src/lib/tls/tls13/tls_extensions_13.h
@@ -51,7 +51,7 @@ class BOTAN_UNSTABLE_API Cookie final : public Extension {
 
       const std::vector<uint8_t>& get_cookie() const { return m_cookie; }
 
-      explicit Cookie(const std::vector<uint8_t>& cookie);
+      explicit Cookie(std::vector<uint8_t> cookie);
 
       explicit Cookie(TLS_Data_Reader& reader, uint16_t extension_size);
 
@@ -175,7 +175,7 @@ class BOTAN_UNSTABLE_API PSK final : public Extension /* NOLINT(*-special-member
       ~PSK() override;
 
       void calculate_binders(const Transcript_Hash_State& truncated_transcript_hash);
-      bool validate_binder(const PSK& server_psk, const std::vector<uint8_t>& binder) const;
+      bool validate_binder(const PSK& server_psk, std::span<const uint8_t> binder) const;
 
       // TODO: Implement pure PSK negotiation that is not used for session
       //       resumption.

--- a/src/lib/tls/tls13/tls_extensions_psk.cpp
+++ b/src/lib/tls/tls13/tls_extensions_psk.cpp
@@ -442,7 +442,7 @@ void PSK::calculate_binders(const Transcript_Hash_State& truncated_transcript_ha
    }
 }
 
-bool PSK::validate_binder(const PSK& server_psk, const std::vector<uint8_t>& binder) const {
+bool PSK::validate_binder(const PSK& server_psk, std::span<const uint8_t> binder) const {
    BOTAN_STATE_CHECK(std::holds_alternative<std::vector<Client_PSK>>(m_impl->psk));
    BOTAN_STATE_CHECK(std::holds_alternative<Server_PSK>(server_psk.m_impl->psk));
 

--- a/src/lib/tls/tls13/tls_messages_13.h
+++ b/src/lib/tls/tls13/tls_messages_13.h
@@ -37,11 +37,11 @@ class BOTAN_UNSTABLE_API Client_Hello_13 final : public Client_Hello {
                       Callbacks& cb,
                       RandomNumberGenerator& rng,
                       std::string_view hostname,
-                      const std::vector<std::string>& next_protocols,
+                      std::vector<std::string> next_protocols,
                       std::optional<Session_with_Handle>& session,
                       std::vector<ExternalPSK> psks);
 
-      static std::variant<Client_Hello_13, Client_Hello_12_Shim> parse(const std::vector<uint8_t>& buf);
+      static std::variant<Client_Hello_13, Client_Hello_12_Shim> parse(std::span<const uint8_t> buf);
 
       void retry(const Hello_Retry_Request& hrr,
                  const Transcript_Hash_State& transcript_hash_state,
@@ -118,7 +118,7 @@ class BOTAN_UNSTABLE_API Server_Hello_13 : public Server_Hello {
                                                                        Callbacks& cb);
 
       static std::variant<Hello_Retry_Request, Server_Hello_13, Server_Hello_12_Shim> parse(
-         const std::vector<uint8_t>& buf);
+         std::span<const uint8_t> buf);
 
       /**
        * Return desired downgrade version indicated by hello random, if any.
@@ -145,7 +145,7 @@ class BOTAN_UNSTABLE_API Hello_Retry_Request final : public Server_Hello_13 {
 
 class BOTAN_UNSTABLE_API Encrypted_Extensions final : public Handshake_Message {
    public:
-      explicit Encrypted_Extensions(const std::vector<uint8_t>& buf);
+      explicit Encrypted_Extensions(std::span<const uint8_t> buf);
       Encrypted_Extensions(const Client_Hello_13& client_hello,
                            const Policy& policy,
                            Callbacks& cb,
@@ -244,7 +244,7 @@ class BOTAN_UNSTABLE_API Certificate_13 final : public Handshake_Message {
       * @param side is this a Connection_Side::Server or Connection_Side::Client certificate message
       * @param cert_type is the certificate type that was negotiated during the handshake
       */
-      Certificate_13(const std::vector<uint8_t>& buf,
+      Certificate_13(std::span<const uint8_t> buf,
                      const Policy& policy,
                      Connection_Side side,
                      Certificate_Type cert_type);
@@ -295,7 +295,7 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
    public:
       Handshake_Type type() const override;
 
-      Certificate_Request_13(const std::vector<uint8_t>& buf, Connection_Side side);
+      Certificate_Request_13(std::span<const uint8_t> buf, Connection_Side side);
 
       //! Creates a Certificate_Request message if it is required by the configuration
       //! @return std::nullopt if configuration does not require client authentication
@@ -315,7 +315,7 @@ class BOTAN_UNSTABLE_API Certificate_Request_13 final : public Handshake_Message
       const std::vector<uint8_t>& context() const { return m_context; }
 
    private:
-      Certificate_Request_13(const std::vector<X509_DN>& acceptable_CAs, const Policy& policy, Callbacks& callbacks);
+      Certificate_Request_13(std::vector<X509_DN> acceptable_CAs, const Policy& policy, Callbacks& callbacks);
 
    private:
       std::vector<uint8_t> m_context;
@@ -332,7 +332,7 @@ class BOTAN_UNSTABLE_API Certificate_Verify_13 final : public Certificate_Verify
       * @param buf the serialized message
       * @param side is this a Connection_Side::Server or Connection_Side::Client certificate message
       */
-      Certificate_Verify_13(const std::vector<uint8_t>& buf, Connection_Side side);
+      Certificate_Verify_13(std::span<const uint8_t> buf, Connection_Side side);
 
       Certificate_Verify_13(const Certificate_13& certificate_message,
                             const std::vector<Signature_Scheme>& peer_allowed_schemes,
@@ -367,7 +367,7 @@ class BOTAN_UNSTABLE_API New_Session_Ticket_13 final : public Handshake_Message 
                             const Session_Handle& handle,
                             Callbacks& callbacks);
 
-      New_Session_Ticket_13(const std::vector<uint8_t>& buf, Connection_Side from);
+      New_Session_Ticket_13(std::span<const uint8_t> buf, Connection_Side from);
 
       std::vector<uint8_t> serialize() const override;
 
@@ -407,7 +407,7 @@ class BOTAN_UNSTABLE_API Key_Update final : public Handshake_Message {
       Handshake_Type type() const override { return Handshake_Type::KeyUpdate; }
 
       explicit Key_Update(bool request_peer_update);
-      explicit Key_Update(const std::vector<uint8_t>& buf);
+      explicit Key_Update(std::span<const uint8_t> buf);
 
       std::vector<uint8_t> serialize() const override;
 

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -435,10 +435,9 @@ Application_Layer_Protocol_Notification::Application_Layer_Protocol_Notification
    m_protocols.emplace_back(protocol);
 }
 
-Application_Layer_Protocol_Notification::Application_Layer_Protocol_Notification(
-   const std::vector<std::string>& protocols) :
-      m_protocols(protocols) {
-   for(const auto& protocol : protocols) {
+Application_Layer_Protocol_Notification::Application_Layer_Protocol_Notification(std::vector<std::string> protocols) :
+      m_protocols(std::move(protocols)) {
+   for(const auto& protocol : m_protocols) {
       BOTAN_ARG_CHECK(!protocol.empty(), "ALPN protocol name must not be empty");
       BOTAN_ARG_CHECK(protocol.size() < 256, "ALPN protocol name too long");
    }

--- a/src/lib/tls/tls_extensions.cpp
+++ b/src/lib/tls/tls_extensions.cpp
@@ -283,7 +283,7 @@ std::set<Extension_Code> Extensions::extension_types() const {
    return offers;
 }
 
-void Extensions::reorder(const std::vector<Extension_Code>& order) {
+void Extensions::reorder(std::span<const Extension_Code> order) {
    const std::set<Extension_Code> in_order(order.begin(), order.end());
 
    std::vector<Extension_Code> new_codes;
@@ -527,7 +527,7 @@ Server_Certificate_Type::Server_Certificate_Type(const Server_Certificate_Type& 
       Certificate_Type_Base(sct, policy.accepted_server_certificate_types()) {}
 
 Certificate_Type_Base::Certificate_Type_Base(const Certificate_Type_Base& certificate_type_from_client,
-                                             const std::vector<Certificate_Type>& server_preference) :
+                                             std::span<const Certificate_Type> server_preference) :
       m_from(Connection_Side::Server) {
    // RFC 7250 4.2
    //    The server_certificate_type extension in the client hello indicates the
@@ -618,7 +618,7 @@ Certificate_Type Certificate_Type_Base::selected_certificate_type() const {
    return m_certificate_types.front();
 }
 
-Supported_Groups::Supported_Groups(const std::vector<Group_Params>& groups) : m_groups(groups) {}
+Supported_Groups::Supported_Groups(std::vector<Group_Params> groups) : m_groups(std::move(groups)) {}
 
 const std::vector<Group_Params>& Supported_Groups::groups() const {
    return m_groups;

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -23,6 +23,7 @@
 #include <memory>
 #include <optional>
 #include <set>
+#include <span>
 
 namespace Botan {
 
@@ -176,7 +177,7 @@ class BOTAN_UNSTABLE_API Certificate_Type_Base : public Extension {
        * Called by the server to select a cert type to be used in the handshake.
        */
       Certificate_Type_Base(const Certificate_Type_Base& certificate_type_from_client,
-                            const std::vector<Certificate_Type>& server_preference);
+                            std::span<const Certificate_Type> server_preference);
 
    public:
       Certificate_Type_Base(TLS_Data_Reader& reader, uint16_t extension_size, Connection_Side from);
@@ -247,7 +248,7 @@ class BOTAN_UNSTABLE_API Supported_Groups final : public Extension {
 
       std::vector<uint8_t> serialize(Connection_Side whoami) const override;
 
-      explicit Supported_Groups(const std::vector<Group_Params>& groups);
+      explicit Supported_Groups(std::vector<Group_Params> groups);
 
       Supported_Groups(TLS_Data_Reader& reader, uint16_t extension_size);
 
@@ -328,7 +329,7 @@ class BOTAN_UNSTABLE_API SRTP_Protection_Profiles final : public Extension {
 
       bool empty() const override { return m_pp.empty(); }
 
-      explicit SRTP_Protection_Profiles(const std::vector<uint16_t>& pp) : m_pp(pp) {}
+      explicit SRTP_Protection_Profiles(std::vector<uint16_t> pp) : m_pp(std::move(pp)) {}
 
       explicit SRTP_Protection_Profiles(uint16_t pp) : m_pp(1, pp) {}
 
@@ -518,7 +519,7 @@ class BOTAN_UNSTABLE_API Extensions final {
       * @p order retain their relative position at the front; extensions in
       * @p order are appended in the given order.
       */
-      void reorder(const std::vector<Extension_Code>& order);
+      void reorder(std::span<const Extension_Code> order);
 
       /**
       * Return the code of the extension that appears last in the encoding

--- a/src/lib/tls/tls_extensions.h
+++ b/src/lib/tls/tls_extensions.h
@@ -148,7 +148,7 @@ class BOTAN_UNSTABLE_API Application_Layer_Protocol_Notification final : public 
       /**
       * List of protocols, used by client
       */
-      explicit Application_Layer_Protocol_Notification(const std::vector<std::string>& protocols);
+      explicit Application_Layer_Protocol_Notification(std::vector<std::string> protocols);
 
       Application_Layer_Protocol_Notification(TLS_Data_Reader& reader, uint16_t extension_size, Connection_Side from);
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -18,6 +18,7 @@
 #include <botan/tls_version.h>
 #include <memory>
 #include <set>
+#include <span>
 #include <string>
 #include <vector>
 
@@ -62,9 +63,9 @@ class BOTAN_UNSTABLE_API Hello_Verify_Request final : public Handshake_Message {
 
       const std::vector<uint8_t>& cookie() const { return m_cookie; }
 
-      explicit Hello_Verify_Request(const std::vector<uint8_t>& buf);
+      explicit Hello_Verify_Request(std::span<const uint8_t> buf);
 
-      Hello_Verify_Request(const std::vector<uint8_t>& client_hello_bits,
+      Hello_Verify_Request(std::span<const uint8_t> client_hello_bits,
                            std::string_view client_identity,
                            const SymmetricKey& secret_key);
 
@@ -155,7 +156,7 @@ class BOTAN_UNSTABLE_API Client_Hello : public Handshake_Message {
  */
 class BOTAN_UNSTABLE_API Client_Hello_12_Shim : public Client_Hello {
    public:
-      explicit Client_Hello_12_Shim(const std::vector<uint8_t>& buf);
+      explicit Client_Hello_12_Shim(std::span<const uint8_t> buf);
 
    protected:
       using Client_Hello::Client_Hello;
@@ -209,7 +210,7 @@ class BOTAN_UNSTABLE_API Server_Hello : public Handshake_Message {
  */
 class BOTAN_UNSTABLE_API Server_Hello_12_Shim : public Server_Hello {
    public:
-      explicit Server_Hello_12_Shim(const std::vector<uint8_t>& buf);
+      explicit Server_Hello_12_Shim(std::span<const uint8_t> buf);
 
    protected:
       friend class Server_Hello_13;  // to allow construction by Server_Hello_13::parse()
@@ -238,7 +239,7 @@ class BOTAN_UNSTABLE_API Certificate_Status : public Handshake_Message {
 
       const std::vector<uint8_t>& response() const { return m_response; }
 
-      explicit Certificate_Status(const std::vector<uint8_t>& buf, Connection_Side from);
+      explicit Certificate_Status(std::span<const uint8_t> buf, Connection_Side from);
 
       explicit Certificate_Status(std::vector<uint8_t> raw_response_bytes);
 
@@ -254,7 +255,7 @@ class BOTAN_UNSTABLE_API Certificate_Verify : public Handshake_Message {
 
       Signature_Scheme signature_scheme() const { return m_scheme; }
 
-      explicit Certificate_Verify(const std::vector<uint8_t>& buf);
+      explicit Certificate_Verify(std::span<const uint8_t> buf);
       Certificate_Verify() = default;
 
       std::vector<uint8_t> serialize() const override;
@@ -269,7 +270,7 @@ class BOTAN_UNSTABLE_API Certificate_Verify : public Handshake_Message {
 */
 class BOTAN_UNSTABLE_API Finished : public Handshake_Message {
    public:
-      explicit Finished(const std::vector<uint8_t>& buf) : m_verification_data(buf) {}
+      explicit Finished(std::vector<uint8_t> buf) : m_verification_data(std::move(buf)) {}
 
       Handshake_Type type() const override { return Handshake_Type::Finished; }
 

--- a/src/lib/tls/tls_messages_internal.h
+++ b/src/lib/tls/tls_messages_internal.h
@@ -58,7 +58,7 @@ class Client_Hello_Internal {
    public:
       Client_Hello_Internal() : m_comp_methods({0}) {}
 
-      explicit Client_Hello_Internal(const std::vector<uint8_t>& buf);
+      explicit Client_Hello_Internal(std::span<const uint8_t> buf);
 
       /**
        * This distinguishes between a TLS 1.3 compliant Client Hello (containing
@@ -112,7 +112,7 @@ class Server_Hello_Internal final {
       /**
        * Deserialize a Server Hello message
        */
-      explicit Server_Hello_Internal(const std::vector<uint8_t>& buf);
+      explicit Server_Hello_Internal(std::span<const uint8_t> buf);
 
       Server_Hello_Internal(Protocol_Version lv,
                             Session_ID sid,

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -781,7 +781,7 @@ void sort_rfc8448_extensions(Botan::TLS::Extensions& exts,
                              Botan::TLS::Connection_Side side,
                              Botan::TLS::Handshake_Type /*type*/ = Botan::TLS::Handshake_Type::ClientHello) {
    if(side == Botan::TLS::Connection_Side::Client) {
-      exts.reorder({
+      exts.reorder(std::array{
          Botan::TLS::Extension_Code::ServerNameIndication,
          Botan::TLS::Extension_Code::SafeRenegotiation,
          Botan::TLS::Extension_Code::SupportedGroups,
@@ -797,7 +797,7 @@ void sort_rfc8448_extensions(Botan::TLS::Extensions& exts,
          Botan::TLS::Extension_Code::PresharedKey,
       });
    } else {
-      exts.reorder({
+      exts.reorder(std::array{
          Botan::TLS::Extension_Code::SupportedGroups,
          Botan::TLS::Extension_Code::KeyShare,
          Botan::TLS::Extension_Code::Cookie,
@@ -1528,7 +1528,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
             // This is the order of extensions when we first introduced the PSK
             // implementation and generated the transcript. To stay compatible
             // with the now hard-coded transcript, we pin the extension order.
-            exts.reorder({
+            exts.reorder(std::array{
                Botan::TLS::Extension_Code::ServerNameIndication,
                Botan::TLS::Extension_Code::SupportedGroups,
                Botan::TLS::Extension_Code::KeyShare,
@@ -1664,7 +1664,7 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
             // public key authentication implementation and generated the transcript.
             // To stay compatible with the now hard-coded transcript, we pin the
             // extension order.
-            exts.reorder({
+            exts.reorder(std::array{
                Botan::TLS::Extension_Code::ServerNameIndication,
                Botan::TLS::Extension_Code::SupportedGroups,
                Botan::TLS::Extension_Code::KeyShare,
@@ -2460,13 +2460,13 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                         // implementation and generated the transcript. To stay compatible
                         // with the now hard-coded transcript, we pin the extension order.
                         if(type == Botan::TLS::Handshake_Type::EncryptedExtensions) {
-                           exts.reorder({
+                           exts.reorder(std::array{
                               Botan::TLS::Extension_Code::SupportedGroups,
                               Botan::TLS::Extension_Code::RecordSizeLimit,
                               Botan::TLS::Extension_Code::ServerNameIndication,
                            });
                         } else if(type == Botan::TLS::Handshake_Type::ServerHello) {
-                           exts.reorder({
+                           exts.reorder(std::array{
                               Botan::TLS::Extension_Code::SupportedVersions,
                               Botan::TLS::Extension_Code::KeyShare,
                               Botan::TLS::Extension_Code::PresharedKey,
@@ -2598,7 +2598,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                // To stay compatible with the now hard-coded transcript, we pin the
                // extension order.
                if(type == Botan::TLS::Handshake_Type::EncryptedExtensions) {
-                  exts.reorder({
+                  exts.reorder(std::array{
                      Botan::TLS::Extension_Code::ClientCertificateType,
                      Botan::TLS::Extension_Code::ServerCertificateType,
                      Botan::TLS::Extension_Code::SupportedGroups,
@@ -2606,7 +2606,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                      Botan::TLS::Extension_Code::ServerNameIndication,
                   });
                } else if(type == Botan::TLS::Handshake_Type::ServerHello) {
-                  exts.reorder({
+                  exts.reorder(std::array{
                      Botan::TLS::Extension_Code::KeyShare,
                      Botan::TLS::Extension_Code::SupportedVersions,
                   });


### PR DESCRIPTION
This is preparatory work for #5000 where we'll need a little more flexibility in the API of some of those classes. But this change is useful independently as well, so here we go.

Note that this also changes a few locations from `const std::vector<>&` to a `std::vector<>` lvalue parameter followed by a `std::move` into private members. @Copilot Make sure that I didn't introduce any use-after-move issues!