### PR TITLE
Avoid including brainpool TLS 1.3 curve points in the TLS-Anvil policy

### DIFF
--- a/src/scripts/tls_anvil/anvil_policy.txt
+++ b/src/scripts/tls_anvil/anvil_policy.txt
@@ -11,3 +11,5 @@ key_exchange_methods = ECDH DH
 signature_methods = ECDSA RSA IMPLICIT
 
 require_extended_master_secret = false
+
+key_exchange_groups = secp256r1 secp384r1 secp521r1 x25519 ffdhe/ietf/2048


### PR DESCRIPTION
This seems to break TLS-Anvil in some unclear way (tests relating to curve selection crashing with null pointer exceptions).

https://github.com/tls-attacker/TLS-Anvil/issues/66