### PR TITLE
Validate AlgorithmIdentifier parameters on decode

### DIFF
--- a/src/lib/asn1/alg_id.cpp
+++ b/src/lib/asn1/alg_id.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
+#include <botan/internal/asn1_utils.h>
 
 namespace Botan {
 
@@ -81,6 +82,39 @@ void AlgorithmIdentifier::encode_into(DER_Encoder& codec) const {
 */
 void AlgorithmIdentifier::decode_from(BER_Decoder& codec) {
    codec.start_sequence().decode(m_oid).raw_bytes(m_parameters).end_cons();
+
+   /*
+   * The parameters field is OPTIONAL ANY but in practice it is one of
+   * - empty
+   * - NULL
+   * - SEQUENCE
+   * - OBJECT IDENTIFIER (namedCurve)
+   * - OCTET STRING (CBC IV in PBES2)
+   *
+   * So require it be exactly one of these values. In particular this ensures that
+   * there is not any additional trailing data (eg after the SEQUENCE encoding)
+   * that might be otherwise skipped over by a reader.
+   */
+
+   const bool acceptable_parameters = [&]() {
+      if(this->parameters_are_null_or_empty()) {
+         return true;
+      }
+      if(ASN1::is_der_sequence_header(m_parameters)) {
+         return true;
+      }
+      if(ASN1::is_single_der_object(m_parameters, ASN1_Type::ObjectId, ASN1_Class::Universal)) {
+         return true;
+      }
+      if(ASN1::is_single_der_object(m_parameters, ASN1_Type::OctetString, ASN1_Class::Universal)) {
+         return true;
+      }
+      return false;
+   }();
+
+   if(!acceptable_parameters) {
+      throw Decoding_Error("AlgorithmIdentifier parameters were not NULL, a SEQUENCE, an OID, or an OCTET STRING");
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/asn1/asn1_utils.h
+++ b/src/lib/asn1/asn1_utils.h
@@ -1,0 +1,32 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_ASN1_UTILS_H_
+#define BOTAN_ASN1_UTILS_H_
+
+#include <botan/asn1_obj.h>
+#include <span>
+
+namespace Botan::ASN1 {
+
+/*
+* Return true if the bytes are exactly one DER-encoded value of the expected
+* type and class, that is a TLV whose tag plus length header plus contents
+* span the entire buffer with no trailing data. The contents themselves are
+* not otherwise validated.
+*/
+bool is_single_der_object(std::span<const uint8_t> bytes, ASN1_Type expected_type, ASN1_Class expected_class);
+
+/**
+* Return true if the bytes are exactly one DER-encoded SEQUENCE, that is a
+* SEQUENCE whose tag plus length header plus contents span the entire buffer
+* with no trailing data. The contents themselves are not otherwise validated.
+*/
+bool is_der_sequence_header(std::span<const uint8_t> bytes);
+
+}  // namespace Botan::ASN1
+
+#endif

--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -9,6 +9,7 @@
 
 #include <botan/bigint.h>
 #include <botan/data_src.h>
+#include <botan/internal/asn1_utils.h>
 #include <botan/internal/int_utils.h>
 #include <botan/internal/loadstor.h>
 #include <memory>
@@ -358,6 +359,41 @@ class DataSource_BERObject final : public DataSource {
 
    private:
       BER_Object m_obj;
+      size_t m_offset = 0;
+};
+
+/*
+* A non-owning DataSource over a span, used to drive tag/length decoding
+* without copying the underlying buffer.
+*/
+class DataSource_Span final : public DataSource {
+   public:
+      size_t read(uint8_t out[], size_t length) override {
+         const size_t got = std::min(m_buf.size() - m_offset, length);
+         copy_mem(out, m_buf.data() + m_offset, got);
+         m_offset += got;
+         return got;
+      }
+
+      size_t peek(uint8_t out[], size_t length, size_t peek_offset) const override {
+         if(peek_offset >= m_buf.size() - m_offset) {
+            return 0;
+         }
+         const size_t got = std::min(m_buf.size() - m_offset - peek_offset, length);
+         copy_mem(out, m_buf.data() + m_offset + peek_offset, got);
+         return got;
+      }
+
+      bool check_available(size_t n) override { return n <= (m_buf.size() - m_offset); }
+
+      bool end_of_data() const override { return m_offset == m_buf.size(); }
+
+      size_t get_bytes_read() const override { return m_offset; }
+
+      explicit DataSource_Span(std::span<const uint8_t> buf) : m_buf(buf) {}
+
+   private:
+      std::span<const uint8_t> m_buf;
       size_t m_offset = 0;
 };
 
@@ -864,5 +900,41 @@ BER_Decoder& BER_Decoder::decode_named_bitstring(uint64_t& out,
    out = decoded;
    return (*this);
 }
+
+namespace ASN1 {
+
+bool is_single_der_object(std::span<const uint8_t> bytes, ASN1_Type expected_type, ASN1_Class expected_class) {
+   if(bytes.empty()) {
+      return false;
+   }
+
+   try {
+      DataSource_Span src(bytes);
+
+      ASN1_Type type_tag = ASN1_Type::NoObject;
+      ASN1_Class class_tag = ASN1_Class::NoObject;
+      const size_t tag_bytes = decode_tag(&src, type_tag, class_tag);
+
+      if(type_tag != expected_type || class_tag != expected_class) {
+         return false;
+      }
+
+      const auto dl = decode_length(&src, /*allow_indef=*/0, /*der_mode=*/true, is_constructed(expected_class));
+
+      const size_t header_bytes = tag_bytes + dl.field_length();
+      if(header_bytes > bytes.size()) {
+         return false;
+      }
+      return dl.content_length() == bytes.size() - header_bytes;
+   } catch(Decoding_Error&) {
+      return false;
+   }
+}
+
+bool is_der_sequence_header(std::span<const uint8_t> bytes) {
+   return is_single_der_object(bytes, ASN1_Type::Sequence, ASN1_Class::Universal | ASN1_Class::Constructed);
+}
+
+}  // namespace ASN1
 
 }  // namespace Botan

--- a/src/lib/asn1/info.txt
+++ b/src/lib/asn1/info.txt
@@ -22,5 +22,6 @@ pss_params.h
 </header:public>
 
 <header:internal>
+asn1_utils.h
 oid_map.h
 </header:internal>

--- a/src/tests/test_asn1.cpp
+++ b/src/tests/test_asn1.cpp
@@ -14,6 +14,7 @@
    #include <botan/bigint.h>
    #include <botan/data_src.h>
    #include <botan/der_enc.h>
+   #include <botan/hex.h>
    #include <botan/pss_params.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/parsing.h>
@@ -634,6 +635,45 @@ Test::Result test_pss_params_rejects_trailing_data_in_mgf1_params() {
    return result;
 }
 
+Test::Result test_alg_id_parameter_validation() {
+   Test::Result result("AlgorithmIdentifier parameter validation");
+
+   auto decode_alg_id = [](std::string_view hex) {
+      const auto wire = Botan::hex_decode(hex);
+      Botan::AlgorithmIdentifier alg_id;
+      Botan::BER_Decoder(wire).decode(alg_id).verify_end();
+   };
+
+   auto verify_params_accepted = [&](const std::string& label, std::string_view hex) {
+      try {
+         decode_alg_id(hex);
+         result.test_success(Botan::fmt("{} parameters accepted", label));
+      } catch(const std::exception& e) {
+         result.test_failure(Botan::fmt("{} parameters unexpectedly rejected: {}", label, e.what()));
+      }
+   };
+
+   auto verify_params_rejected = [&](const std::string& label, std::string_view hex) {
+      result.test_throws<Botan::Decoding_Error>(Botan::fmt("{} parameters rejected", label),
+                                                [&]() { decode_alg_id(hex); });
+   };
+
+   // The wire is SEQUENCE { OID 2.5.4.3, <parameters> } in each case
+
+   verify_params_accepted("absent", "30050603550403");
+   verify_params_accepted("NULL", "300706035504030500");
+   verify_params_accepted("SEQUENCE", "300706035504033000");
+   verify_params_accepted("OID", "300A06035504030603550403");
+   verify_params_accepted("OCTET STRING", "300906035504030402AABB");
+
+   verify_params_rejected("two values (NULL, NULL)", "3009060355040305000500");
+   verify_params_rejected("trailing data after NULL", "300A06035504030500020100");
+   verify_params_rejected("truncated SEQUENCE", "300706035504033005");
+   verify_params_rejected("single INTEGER", "30080603550403020100");
+
+   return result;
+}
+
 class ASN1_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
@@ -657,6 +697,7 @@ class ASN1_Tests final : public Test {
          results.push_back(test_asn1_bitstring_helpers());
          results.push_back(test_asn1_string_zero_length_roundtrip());
          results.push_back(test_pss_params_rejects_trailing_data_in_mgf1_params());
+         results.push_back(test_alg_id_parameter_validation());
 
          return results;
       }


### PR DESCRIPTION
In theory this parameters block is ANY but in practice it is one a few handful of values. Validate on decode that it is exactly a single DER TLV of one of the following types: NULL, SEQUENCE, OBJECT IDENTIFIER, or OCTET STRING.

This may not entirely stick. We might have to drop back to requiring eg a DER TLV of any type, relying on higher levels to perform the full validation step.