### PR TITLE
Introduce PK_Decryptor(_EME)::ciphertext_length()

### DIFF
--- a/src/lib/prov/pkcs11/p11_rsa.cpp
+++ b/src/lib/prov/pkcs11/p11_rsa.cpp
@@ -141,6 +141,8 @@ class PKCS11_RSA_Decryption_Operation final : public PK_Ops::Decryption {
 
       size_t plaintext_length(size_t /*ctext_len*/) const override { return m_key.get_n().bytes(); }
 
+      size_t ciphertext_length(size_t /*ptext_len*/) const override { return m_key.get_n().bytes(); }
+
       secure_vector<uint8_t> decrypt(uint8_t& valid_mask, std::span<const uint8_t> ctext) override {
          valid_mask = 0;
 
@@ -205,6 +207,8 @@ class PKCS11_RSA_Decryption_Operation_Software_EME final : public PK_Ops::Decryp
             PK_Ops::Decryption_with_Padding(padding), m_raw_op(key, "Raw", rng) {}
 
       size_t plaintext_length(size_t ctext_len) const override { return m_raw_op.plaintext_length(ctext_len); }
+
+      size_t ciphertext_length(size_t ptext_len) const override { return m_raw_op.ciphertext_length(ptext_len); }
 
       secure_vector<uint8_t> raw_decrypt(std::span<const uint8_t> input) override {
          // Returns the fixed-width RSA encoded message (I2OSP(m, k)); the outer

--- a/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
+++ b/src/lib/prov/tpm2/tpm2_rsa/tpm2_rsa.cpp
@@ -381,6 +381,10 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption {
          return m_key_handle._public_info(m_sessions, TPM2_ALG_RSA).pub->publicArea.parameters.rsaDetail.keyBits / 8;
       }
 
+      size_t ciphertext_length(size_t /* ptext_len */) const override {
+         return m_key_handle._public_info(m_sessions, TPM2_ALG_RSA).pub->publicArea.parameters.rsaDetail.keyBits / 8;
+      }
+
    private:
       const Object& m_key_handle;
       const SessionBundle& m_sessions;

--- a/src/lib/pubkey/dlies/dlies.cpp
+++ b/src/lib/pubkey/dlies/dlies.cpp
@@ -127,6 +127,20 @@ size_t DLIES_Decryptor::plaintext_length(size_t ctext_len) const {
    return ctext_len - (m_pub_key_size + m_mac->output_length());
 }
 
+size_t DLIES_Decryptor::ciphertext_length(size_t ptext_len) const {
+   const auto ctext_len = [&]() -> size_t {
+      if(m_cipher != nullptr) {
+         // We need the encryption direction to estimate ciphertext lengths
+         const auto cipher = Cipher_Mode::create(m_cipher->name(), Cipher_Dir::Encryption);
+         return cipher->output_length(ptext_len);
+      } else {
+         return ptext_len;
+      }
+   }();
+
+   return m_pub_key_size + m_mac->output_length() + ctext_len;
+}
+
 secure_vector<uint8_t> DLIES_Decryptor::do_decrypt(uint8_t& valid_mask, const uint8_t msg[], size_t length) const {
    if(length < m_pub_key_size + m_mac->output_length()) {
       throw Decoding_Error("DLIES decryption: ciphertext is too short");

--- a/src/lib/pubkey/dlies/dlies.h
+++ b/src/lib/pubkey/dlies/dlies.h
@@ -137,6 +137,8 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Decryptor final : public PK_Decryptor {
 
       size_t plaintext_length(size_t ctext_len) const override;
 
+      size_t ciphertext_length(size_t ptext_len) const override;
+
       const size_t m_pub_key_size;
       PK_Key_Agreement m_ka;
       std::unique_ptr<KDF> m_kdf;

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -394,6 +394,17 @@ size_t ECIES_Decryptor::plaintext_length(size_t ctext_len) const {
    return m_cipher->output_length(ctext_len - overhead);
 }
 
+size_t ECIES_Decryptor::ciphertext_length(size_t ptext_len) const {
+   // We need the encryption direction to estimate the ciphertext length given
+   // an expected plaintext length.
+   auto cipher = m_params.create_cipher(Cipher_Dir::Encryption);
+
+   const size_t point_size = compute_point_size(m_params.group(), m_params.point_format());
+   const size_t mac_size = m_mac->output_length();
+   const size_t ct_size_bound = cipher->output_length(ptext_len);
+   return point_size + mac_size + ct_size_bound;
+}
+
 /**
 * ECIES Decryption according to ISO 18033-2
 */

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -341,6 +341,8 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_Decryptor final : public PK_Decryptor {
 
       size_t plaintext_length(size_t ctext_len) const override;
 
+      size_t ciphertext_length(size_t ptext_len) const override;
+
       const ECIES_KA_Operation m_ka;
       const ECIES_System_Params m_params;
       std::unique_ptr<MessageAuthenticationCode> m_mac;

--- a/src/lib/pubkey/elgamal/elgamal.cpp
+++ b/src/lib/pubkey/elgamal/elgamal.cpp
@@ -175,6 +175,8 @@ class ElGamal_Decryption_Operation final : public PK_Ops::Decryption_with_Paddin
 
       size_t plaintext_length(size_t /*ctext_len*/) const override { return m_key->group().p_bytes(); }
 
+      size_t ciphertext_length(size_t /*ptext_len*/) const override { return 2 * m_key->group().p_bytes(); }
+
       secure_vector<uint8_t> raw_decrypt(std::span<const uint8_t> ctext) override;
 
    private:

--- a/src/lib/pubkey/pk_ops.h
+++ b/src/lib/pubkey/pk_ops.h
@@ -68,6 +68,12 @@ class BOTAN_UNSTABLE_API Decryption /* NOLINT(*special-member-functions) */ {
 
       virtual size_t plaintext_length(size_t ctext_len) const = 0;
 
+      /**
+      * Given the plaintext length, return an upper bound on the ciphertext
+      * length that decrypt() expects for this key and padding.
+      */
+      virtual size_t ciphertext_length(size_t ptext_len) const = 0;
+
       virtual ~Decryption() = default;
 };
 

--- a/src/lib/pubkey/pubkey.cpp
+++ b/src/lib/pubkey/pubkey.cpp
@@ -135,6 +135,10 @@ size_t PK_Decryptor_EME::plaintext_length(size_t ctext_len) const {
    return m_op->plaintext_length(ctext_len);
 }
 
+size_t PK_Decryptor_EME::ciphertext_length(size_t ptext_len) const {
+   return m_op->ciphertext_length(ptext_len);
+}
+
 secure_vector<uint8_t> PK_Decryptor_EME::do_decrypt(uint8_t& valid_mask, const uint8_t in[], size_t in_len) const {
    return m_op->decrypt(valid_mask, {in, in_len});
 }

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -133,6 +133,12 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor {
       */
       virtual size_t plaintext_length(size_t ctext_len) const = 0;
 
+      /**
+      * Return an upper bound on the ciphertext length for a particular
+      * plaintext input length.
+      */
+      virtual size_t ciphertext_length(size_t ptext_len) const = 0;
+
       PK_Decryptor() = default;
       virtual ~PK_Decryptor() = default;
 
@@ -541,6 +547,8 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor_EME final : public PK_Decryptor {
                        std::string_view provider = "");
 
       size_t plaintext_length(size_t ctext_len) const override;
+
+      size_t ciphertext_length(size_t ptext_len) const override;
 
       ~PK_Decryptor_EME() override;
 

--- a/src/lib/pubkey/pubkey.h
+++ b/src/lib/pubkey/pubkey.h
@@ -56,7 +56,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Encryptor {
       /**
       * Return an upper bound on the ciphertext length
       */
-      virtual size_t ciphertext_length(size_t ctext_len) const = 0;
+      virtual size_t ciphertext_length(size_t ptext_len) const = 0;
 
       PK_Encryptor() = default;
       virtual ~PK_Encryptor() = default;
@@ -540,7 +540,7 @@ class BOTAN_PUBLIC_API(2, 0) PK_Decryptor_EME final : public PK_Decryptor {
                        std::string_view padding,
                        std::string_view provider = "");
 
-      size_t plaintext_length(size_t ptext_len) const override;
+      size_t plaintext_length(size_t ctext_len) const override;
 
       ~PK_Decryptor_EME() override;
 

--- a/src/lib/pubkey/rsa/rsa.cpp
+++ b/src/lib/pubkey/rsa/rsa.cpp
@@ -701,6 +701,8 @@ class RSA_Decryption_Operation final : public PK_Ops::Decryption_with_Padding,
 
       size_t plaintext_length(size_t /*ctext_len*/) const override { return public_modulus_bytes(); }
 
+      size_t ciphertext_length(size_t /*ptext_len*/) const override { return public_modulus_bytes(); }
+
       secure_vector<uint8_t> raw_decrypt(std::span<const uint8_t> input) override {
          /*
          * RFC 8017 7.1.2 and 7.2.2

--- a/src/lib/pubkey/sm2/sm2_enc.cpp
+++ b/src/lib/pubkey/sm2/sm2_enc.cpp
@@ -110,6 +110,13 @@ class SM2_Decryption_Operation final : public PK_Ops::Decryption {
          return ptext_len - (2 * elem_size + m_hash->output_length());
       }
 
+      size_t ciphertext_length(size_t ptext_len) const override {
+         const size_t elem_size = m_group.get_order_bytes();
+         const size_t der_overhead = 16;
+
+         return der_overhead + 2 * elem_size + m_hash->output_length() + ptext_len;
+      }
+
       secure_vector<uint8_t> decrypt(uint8_t& valid_mask, std::span<const uint8_t> ctext) override {
          const size_t p_bytes = m_group.get_p_bytes();
 

--- a/src/tests/test_dlies.cpp
+++ b/src/tests/test_dlies.cpp
@@ -86,8 +86,15 @@ class DLIES_KAT_Tests final : public Text_Based_Test {
 
          encryptor.set_other_key(to.public_value());
 
+         const auto ct_len_bound_enc = static_cast<Botan::PK_Encryptor&>(encryptor).ciphertext_length(input.size());
+         const auto ct_len_bound_dec = static_cast<Botan::PK_Decryptor&>(decryptor).ciphertext_length(input.size());
+         result.test_sz_eq("ciphertext length bounds match", ct_len_bound_enc, ct_len_bound_dec);
+
          result.test_bin_eq("encryption", encryptor.encrypt(input, this->rng()), expected);
          result.test_bin_eq("decryption", decryptor.decrypt(expected), input);
+         result.test_sz_lte("ciphertext length within bound",
+                            expected.size(),
+                            static_cast<Botan::PK_Decryptor&>(decryptor).ciphertext_length(input.size()));
 
          check_invalid_ciphertexts(result, decryptor, input, expected, this->rng());
 
@@ -148,6 +155,9 @@ Test::Result test_xor() {
          result.test_throws("ciphertext too short", [&decryptor]() { decryptor.decrypt(std::vector<uint8_t>(2)); });
 
          result.test_bin_eq("decryption", decryptor.decrypt(ciphertext), plaintext);
+         result.test_sz_lte("ciphertext length within bound",
+                            ciphertext.size(),
+                            static_cast<Botan::PK_Decryptor&>(decryptor).ciphertext_length(plaintext.size()));
 
          check_invalid_ciphertexts(result, decryptor, unlock(plaintext), ciphertext, *rng);
       }

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -62,12 +62,22 @@ void check_encrypt_decrypt(Test::Result& result,
          ecies_dec.set_label(label);
       }
 
+      const auto ct_len_bound_enc = static_cast<Botan::PK_Encryptor&>(ecies_enc).ciphertext_length(plaintext.size());
+      const auto ct_len_bound_dec = static_cast<Botan::PK_Decryptor&>(ecies_dec).ciphertext_length(plaintext.size());
+      result.test_sz_eq("ciphertext length bounds match", ct_len_bound_enc, ct_len_bound_dec);
+
       const std::vector<uint8_t> encrypted = ecies_enc.encrypt(plaintext, rng);
       if(!ciphertext.empty()) {
          result.test_bin_eq("encrypted data", encrypted, ciphertext);
       }
+      result.test_sz_lte("ciphertext length within bounds",
+                         encrypted.size(),
+                         static_cast<Botan::PK_Decryptor&>(ecies_dec).ciphertext_length(plaintext.size()));
       const Botan::secure_vector<uint8_t> decrypted = ecies_dec.decrypt(encrypted);
       result.test_bin_eq("decrypted data equals plaintext", decrypted, plaintext);
+
+      const auto pt_len_bound_dec = static_cast<Botan::PK_Decryptor&>(ecies_dec).plaintext_length(encrypted.size());
+      result.test_sz_lte("plaintext length bounds match", plaintext.size(), pt_len_bound_dec);
 
       std::vector<uint8_t> invalid_encrypted = encrypted;
       uint8_t& last_byte = invalid_encrypted[invalid_encrypted.size() - 1];

--- a/src/tests/test_pkcs11_high_level.cpp
+++ b/src/tests/test_pkcs11_high_level.cpp
@@ -775,6 +775,8 @@ Test::Result test_rsa_encrypt_decrypt() {
          try {
             const Botan::PK_Encryptor_EME encryptor(keypair.first, *rng, padding);
             encrypted = encryptor.encrypt(plaintext, *rng);
+            result.test_sz_lte(
+               "ciphertext length estimate", encrypted.size(), encryptor.ciphertext_length(plaintext.size()));
          } catch(Botan::PKCS11::PKCS11_ReturnError& e) {
             result.test_failure("PKCS11 RSA encrypt " + padding, e.what());
          }
@@ -785,6 +787,11 @@ Test::Result test_rsa_encrypt_decrypt() {
             keypair.second.set_use_software_padding(blinding);
             const Botan::PK_Decryptor_EME decryptor(keypair.second, *rng, padding);
             decrypted = decryptor.decrypt(encrypted);
+
+            result.test_sz_lte(
+               "plaintext length estimate", decrypted.size(), decryptor.plaintext_length(encrypted.size()));
+            result.test_sz_lte(
+               "ciphertext length estimate", encrypted.size(), decryptor.ciphertext_length(decrypted.size()));
          } catch(Botan::PKCS11::PKCS11_ReturnError& e) {
             std::ostringstream err;
             err << "PKCS11 RSA decrypt " << padding;

--- a/src/tests/test_pubkey.cpp
+++ b/src/tests/test_pubkey.cpp
@@ -417,6 +417,8 @@ Test::Result PK_Encryption_Decryption_Test::run_one_test(const std::string& pad_
 
          result.test_sz_lte(
             "Plaintext within length", decrypted.size(), decryptor->plaintext_length(ciphertext.size()));
+         result.test_sz_lte(
+            "Ciphertext within length", ciphertext.size(), decryptor->ciphertext_length(plaintext.size()));
       } catch(Botan::Exception& e) {
          result.test_failure("Failed to decrypt KAT ciphertext", e.what());
       }
@@ -488,6 +490,8 @@ Test::Result PK_Decryption_Test::run_one_test(const std::string& pad_hdr, const 
       Botan::secure_vector<uint8_t> decrypted;
       try {
          decrypted = decryptor->decrypt(ciphertext);
+         result.test_sz_lte(
+            "Ciphertext within length", ciphertext.size(), decryptor->ciphertext_length(plaintext.size()));
       } catch(Botan::Exception& e) {
          result.test_failure("Failed to decrypt KAT ciphertext", e.what());
       }

--- a/src/tests/test_tpm2.cpp
+++ b/src/tests/test_tpm2.cpp
@@ -702,6 +702,10 @@ std::vector<Test::Result> test_tpm2_rsa() {
                const Botan::PK_Encryptor_EME enc(*pk, null_rng, "OAEP(SHA-256)");
                const auto ciphertext = enc.encrypt(plaintext, null_rng);
 
+               // make sure that the ciphertext estimate tallies
+               const auto ciphertext_estimate = enc.ciphertext_length(plaintext.size());
+               result.test_sz_lte("ciphertext length estimate", ciphertext.size(), ciphertext_estimate);
+
                // decrypt the message using the TPM's private RSA key
                const Botan::PK_Decryptor_EME dec(*sk, null_rng, "OAEP(SHA-256)");
                const auto decrypted = dec.decrypt(ciphertext);
@@ -726,6 +730,12 @@ std::vector<Test::Result> test_tpm2_rsa() {
                Botan::PK_Decryptor_EME dec(*key, null_rng /* TPM takes care of this */, "OAEP(SHA-256)");
                const auto decrypted = dec.decrypt(ciphertext);
                result.test_bin_eq("decrypted message", decrypted, plaintext);
+
+               // make sure that the ciphertext and plaintext estimates tally
+               const auto plaintext_estimate = dec.plaintext_length(ciphertext.size());
+               const auto ciphertext_estimate = enc.ciphertext_length(plaintext.size());
+               result.test_sz_lte("plaintext length estimate", plaintext.size(), plaintext_estimate);
+               result.test_sz_lte("ciphertext length estimate", ciphertext.size(), ciphertext_estimate);
 
                // corrupt the ciphertext and try to decrypt it
                auto mutated_ciphertext = Test::mutate_vec(ciphertext, *rng);


### PR DESCRIPTION
This allows querying an instance of `PK_Decryptor` for an estimate of the expected ciphertext size given an expected plaintext length. In the general use case that might not be overly useful, assuming that the plaintext size is not known before decryption.

However, for many algorithms (most notably RSA or ElGamal) the expected ciphertext size is actually fixed and only dependent on the key length. For those, the new method facilitates an algorithm-agnostic querying of the expected ciphertext size, e.g. for input validation, pre-allocation and such.

Concretely, it comes in handy in the context of #5686 where we need an RSA-to-KEM Adapter and `PK_KEM_Decryptor` has an `encapsulated_key_length()` accessor that can be implemented conveniently with this new method.

Additionally this fixes two confusing typos in the abstract public interface classes.