### PR TITLE
Add support for constructed OCTET STRING and BIT STRING during BER decoding

### DIFF
--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -819,20 +819,119 @@ bool is_constructed(const BER_Object& obj) {
    return is_constructed(obj.class_tag());
 }
 
+/*
+* Bounds the nesting of constructed OCTET STRING/BIT STRING encodings.
+*
+* It's allowed, though probably rarely used, for a BER constructed string
+* to have a segment which is itself a BER constructed string. We handle
+* this recursively, so place an explicit limit on how deep we'll go.
+*/
+constexpr size_t ALLOWED_CONSTRUCTED_STRING_NESTING = 2;
+
+/*
+* Concatenate the segments of a BER constructed OCTET STRING (X.690 sec 8.7.3)
+*
+* In the constructed form the secondary tags are always universal OCTET STRING
+* rather than any possible implicit tag. It's also allowed for any of the
+* segments to themselves be constructed.
+*/
+template <typename Alloc>
+void asn1_concat_constructed_octet_string(std::vector<uint8_t, Alloc>& buffer,
+                                          const BER_Object& obj,
+                                          const BER_Decoder::Limits& limits,
+                                          size_t depth) {
+   if(depth >= ALLOWED_CONSTRUCTED_STRING_NESTING) {
+      throw BER_Decoding_Error("Constructed OCTET STRING is too deeply nested");
+   }
+
+   BER_Decoder segments(obj, limits);
+   while(segments.more_items()) {
+      const BER_Object seg = segments.get_next_object();
+      if(seg.is_a(ASN1_Type::OctetString, ASN1_Class::Universal)) {
+         buffer.insert(buffer.end(), seg.bits(), seg.bits() + seg.length());
+      } else if(seg.is_a(ASN1_Type::OctetString, ASN1_Class::Universal | ASN1_Class::Constructed)) {
+         asn1_concat_constructed_octet_string(buffer, seg, limits, depth + 1);
+      } else {
+         throw BER_Decoding_Error("Constructed OCTET STRING contains an invalid segment");
+      }
+   }
+}
+
+/*
+* Concatenate the segments of a BER constructed BIT STRING (X.690 sec 8.6.4)
+*
+* Returns the unused bit count of the final segment; BER requires that every
+* earlier segment must be a multiple of eight bits.
+*/
+template <typename Alloc>
+uint8_t asn1_concat_constructed_bit_string(std::vector<uint8_t, Alloc>& buffer,
+                                           const BER_Object& obj,
+                                           const BER_Decoder::Limits& limits,
+                                           size_t depth) {
+   if(depth >= ALLOWED_CONSTRUCTED_STRING_NESTING) {
+      throw BER_Decoding_Error("Constructed BIT STRING is too deeply nested");
+   }
+
+   uint8_t unused_bits = 0;
+
+   BER_Decoder segments(obj, limits);
+   while(segments.more_items()) {
+      if(unused_bits != 0) {
+         throw BER_Decoding_Error("Constructed BIT STRING has unused bits before the final segment");
+      }
+
+      const BER_Object seg = segments.get_next_object();
+      if(seg.is_a(ASN1_Type::BitString, ASN1_Class::Universal)) {
+         if(seg.length() == 0) {
+            throw BER_Decoding_Error("Invalid BIT STRING");
+         }
+         unused_bits = seg.bits()[0];
+         if(unused_bits >= 8) {
+            throw BER_Decoding_Error("Bad number of unused bits in BIT STRING");
+         }
+         if(seg.length() == 1 && unused_bits != 0) {
+            throw BER_Decoding_Error("Invalid BIT STRING");
+         }
+         buffer.insert(buffer.end(), seg.bits() + 1, seg.bits() + seg.length());
+      } else if(seg.is_a(ASN1_Type::BitString, ASN1_Class::Universal | ASN1_Class::Constructed)) {
+         unused_bits = asn1_concat_constructed_bit_string(buffer, seg, limits, depth + 1);
+      } else {
+         throw BER_Decoding_Error("Constructed BIT STRING contains an invalid segment");
+      }
+   }
+
+   return unused_bits;
+}
+
 template <typename Alloc>
 void asn1_decode_binary_string(std::vector<uint8_t, Alloc>& buffer,
                                const BER_Object& obj,
                                ASN1_Type real_type,
                                ASN1_Type type_tag,
                                ASN1_Class class_tag,
-                               bool require_der) {
-   obj.assert_is_a(type_tag, class_tag);
-
-   // Only primitive OCTET STRING/BIT STRING are supported; constructed
-   // (fragmented) BER forms are rejected rather than concatenated.
+                               const BER_Decoder::Limits& limits) {
+   // DER requires BIT STRING and OCTET STRING to use primitive encoding;
+   // in BER the constructed (fragmented) form is decoded by concatenation
    if(is_constructed(obj)) {
-      throw BER_Decoding_Error("Constructed OCTET STRING/BIT STRING is not supported");
+      obj.assert_is_a(type_tag, class_tag | ASN1_Class::Constructed);
+
+      if(limits.require_der_encoding()) {
+         throw BER_Decoding_Error("Detected constructed string encoding in DER structure");
+      }
+
+      // Concatenate into a temporary so a failed decode leaves buffer unmodified
+      std::vector<uint8_t, Alloc> concat;
+      concat.reserve(obj.length());  // upper possible bound on the output size
+      if(real_type == ASN1_Type::OctetString) {
+         asn1_concat_constructed_octet_string(concat, obj, limits, 0);
+      } else {
+         asn1_concat_constructed_bit_string(concat, obj, limits, 0);
+      }
+      buffer = std::move(concat);
+      return;
    }
+
+   obj.assert_is_a(type_tag, class_tag);
 
    if(real_type == ASN1_Type::OctetString) {
       buffer.assign(obj.bits(), obj.bits() + obj.length());
@@ -853,7 +952,7 @@ void asn1_decode_binary_string(std::vector<uint8_t, Alloc>& buffer,
       }
 
       // DER requires unused bits in BIT STRING to be zero (X.690 section 11.2.2)
-      if(require_der && unused_bits > 0) {
+      if(limits.require_der_encoding() && unused_bits > 0) {
          const uint8_t last_byte = obj.bits()[obj.length() - 1];
          if((last_byte & ((1 << unused_bits) - 1)) != 0) {
             throw BER_Decoding_Error("Detected non-zero padding bits in BIT STRING in DER structure");
@@ -870,12 +969,7 @@ void asn1_decode_binary_string(std::vector<uint8_t, Alloc>& buffer,
 
 uint8_t asn1_bitstring_unused_bits(const BER_Object& obj, ASN1_Type type_tag, ASN1_Class class_tag, bool require_der) {
    obj.assert_is_a(type_tag, class_tag);
-
-   // Only primitive BIT STRING is supported; constructed (fragmented) BER
-   // forms are rejected rather than concatenated.
-   if(is_constructed(obj)) {
-      throw BER_Decoding_Error("Constructed OCTET STRING/BIT STRING is not supported");
-   }
+   BOTAN_ASSERT_NOMSG(!is_constructed(obj));
 
    if(obj.length() == 0) {
       throw BER_Decoding_Error("Invalid BIT STRING");
@@ -914,8 +1008,7 @@ BER_Decoder& BER_Decoder::decode(secure_vector<uint8_t>& buffer,
       throw BER_Bad_Tag("Bad tag for {BIT,OCTET} STRING", static_cast<uint32_t>(real_type));
    }
 
-   asn1_decode_binary_string(
-      buffer, get_next_object(), real_type, type_tag, class_tag, m_limits.require_der_encoding());
+   asn1_decode_binary_string(buffer, get_next_object(), real_type, type_tag, class_tag, m_limits);
    return (*this);
 }
 
@@ -927,17 +1020,27 @@ BER_Decoder& BER_Decoder::decode(std::vector<uint8_t>& buffer,
       throw BER_Bad_Tag("Bad tag for {BIT,OCTET} STRING", static_cast<uint32_t>(real_type));
    }
 
-   asn1_decode_binary_string(
-      buffer, get_next_object(), real_type, type_tag, class_tag, m_limits.require_der_encoding());
+   asn1_decode_binary_string(buffer, get_next_object(), real_type, type_tag, class_tag, m_limits);
    return (*this);
 }
 
 BER_Decoder& BER_Decoder::decode_bitstring(ASN1_BitString& out, ASN1_Type type_tag, ASN1_Class class_tag) {
    const BER_Object obj = get_next_object();
-   const uint8_t unused_bits = asn1_bitstring_unused_bits(obj, type_tag, class_tag, m_limits.require_der_encoding());
 
    std::vector<uint8_t> bits;
-   bits.assign(obj.bits() + 1, obj.bits() + obj.length());
+   uint8_t unused_bits = 0;
+
+   if(is_constructed(obj.class_tag())) {
+      obj.assert_is_a(type_tag, class_tag | ASN1_Class::Constructed);
+      if(m_limits.require_der_encoding()) {
+         throw BER_Decoding_Error("Detected constructed string encoding in DER structure");
+      }
+      bits.reserve(obj.length());  // upper possible bound on the output size
+      unused_bits = asn1_concat_constructed_bit_string(bits, obj, m_limits, 0);
+   } else {
+      unused_bits = asn1_bitstring_unused_bits(obj, type_tag, class_tag, m_limits.require_der_encoding());
+      bits.assign(obj.bits() + 1, obj.bits() + obj.length());
+   }
 
    if(unused_bits > 0 && !bits.empty()) {
       bits.back() &= static_cast<uint8_t>(0xFF << unused_bits);

--- a/src/tests/test_asn1.cpp
+++ b/src/tests/test_asn1.cpp
@@ -165,37 +165,111 @@ Test::Result test_ber_max_object_size() {
    return result;
 }
 
-Test::Result test_ber_constructed_string_rejected() {
-   Test::Result result("BER constructed OCTET/BIT STRING rejected");
+Test::Result test_ber_constructed_string_decoding() {
+   Test::Result result("BER constructed OCTET/BIT STRING decoding");
 
    using Botan::ASN1_Class;
    using Botan::ASN1_Type;
 
-   // Constructed OCTET STRING (24) wrapping two OCTET STRING fragments
-   const std::vector<uint8_t> cons_octet = {0x24, 0x06, 0x04, 0x02, 0xAA, 0xBB, 0x04, 0x00};
-   // Constructed BIT STRING (23) wrapping one BIT STRING fragment
-   const std::vector<uint8_t> cons_bits = {0x23, 0x04, 0x03, 0x02, 0x00, 0xAA};
+   const auto ber = Botan::BER_Decoder::Limits::BER();
 
-   // Reachable when the caller's expected class matches the constructed object;
-   // rejected in both BER and DER
-   for(auto limits : {Botan::BER_Decoder::Limits::BER(), Botan::BER_Decoder::Limits::DER()}) {
-      result.test_throws<Botan::Decoding_Error>("constructed OCTET STRING rejected", [&]() {
-         std::vector<uint8_t> out;
-         Botan::BER_Decoder(cons_octet, limits)
-            .decode(out, ASN1_Type::OctetString, ASN1_Type::OctetString, ASN1_Class::Constructed);
-      });
+   // Constructed OCTET STRING wrapping two fragments plus an empty one
+   const std::vector<uint8_t> cons_octet = {0x24, 0x09, 0x04, 0x02, 0xAA, 0xBB, 0x04, 0x00, 0x04, 0x01, 0xCC};
+   // The same value using indefinite length
+   const std::vector<uint8_t> cons_octet_indef = {
+      0x24, 0x80, 0x04, 0x02, 0xAA, 0xBB, 0x04, 0x00, 0x04, 0x01, 0xCC, 0x00, 0x00};
+   // The same value with a nested constructed segment holding the last fragment
+   const std::vector<uint8_t> cons_octet_nested = {
+      0x24, 0x0B, 0x04, 0x02, 0xAA, 0xBB, 0x24, 0x80, 0x04, 0x01, 0xCC, 0x00, 0x00};
+   const std::vector<uint8_t> expected_octets = {0xAA, 0xBB, 0xCC};
 
-      result.test_throws<Botan::Decoding_Error>("constructed BIT STRING rejected", [&]() {
-         std::vector<uint8_t> out;
-         Botan::BER_Decoder(cons_bits, limits)
-            .decode(out, ASN1_Type::BitString, ASN1_Type::BitString, ASN1_Class::Constructed);
-      });
-
-      result.test_throws<Botan::Decoding_Error>("constructed BIT STRING rejected via decode_bitstring", [&]() {
-         Botan::ASN1_BitString bs;
-         Botan::BER_Decoder(cons_bits, limits).decode_bitstring(bs, ASN1_Type::BitString, ASN1_Class::Constructed);
-      });
+   for(const auto& input : {cons_octet, cons_octet_indef, cons_octet_nested}) {
+      std::vector<uint8_t> out;
+      Botan::BER_Decoder(input, ber).decode(out, ASN1_Type::OctetString).verify_end();
+      result.test_bin_eq("constructed OCTET STRING concatenated", out, expected_octets);
    }
+
+   // An implicitly tagged [0] constructed OCTET STRING
+   const std::vector<uint8_t> cons_octet_implicit = {0xA0, 0x07, 0x04, 0x02, 0xAA, 0xBB, 0x04, 0x01, 0xCC};
+   std::vector<uint8_t> implicit_out;
+   Botan::BER_Decoder(cons_octet_implicit, ber)
+      .decode(implicit_out, ASN1_Type::OctetString, ASN1_Type(0), ASN1_Class::ContextSpecific)
+      .verify_end();
+   result.test_bin_eq("implicitly tagged constructed OCTET STRING", implicit_out, expected_octets);
+
+   // Constructed BIT STRING: 8 bits then 4 bits, so the final segment
+   // carries 4 unused bits
+   const std::vector<uint8_t> cons_bits = {0x23, 0x08, 0x03, 0x02, 0x00, 0xAA, 0x03, 0x02, 0x04, 0xB0};
+   Botan::ASN1_BitString bs;
+   Botan::BER_Decoder(cons_bits, ber).decode_bitstring(bs).verify_end();
+   result.test_sz_eq("constructed BIT STRING length", bs.bit_length(), 12);
+   result.test_bin_eq("constructed BIT STRING value", bs.bytes(), std::vector<uint8_t>{0xAA, 0xB0});
+
+   std::vector<uint8_t> bits_out;
+   Botan::BER_Decoder(cons_bits, ber).decode(bits_out, ASN1_Type::BitString).verify_end();
+   result.test_bin_eq("constructed BIT STRING via vector decode", bits_out, std::vector<uint8_t>{0xAA, 0xB0});
+
+   // A constructed string with no segments is an empty string
+   const std::vector<uint8_t> cons_empty = {0x24, 0x00};
+   std::vector<uint8_t> empty_out = {0xFF};
+   Botan::BER_Decoder(cons_empty, ber).decode(empty_out, ASN1_Type::OctetString).verify_end();
+   result.test_sz_eq("empty constructed OCTET STRING", empty_out.size(), 0);
+
+   // Unused bits are only permitted in the final segment (X.690 8.6.4)
+   const std::vector<uint8_t> bad_bits = {0x23, 0x08, 0x03, 0x02, 0x04, 0xA0, 0x03, 0x02, 0x00, 0xBB};
+   result.test_throws<Botan::Decoding_Error>("unused bits before final segment rejected", [&]() {
+      Botan::ASN1_BitString out;
+      Botan::BER_Decoder(bad_bits, ber).decode_bitstring(out);
+   });
+
+   // Segments must have the same string type as the outer object
+   const std::vector<uint8_t> bad_segment = {0x24, 0x04, 0x03, 0x02, 0x00, 0xAA};
+   result.test_throws<Botan::Decoding_Error>("wrong segment type rejected", [&]() {
+      std::vector<uint8_t> out;
+      Botan::BER_Decoder(bad_segment, ber).decode(out, ASN1_Type::OctetString);
+   });
+
+   // Nesting beyond the limit is rejected. This value must match ALLOWED_CONSTRUCTED_STRING_NESTING
+   // in ber_dec.cpp
+   constexpr size_t expected_constr_nesting_allowed = 2;
+
+   for(size_t depth = 0; depth != 16; ++depth) {
+      std::vector<uint8_t> deep = {0x04, 0x01, 0xAA};
+      for(size_t i = 0; i != depth; ++i) {
+         std::vector<uint8_t> wrapped = {0x24, static_cast<uint8_t>(deep.size())};
+         wrapped.insert(wrapped.end(), deep.begin(), deep.end());
+         deep = std::move(wrapped);
+      }
+
+      if(depth <= expected_constr_nesting_allowed) {
+         std::vector<uint8_t> out;
+         Botan::BER_Decoder(deep, ber).decode(out, ASN1_Type::OctetString);
+         result.test_success("BER_Decoder accepted nested encoding");
+         result.test_bin_eq("Constructed matched expected value", out, "AA");
+      } else {
+         result.test_throws<Botan::Decoding_Error>("deeply nested constructed string rejected", [&]() {
+            std::vector<uint8_t> out;
+            Botan::BER_Decoder(deep, ber).decode(out, ASN1_Type::OctetString);
+         });
+      }
+   }
+
+   // DER requires the primitive form, in every code path
+   const auto der = Botan::BER_Decoder::Limits::DER();
+   result.test_throws<Botan::Decoding_Error>("constructed OCTET STRING rejected in DER", [&]() {
+      std::vector<uint8_t> out;
+      Botan::BER_Decoder(cons_octet, der)
+         .decode(out, ASN1_Type::OctetString, ASN1_Type::OctetString, ASN1_Class::Constructed);
+   });
+   result.test_throws<Botan::Decoding_Error>("constructed BIT STRING rejected in DER", [&]() {
+      std::vector<uint8_t> out;
+      Botan::BER_Decoder(cons_bits, der)
+         .decode(out, ASN1_Type::BitString, ASN1_Type::BitString, ASN1_Class::Constructed);
+   });
+   result.test_throws<Botan::Decoding_Error>("constructed BIT STRING rejected in DER via decode_bitstring", [&]() {
+      Botan::ASN1_BitString out;
+      Botan::BER_Decoder(cons_bits, der).decode_bitstring(out, ASN1_Type::BitString, ASN1_Class::Constructed);
+   });
 
    return result;
 }
@@ -908,7 +982,7 @@ class ASN1_Tests final : public Test {
          results.push_back(test_ber_eoc_decoding_limits());
          results.push_back(test_ber_standalone_eoc_limits());
          results.push_back(test_ber_max_object_size());
-         results.push_back(test_ber_constructed_string_rejected());
+         results.push_back(test_ber_constructed_string_decoding());
          results.push_back(test_ber_indefinite_length_trailing_data());
          results.push_back(test_ber_find_eoc());
          results.push_back(test_asn1_utf8_ascii_parsing());


### PR DESCRIPTION
In all prior released versions, we would accept this tagging, but decode it incorrectly. The recent commit 838ed8ed86 changed it to outright rejection, which is probably better overall. But it is not difficult to support, and indefinite length BER string encodings are pervasive in protocols like CMS.