### PR TITLE
FIX: Minor quirks in TLS 1.3

### DIFF
--- a/src/lib/tls/tls13/msg_certificate_13.cpp
+++ b/src/lib/tls/tls13/msg_certificate_13.cpp
@@ -17,6 +17,7 @@
 #include <botan/tls_extensions.h>
 #include <botan/tls_policy.h>
 #include <botan/x509_key.h>
+#include <botan/internal/stl_util.h>
 #include <botan/internal/tls_reader.h>
 #include <algorithm>
 #include <iterator>
@@ -39,7 +40,10 @@ std::vector<std::string> filter_signature_schemes(const std::vector<Signature_Sc
    std::vector<std::string> compatible_schemes;
    for(const auto& scheme : peer_scheme_preference) {
       if(scheme.is_available() && scheme.is_compatible_with(Protocol_Version::TLS_V13)) {
-         compatible_schemes.push_back(scheme.algorithm_name());
+         const auto algo_name = scheme.algorithm_name();
+         if(!value_exists(compatible_schemes, algo_name)) {
+            compatible_schemes.push_back(algo_name);
+         }
       }
    }
 

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -289,6 +289,13 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
 }
 
 Record_Layer::ReadResult<Record> Record_Layer::next_record(Cipher_State* cipher_state) {
+   // Special case: on the record boundary we don't actually need any more data
+   // and we also don't want to be the know-it-all that now demands exactly
+   // enough bytes to start parsing the next record header.
+   if(m_read_buffer.empty()) {
+      return BytesNeeded(0);
+   }
+
    const auto remaining = m_read_buffer.size() - m_read_offset;
 
    if(remaining < TLS_HEADER_SIZE) {

--- a/src/tests/test_tls_record_layer_13.cpp
+++ b/src/tests/test_tls_record_layer_13.cpp
@@ -178,8 +178,7 @@ std::vector<Test::Result> basic_sanitization_parse_records(TLS::Connection_Side 
                  [&](auto& result) {
                     auto read = parse_records({});
                     result.require("needs bytes", std::holds_alternative<TLS::BytesNeeded>(read));
-                    result.test_sz_eq(
-                       "need all the header bytes", std::get<TLS::BytesNeeded>(read), Botan::TLS::TLS_HEADER_SIZE);
+                    result.test_sz_eq("require no bytes on record boundary", std::get<TLS::BytesNeeded>(read), 0);
                  }),
 
            CHECK("incomplete header asks for more data",

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -150,7 +150,7 @@ class Credentials_Manager_Test final : public Botan::Credentials_Manager {
          const std::vector<std::string>& identities = {},
          const std::optional<std::string>& prf = std::nullopt) override {
          if(identities.empty()) {
-            return find_preshared_keys(host, whoami, identities, prf);
+            return Botan::Credentials_Manager::find_preshared_keys(host, whoami, identities, prf);
          }
 
          std::vector<Botan::TLS::ExternalPSK> psks;


### PR DESCRIPTION
While trying to extend the `unit_tls` test harness for TLS 1.3 I found a few minor things that may be worth fixing independently. Unfortunately, extending `unit_tls` proved to be quite cumbersome and will require much more restructuring within the test case than expected. I might get back to that later.

Fixes:

1. When calling `TLS::Channel::received_data()` with a buffer that is aligned at a full record, TLS 1.3 would read all contained records and then report that it needs "5 more bytes" (which are the hypothetical header bytes of the "next" record). That's inconsistent with the behaviour of TLS 1.2 where it would report "0 more bytes" in that case. Now TLS 1.3 also reports "0 more bytes" in that case.
2. TLS 1.3 potentially called `Credentials_Manager::find_cert_chain()` with a vector of desired `cert_key_types` with duplicated entries (for instance `{"RSA", "RSA", "ECDSA"}`). It now deduplicates this wish list.
3. Within the `unit_tls` test case: when calling `Credentials_Manager_Test::find_preshared_keys()` with an empty `identities` vector, an endless recursion would ensue. For TLS 1.2 that code was apparently never reached. It showed up only in my TLS 1.3 experiments. This was meant to be an up-call, I guess.