### PR TITLE
Fix some errors in the Python binding

### DIFF
--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -691,27 +691,34 @@ def _call_fn_returning_str(guess, fn):
     v = _call_fn_returning_vec(guess, fn)
     return v.decode('ascii')[:-1]
 
-@VIEW_BIN_CALLBACK
-def _view_bin_fn(_ctx, buf_val, buf_len):
-    _view_bin_fn.output = buf_val[0:buf_len]
-    return 0
-
 def _call_fn_viewing_vec(fn) -> bytes:
-    fn(None, _view_bin_fn)
-    result = _view_bin_fn.output
-    _view_bin_fn.output = None
-    return result
+    # The viewer callback and its output holder are call-local so that
+    # concurrent calls from multiple threads (ctypes releases the GIL across
+    # the C call) cannot clobber each other's exported data.
+    output = []
 
-@VIEW_STR_CALLBACK
-def _view_str_fn(_ctx, str_val, _str_len):
-    _view_str_fn.output = str_val
-    return 0
+    @VIEW_BIN_CALLBACK
+    def viewer(_ctx, buf_val, buf_len):
+        output.append(buf_val[0:buf_len])
+        return 0
+
+    fn(None, viewer)
+    if not output:
+        raise BotanException('View callback was not invoked')
+    return output[0]
 
 def _call_fn_viewing_str(fn) -> str:
-    fn(None, _view_str_fn)
-    result = _view_str_fn.output.decode('utf8')
-    _view_str_fn.output = None
-    return result
+    output = []
+
+    @VIEW_STR_CALLBACK
+    def viewer(_ctx, str_val, _str_len):
+        output.append(str_val)
+        return 0
+
+    fn(None, viewer)
+    if not output:
+        raise BotanException('View callback was not invoked')
+    return output[0].decode('utf8')
 
 def _ctype_str(s: str | None) -> bytes | None:
     if s is None:
@@ -1420,9 +1427,10 @@ def pbkdf(algo: str, password: str, out_len: int, iterations: int = 100000, salt
 
     out_buf = create_string_buffer(out_len)
 
+    passbits = _ctype_bits(password)
     _DLL.botan_pwdhash(_ctype_str(algo), iterations, 0, 0,
                        out_buf, out_len,
-                       _ctype_str(password), len(password),
+                       passbits, len(passbits),
                        salt, len(salt))
     return (salt, iterations, out_buf.raw)
 
@@ -1436,10 +1444,11 @@ def pbkdf_timed(algo: str, password: str, out_len: int, ms_to_run: int = 300, sa
     out_buf = create_string_buffer(out_len)
     iterations = c_size_t(0)
 
+    passbits = _ctype_bits(password)
     _DLL.botan_pwdhash_timed(_ctype_str(algo), c_uint32(ms_to_run),
                              byref(iterations), None, None,
                              out_buf, out_len,
-                             _ctype_str(password), len(password),
+                             passbits, len(passbits),
                              salt, len(salt))
     return (salt, iterations.value, out_buf.raw)
 
@@ -3389,11 +3398,38 @@ def zfec_decode(k: int, n: int, indexes: list[int], inputs: list[bytes]) -> list
     :param indexes: which of the shares are we giving the decoder
     :param inputs: the input shares (e.g. from a previous call to zfec_encode) which all must be the same length
 
+    Exactly `k` shares are needed to recover the data. Supplying more than `k`
+    (index, share) pairs is allowed; the extras are ignored.
+
     :returns: a list of bytes containing the original shares decoded from the provided shares (in `inputs`)
     """
 
+    # botan_zfec_decode() reads exactly K indexes and K input shares without
+    # bounds checking, so validate and normalize the arrays here before handing
+    # them to the native call to avoid out-of-bounds reads.
+    if not 1 <= k <= n < 256:
+        raise BotanException('Invalid zfec parameters: require 1 <= k <= n < 256')
+
+    if len(indexes) != len(inputs):
+        raise BotanException('zfec_decode requires one index per input share')
+
     if len(inputs) < k:
-        raise BotanException('Insufficient inputs for zfec decoding')
+        raise BotanException('zfec_decode requires at least k input shares')
+
+    if any(not 0 <= index < n for index in indexes):
+        raise BotanException('zfec_decode index out of range [0, n)')
+
+    if len(set(indexes)) != len(indexes):
+        raise BotanException('zfec_decode indexes must be unique')
+
+    # Only k shares are needed. If more are supplied, keep the k with the
+    # lowest indexes and ignore the rest: indexes 0..k-1 are the systematic
+    # shares, which reproduce the original data directly, so preferring the
+    # lower indexes avoids the cost of decoding from parity shares.
+    if len(inputs) > k:
+        chosen = sorted(zip(indexes, inputs), key=lambda pair: pair[0])[:k]
+        indexes = [index for index, _ in chosen]
+        inputs = [share for _, share in chosen]
 
     p_size_t = c_size_t * len(indexes)
     c_indexes = p_size_t(*[c_size_t(index) for index in indexes])

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -8,6 +8,7 @@ Botan is released under the Simplified BSD License (see license.txt)
 
 import unittest
 import binascii
+import hashlib
 import os
 import platform
 import argparse
@@ -127,6 +128,48 @@ class BotanPythonTests(unittest.TestCase):
         self.assertFalse(botan.check_bcrypt('live fire', phash))
 
         self.assertTrue(botan.check_bcrypt('test', '$2a$04$wjen1fAA.UW6UxthpKK.huyOoxvCR7ATRCVC4CBIEGVDOCtr8Oj1C'))
+
+    def test_password_utf8(self):
+        # The password-based interfaces must consume the full UTF-8 encoding of
+        # a non-ASCII password, not a truncated character-count prefix. The
+        # precomposed characters 'é' (U+00E9) and 'è' (U+00E8), each prefixed
+        # with 'p', encode to UTF-8 as 70 c3 a9 and 70 c3 a8 respectively: they
+        # share their first two bytes and differ only in the third, so a
+        # wrapper that truncated to the character count would derive identical
+        # keys for them.
+        salt = hex_decode('0001020304050607')
+        pw_a = 'pé'  # 70 c3 a9
+        pw_b = 'pè'  # 70 c3 a8
+        self.assertEqual(len(pw_a), 2)
+        self.assertEqual(len(pw_a.encode('utf-8')), 3)
+
+        # PBKDF2: cross-check against the stdlib reference over the full UTF-8
+        # bytes, and confirm the two passwords do not collide.
+        (_, _, key_a) = botan.pbkdf('PBKDF2(SHA-256)', pw_a, 32, 1000, salt)
+        self.assertEqual(key_a, hashlib.pbkdf2_hmac('sha256', pw_a.encode('utf-8'), salt, 1000, 32))
+        (_, _, key_b) = botan.pbkdf('PBKDF2(SHA-256)', pw_b, 32, 1000, salt)
+        self.assertNotEqual(key_a, key_b)
+
+        # pbkdf_timed derives over the same iterations must match pbkdf.
+        (t_salt, iters, timed) = botan.pbkdf_timed('PBKDF2(SHA-256)', pw_a, 32, 10)
+        self.assertEqual(timed, botan.pbkdf('PBKDF2(SHA-256)', pw_a, 32, iters, t_salt)[2])
+
+        # Every length-taking pwdhash interface must treat a str password
+        # identically to its explicit UTF-8 bytes (i.e. it passes the byte
+        # length, not the character count) and must not collide pw_a with pw_b.
+        def check(derive):
+            self.assertEqual(derive(pw_a), derive(pw_a.encode('utf-8')))
+            self.assertNotEqual(derive(pw_a), derive(pw_b))
+
+        check(lambda p: botan.pbkdf('PBKDF2(SHA-256)', p, 32, 1000, salt)[2])
+        check(lambda p: botan.scrypt(32, p, salt, 16, 1, 1))
+        check(lambda p: botan.argon2('Argon2id', 32, p, salt, 8, 1, 1))
+
+        # bcrypt passes a NUL-terminated string; a non-ASCII password must
+        # round-trip through generate/verify and not match a different one.
+        phash = botan.bcrypt(pw_a, botan.RandomNumberGenerator(), 4)
+        self.assertTrue(botan.check_bcrypt(pw_a, phash))
+        self.assertFalse(botan.check_bcrypt(pw_b, phash))
 
     def test_mac(self):
 
@@ -1491,6 +1534,36 @@ class BotanPythonZfecTests(unittest.TestCase):
                 b"".join(decoded),
                 input_bytes
             )
+
+    def test_decode_extra_shares(self):
+        # Supplying more than k shares is allowed; the extras are ignored.
+        k, n = 3, 6
+        input_bytes = bytes(range(96))  # 96 == 32 * k
+        output_shares = botan.zfec_encode(k, n, input_bytes)
+        all_indexes = list(range(n))
+
+        # All n shares provided (out of order): still decodes.
+        decoded = botan.zfec_decode(k, n, list(reversed(all_indexes)), list(reversed(output_shares)))
+        self.assertEqual(b"".join(decoded), input_bytes)
+
+        # k+1 shares provided: decodes.
+        decoded = botan.zfec_decode(k, n, all_indexes[:k + 1], output_shares[:k + 1])
+        self.assertEqual(b"".join(decoded), input_bytes)
+
+    def test_decode_rejects_bad_input(self):
+        k, n = 3, 5
+        input_bytes = bytes(range(96))
+        shares = botan.zfec_encode(k, n, input_bytes)
+        for indexes, inputs in [
+                ([0, 1], shares[:2]),          # fewer than k shares
+                ([0, 1], shares[:3]),          # index/share count mismatch
+                ([0, 1, n], shares[:3]),       # index out of range
+                ([0, 1, 1], shares[:3]),       # duplicate index
+        ]:
+            with self.assertRaises(botan.BotanException):
+                botan.zfec_decode(k, n, indexes, inputs)
+        with self.assertRaises(botan.BotanException):
+            botan.zfec_decode(k + n, n, list(range(k)), shares[:k])  # k > n
 
 
 def main():


### PR DESCRIPTION
The view callback used a global buffer so in multi-threaded callers it was possible to get unexpected data (from another concurrent library call).

Fix PBKDF2 handling of UTF-8 inputs. It passed as the input length the number of characters rather than the number of bytes, which would cause truncation. The other password hashing interfaces got this right.

Fix zfec decoding steps handling of invalid inputs. If called with invalid input lengths, it would cause memory errors since the FFI layer assumes the caller is actually passing eg k shares.