### PR TITLE
Fix various bugs in the Pipe/Filter library

### DIFF
--- a/src/lib/filters/algo_filt.cpp
+++ b/src/lib/filters/algo_filt.cpp
@@ -6,13 +6,18 @@
 */
 
 #include <botan/filters.h>
+
+#include <botan/assert.h>
 #include <algorithm>
 
 namespace Botan {
 
 #if defined(BOTAN_HAS_STREAM_CIPHER)
 
-StreamCipher_Filter::StreamCipher_Filter(StreamCipher* cipher) : m_cipher(cipher), m_buffer(m_cipher->buffer_size()) {}
+StreamCipher_Filter::StreamCipher_Filter(StreamCipher* cipher) :
+      m_cipher(cipher), m_buffer(cipher != nullptr ? cipher->buffer_size() : 0) {
+   BOTAN_ARG_CHECK(m_cipher != nullptr, "StreamCipher_Filter cipher argument must not be null");
+}
 
 StreamCipher_Filter::StreamCipher_Filter(StreamCipher* cipher, const SymmetricKey& key) : StreamCipher_Filter(cipher) {
    m_cipher->set_key(key);

--- a/src/lib/filters/b64_filt.cpp
+++ b/src/lib/filters/b64_filt.cpp
@@ -10,7 +10,6 @@
 #include <botan/base64.h>
 #include <botan/exceptn.h>
 #include <botan/mem_ops.h>
-#include <botan/internal/int_utils.h>
 #include <algorithm>
 
 namespace Botan {
@@ -112,8 +111,9 @@ void Base64_Decoder::write(const uint8_t input[], size_t length) {
    while(length > 0) {
       const size_t to_copy = std::min<size_t>(length, m_in.size() - m_position);
       if(to_copy == 0) {
-         m_in.resize(mul_or_throw<size_t>(2, m_in.size(), "Base64_Decoder input too large"));
-         m_out.resize(mul_or_throw<size_t>(2, m_out.size(), "Base64_Decoder input too large"));
+         // The input buffer filled without the decoder consuming any of it.
+         // Reject rather than trying to grow the buffer.
+         throw Invalid_Argument("Base64_Decoder: invalid input");
       }
       copy_mem(&m_in[m_position], input, to_copy);
       m_position += to_copy;

--- a/src/lib/filters/cipher_filter.cpp
+++ b/src/lib/filters/cipher_filter.cpp
@@ -28,7 +28,6 @@ size_t choose_update_size(size_t update_granularity) {
 Cipher_Mode_Filter::Cipher_Mode_Filter(Cipher_Mode* mode) :
       Buffered_Filter(choose_update_size(mode->ideal_granularity()), mode->minimum_final_size()),
       m_mode(mode),
-      m_nonce(mode->default_nonce_length()),
       m_buffer(m_mode->ideal_granularity()) {}
 
 std::string Cipher_Mode_Filter::name() const {
@@ -60,6 +59,7 @@ void Cipher_Mode_Filter::end_msg() {
 }
 
 void Cipher_Mode_Filter::start_msg() {
+   // m_nonce is empty unless set_iv() was called (it is cleared after each message).
    if(m_nonce.empty() && !m_mode->valid_nonce_length(0)) {
       throw Invalid_State("Cipher " + m_mode->name() + " requires a fresh nonce for each message");
    }

--- a/src/lib/filters/data_snk.cpp
+++ b/src/lib/filters/data_snk.cpp
@@ -35,6 +35,9 @@ void DataSink_Stream::write(const uint8_t buf[], size_t length) {
 */
 void DataSink_Stream::end_msg() {
    m_sink.flush();
+   if(!m_sink.good()) {
+      throw Stream_IO_Error("DataSink_Stream: Failure flushing " + m_identifier);
+   }
 }
 
 /*

--- a/src/lib/filters/fd_unix/fd_unix.cpp
+++ b/src/lib/filters/fd_unix/fd_unix.cpp
@@ -8,6 +8,7 @@
 #include <botan/pipe.h>
 
 #include <botan/exceptn.h>
+#include <cerrno>
 #include <unistd.h>
 
 namespace Botan {
@@ -23,6 +24,9 @@ int operator<<(int fd, Pipe& pipe) {
       while(got > 0) {
          const ssize_t ret = ::write(fd, &buffer[position], got);
          if(ret < 0) {
+            if(errno == EINTR) {
+               continue;
+            }
             throw Stream_IO_Error("Pipe output operator (unixfd) has failed");
          }
 
@@ -41,6 +45,9 @@ int operator>>(int fd, Pipe& pipe) {
    while(true) {
       const ssize_t ret = ::read(fd, buffer.data(), buffer.size());
       if(ret < 0) {
+         if(errno == EINTR) {
+            continue;
+         }
          throw Stream_IO_Error("Pipe input operator (unixfd) has failed");
       } else if(ret == 0) {
          break;

--- a/src/lib/filters/filter.cpp
+++ b/src/lib/filters/filter.cpp
@@ -83,7 +83,14 @@ void Filter::attach(Filter* new_filter) {
       while(last->get_next() != nullptr) {
          last = last->get_next();
       }
-      last->m_next[last->current_port()] = new_filter;
+      // A filter with no ports (e.g. Fork(nullptr, 0)) has an empty m_next, so
+      // indexing current_port() would be out of bounds. Such a filter has no
+      // free port to attach to.
+      if(last->current_port() < last->m_next.size()) {
+         last->m_next[last->current_port()] = new_filter;
+      } else {
+         throw Invalid_Argument("Filter::attach: cannot attach to a filter with no output port");
+      }
    }
 }
 

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -12,6 +12,7 @@
 #include <botan/internal/out_buf.h>
 #include <botan/internal/secqueue.h>
 #include <memory>
+#include <utility>
 
 namespace Botan {
 
@@ -29,7 +30,12 @@ class Null_Filter final : public Filter {
 
 }  // namespace
 
-Pipe::Pipe(Pipe&&) noexcept = default;
+// Transfer ownership and leave the moved-from Pipe empty
+Pipe::Pipe(Pipe&& other) noexcept :
+      m_pipe(std::exchange(other.m_pipe, nullptr)),
+      m_outputs(std::move(other.m_outputs)),
+      m_default_read(std::exchange(other.m_default_read, 0)),
+      m_inside_msg(std::exchange(other.m_inside_msg, false)) {}
 
 Pipe::Invalid_Message_Number::Invalid_Message_Number(std::string_view where, message_id msg) :
       Invalid_Argument(fmt("Pipe::{}: Invalid message number {}", where, msg)) {}
@@ -300,7 +306,9 @@ void Pipe::pop() {
 
    while(to_remove > 0) {
       const std::unique_ptr<Filter> to_destroy(m_pipe);
-      m_pipe = m_pipe->m_next[0];
+      // A filter with no ports has an empty m_next. Such a filter has no
+      // successor, so if popped the pipe is certainly empty at this point
+      m_pipe = (m_pipe->total_ports() > 0) ? m_pipe->m_next[0] : nullptr;
       to_remove -= 1;
    }
 }

--- a/src/lib/filters/pipe.cpp
+++ b/src/lib/filters/pipe.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/pipe.h>
 
+#include <botan/assert.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/mem_utils.h>
 #include <botan/internal/out_buf.h>
@@ -36,6 +37,16 @@ Pipe::Pipe(Pipe&& other) noexcept :
       m_outputs(std::move(other.m_outputs)),
       m_default_read(std::exchange(other.m_default_read, 0)),
       m_inside_msg(std::exchange(other.m_inside_msg, false)) {}
+
+Output_Buffers& Pipe::outputs() {
+   BOTAN_STATE_CHECK(m_outputs != nullptr);
+   return *m_outputs;
+}
+
+const Output_Buffers& Pipe::outputs() const {
+   BOTAN_STATE_CHECK(m_outputs != nullptr);
+   return *m_outputs;
+}
 
 Pipe::Invalid_Message_Number::Invalid_Message_Number(std::string_view where, message_id msg) :
       Invalid_Argument(fmt("Pipe::{}: Invalid message number {}", where, msg)) {}
@@ -177,7 +188,7 @@ void Pipe::end_msg() {
    }
    m_inside_msg = false;
 
-   m_outputs->retire();
+   outputs().retire();
 }
 
 /*
@@ -190,7 +201,7 @@ void Pipe::find_endpoints(Filter* f) {
       } else {
          SecureQueue* q = new SecureQueue;  // NOLINT(*-owning-memory)
          f->m_next[j] = q;
-         m_outputs->add(q);
+         outputs().add(q);
       }
    }
 }
@@ -215,7 +226,7 @@ void Pipe::append(Filter* filter) {
 }
 
 void Pipe::append_filter(Filter* filter) {
-   if(m_outputs->message_count() != 0) {
+   if(outputs().message_count() != 0) {
       throw Invalid_State("Cannot call Pipe::append_filter after start_msg");
    }
 
@@ -227,7 +238,7 @@ void Pipe::prepend(Filter* filter) {
 }
 
 void Pipe::prepend_filter(Filter* filter) {
-   if(m_outputs->message_count() != 0) {
+   if(outputs().message_count() != 0) {
       throw Invalid_State("Cannot call Pipe::prepend_filter after start_msg");
    }
 
@@ -317,7 +328,7 @@ void Pipe::pop() {
 * Return the number of messages in this Pipe
 */
 Pipe::message_id Pipe::message_count() const {
-   return m_outputs->message_count();
+   return outputs().message_count();
 }
 
 /*

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -355,6 +355,10 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       void find_endpoints(Filter* filt);
       void clear_endpoints(Filter* filt);
 
+      // Accessors for m_outputs which is null in a moved-from Pipe
+      Output_Buffers& outputs();
+      const Output_Buffers& outputs() const;
+
       message_id get_message_no(std::string_view func_name, message_id msg) const;
 
       Filter* m_pipe;

--- a/src/lib/filters/pipe.h
+++ b/src/lib/filters/pipe.h
@@ -342,7 +342,7 @@ class BOTAN_PUBLIC_API(2, 0) Pipe final : public DataSource {
       Pipe(std::initializer_list<Filter*> filters);
 
       Pipe(const Pipe&) = delete;
-      Pipe(Pipe&&) noexcept;
+      Pipe(Pipe&& other) noexcept;
       Pipe& operator=(const Pipe&) = delete;
       Pipe& operator=(Pipe&&) = delete;
 

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -152,11 +152,11 @@ size_t Pipe::peek(uint8_t& out, size_t offset, message_id msg) const {
 }
 
 size_t Pipe::get_bytes_read() const {
-   return m_outputs->get_bytes_read(default_msg());
+   return get_bytes_read(DEFAULT_MESSAGE);
 }
 
 size_t Pipe::get_bytes_read(message_id msg) const {
-   return m_outputs->get_bytes_read(msg);
+   return m_outputs->get_bytes_read(get_message_no("get_bytes_read", msg));
 }
 
 bool Pipe::check_available(size_t n) {

--- a/src/lib/filters/pipe_rw.cpp
+++ b/src/lib/filters/pipe_rw.cpp
@@ -75,7 +75,7 @@ void Pipe::write(DataSource& source) {
 * Read some data from the pipe
 */
 size_t Pipe::read(uint8_t output[], size_t length, message_id msg) {
-   return m_outputs->read(output, length, get_message_no("read", msg));
+   return outputs().read(output, length, get_message_no("read", msg));
 }
 
 /*
@@ -127,14 +127,14 @@ std::string Pipe::read_all_as_string(message_id msg) {
 * Find out how many bytes are ready to read
 */
 size_t Pipe::remaining(message_id msg) const {
-   return m_outputs->remaining(get_message_no("remaining", msg));
+   return outputs().remaining(get_message_no("remaining", msg));
 }
 
 /*
 * Peek at some data in the pipe
 */
 size_t Pipe::peek(uint8_t output[], size_t length, size_t offset, message_id msg) const {
-   return m_outputs->peek(output, length, offset, get_message_no("peek", msg));
+   return outputs().peek(output, length, offset, get_message_no("peek", msg));
 }
 
 /*
@@ -156,7 +156,7 @@ size_t Pipe::get_bytes_read() const {
 }
 
 size_t Pipe::get_bytes_read(message_id msg) const {
-   return m_outputs->get_bytes_read(get_message_no("get_bytes_read", msg));
+   return outputs().get_bytes_read(get_message_no("get_bytes_read", msg));
 }
 
 bool Pipe::check_available(size_t n) {

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -17,26 +17,26 @@ namespace Botan {
 
 struct Threaded_Fork_Data {
       /*
-   * Semaphore for indicating that there is work to be done (or to
-   * quit)
-   */
+      * Semaphore for indicating that there is work to be done (or to
+      * quit)
+      */
       Semaphore m_input_ready_semaphore;
 
       /*
-   * Synchronises all threads to complete processing data in lock-step.
-   */
+      * Synchronises all threads to complete processing data in lock-step.
+      */
       Barrier m_input_complete_barrier;
 
       /*
-   * The work that needs to be done. This should be only when the threads
-   * are NOT running (i.e. before notifying the work condition, after
-   * the input_complete_barrier has reset.)
-   */
+      * The work that needs to be done. This should be only when the threads
+      * are NOT running (i.e. before notifying the work condition, after
+      * the input_complete_barrier has reset.)
+      */
       const uint8_t* m_input = nullptr;
 
       /*
-   * The length of the work that needs to be done.
-   */
+      * The length of the work that needs to be done.
+      */
       size_t m_input_length = 0;
 };
 
@@ -87,6 +87,14 @@ void Threaded_Fork::set_next(Filter* f[], size_t n) {
 }
 
 void Threaded_Fork::send(const uint8_t input[], size_t length) {
+   /*
+   * The workers treat a nullptr input pointer as a shutdown marker, and a (nullptr, 0)
+   * call is otherwise valid. Just ignore an empty input here, matching Filter::send
+   */
+   if(length == 0) {
+      return;
+   }
+
    if(!m_write_queue.empty()) {
       thread_delegate_work(m_write_queue.data(), m_write_queue.size());
    }
@@ -131,7 +139,10 @@ void Threaded_Fork::thread_entry(Filter* filter) {
          break;
       }
 
-      filter->write(m_thread_data->m_input, m_thread_data->m_input_length);
+      // Plain Fork skips null ports the same way
+      if(filter != nullptr) {
+         filter->write(m_thread_data->m_input, m_thread_data->m_input_length);
+      }
       m_thread_data->m_input_complete_barrier.sync();
    }
 }


### PR DESCRIPTION
- Avoid possible nullptr deref in StreamCipher_Filter constructor

- Avoid possibly unbounded allocation on invalid input in Base64_Decoder filter. Given a stream of invalid junk we'd buffer it all, which isn't sensible.

- In Cipher_Mode_Filter avoid providing a default all-zero IV for the first message

- In DataSink_Stream::end_msg detect a failure to flush the stream

- In Pipe's Unix I/O operators ignore EINTR returns

- In Filter::attach avoid null deref for a filter with no output ports

- Correctly detect invalid message numbers in Pipe::get_bytes_read

- In Threaded_Fork ignore empty sends, since the thread treats as a nullptr input as a stop signal.

- In Threaded_Fork, avoid a null deref when one of the filter arguments is a nullptr (implicit data passthrough).

- Fix Pipe's move constructor to deactivate the moved-from object.

- In Pipe::pop avoid a nullptr deref if popping a Filter with no output ports.