### PR TITLE
Properly split EC_AffinePoint deserialization

### DIFF
--- a/doc/api_ref/ecc.rst
+++ b/doc/api_ref/ecc.rst
@@ -140,13 +140,37 @@ side channels) unless otherwise documented. Usually this is denoted by including
 
       Point deserialization. Throws if invalid, including if the point is not on the curve.
 
-      This accepts SEC1 compressed or uncompressed formats
+      This accepts SEC1 compressed or uncompressed formats. It also (for
+      backward compatibility) accepts the deprecated hybrid format, and the
+      encoding of the identity element as a single zero byte. Prefer
+      ``deserialize_compressed`` or ``deserialize_uncompressed``, which accept
+      exactly one well-defined encoding.
 
    .. cpp:function:: static std::optional<EC_AffinePoint> deserialize(const EC_Group& group, std::span<const uint8_t> bytes)
 
       Point deserialization. Returns ``nullopt`` if invalid, including if the point is not on the curve.
 
-      This accepts SEC1 compressed or uncompressed formats
+      This accepts SEC1 compressed or uncompressed formats. It also (for
+      backward compatibility) accepts the deprecated hybrid format, and the
+      encoding of the identity element as a single zero byte. Prefer
+      ``deserialize_compressed`` or ``deserialize_uncompressed``, which accept
+      exactly one well-defined encoding.
+
+   .. cpp:function:: static std::optional<EC_AffinePoint> deserialize_compressed(const EC_Group& group, std::span<const uint8_t> bytes)
+
+      Point deserialization, accepting only the SEC1 compressed format (header
+      byte 0x02 or 0x03). The hybrid and identity encodings are rejected.
+      Returns ``nullopt`` if invalid, including if the point is not on the curve.
+
+      Available since Botan 3.13
+
+   .. cpp:function:: static std::optional<EC_AffinePoint> deserialize_uncompressed(const EC_Group& group, std::span<const uint8_t> bytes)
+
+      Point deserialization, accepting only the SEC1 uncompressed format
+      (header byte 0x04). The hybrid and identity encodings are rejected.
+      Returns ``nullopt`` if invalid, including if the point is not on the curve.
+
+      Available since Botan 3.13
 
    .. cpp:function:: bool is_identity() const
 

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -205,6 +205,7 @@ std::string map_to_bogo_error(const std::string& e) noexcept {
       {"Invalid SessionTicket: Extra bytes at end of message", ":DECODE_ERROR:"},
       {"Invalid authentication tag: ChaCha20Poly1305 tag check failed", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
       {"Invalid authentication tag: GCM tag check failed", ":DECRYPTION_FAILED_OR_BAD_RECORD_MAC:"},
+      {"Invalid ECDH public key encoding", ":BAD_ECPOINT:"},
       {"Invalid encapsulated key length", ":BAD_ECPOINT:"},
       {"Invalid handshake message type", ":UNEXPECTED_RECORD:"},
       {"Invalid hybrid KEM ciphertext", ":BAD_ECPOINT:"},

--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -3,6 +3,7 @@
 #include <botan/dl_group.h>
 #include <botan/ec_group.h>
 #include <botan/ecdh.h>
+#include <botan/exceptn.h>
 #include <botan/tls.h>
 
 /**
@@ -49,7 +50,16 @@ class Callbacks : public Botan::TLS::Callbacks {
             std::get<Botan::TLS::Group_Params>(group) == Botan::TLS::Group_Params(0xFE00)) {
             // load the peer's public key of my custom curve
             const auto ec_group = Botan::EC_Group::from_name("numsp256d1");
-            return std::make_unique<Botan::ECDH_PublicKey>(ec_group, Botan::EC_AffinePoint(ec_group, public_value));
+            auto point = Botan::EC_AffinePoint::deserialize_uncompressed(ec_group, public_value);
+
+            if(!point) {
+               // TLS 1.2 allows negotiating compressed points
+               point = Botan::EC_AffinePoint::deserialize_compressed(ec_group, public_value);
+            }
+            if(!point) {
+               throw Botan::Decoding_Error("Invalid ECDH public key encoding");
+            }
+            return std::make_unique<Botan::ECDH_PublicKey>(ec_group, std::move(*point));
          } else {
             // no custom curve used: up-call the default implementation
             return Botan::TLS::Callbacks::tls_deserialize_peer_public_key(group, public_value);

--- a/src/lib/math/pcurves/pcurves.h
+++ b/src/lib/math/pcurves/pcurves.h
@@ -234,12 +234,22 @@ class PrimeOrderCurve /* NOLINT(*-special-member-functions) */ {
       /// Return the standard generator
       virtual AffinePoint generator() const = 0;
 
-      /// Deserialize a point
+      /// Return the identity element (aka the point at infinity)
+      virtual AffinePoint point_identity() const = 0;
+
+      /// Deserialize a point in the SEC1 uncompressed format
       ///
-      /// Both compressed and uncompressed encodings are accepted
+      /// The input must be exactly 1 + 2*field_element_bytes long and have a
+      /// header byte of 0x04. All other encodings are rejected, as are inputs
+      /// where (x,y) is not a point on the curve.
+      virtual std::optional<AffinePoint> deserialize_point_uncompressed(std::span<const uint8_t> bytes) const = 0;
+
+      /// Deserialize a point in the SEC1 compressed format
       ///
-      /// Note that the deprecated "hybrid" encoding is not supported here
-      virtual std::optional<AffinePoint> deserialize_point(std::span<const uint8_t> bytes) const = 0;
+      /// The input must be exactly 1 + field_element_bytes long and have a
+      /// header byte of 0x02 or 0x03. All other encodings are rejected, as are
+      /// inputs where x is not the affine x coordinate of a point on the curve.
+      virtual std::optional<AffinePoint> deserialize_point_compressed(std::span<const uint8_t> bytes) const = 0;
 
       /// Deserialize a scalar in [1,p)
       ///

--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.cpp
@@ -982,12 +982,10 @@ class GenericAffinePoint final {
       }
 
       /**
-      * Point deserialization
-      *
-      * This accepts compressed or uncompressed formats.
+      * Point deserialization (SEC1 uncompressed format only)
       */
-      static std::optional<GenericAffinePoint> deserialize(const GenericPrimeOrderCurve* curve,
-                                                           std::span<const uint8_t> bytes) {
+      static std::optional<GenericAffinePoint> deserialize_uncompressed(const GenericPrimeOrderCurve* curve,
+                                                                        std::span<const uint8_t> bytes) {
          const size_t fe_bytes = curve->_params().field_bytes();
 
          if(bytes.size() == 1 + 2 * fe_bytes && bytes[0] == 0x04) {
@@ -1001,7 +999,19 @@ class GenericAffinePoint final {
                   return GenericAffinePoint(*x, *y);
                }
             }
-         } else if(bytes.size() == 1 + fe_bytes && (bytes[0] == 0x02 || bytes[0] == 0x03)) {
+         }
+
+         return {};
+      }
+
+      /**
+      * Point deserialization (SEC1 compressed format only)
+      */
+      static std::optional<GenericAffinePoint> deserialize_compressed(const GenericPrimeOrderCurve* curve,
+                                                                      std::span<const uint8_t> bytes) {
+         const size_t fe_bytes = curve->_params().field_bytes();
+
+         if(bytes.size() == 1 + fe_bytes && (bytes[0] == 0x02 || bytes[0] == 0x03)) {
             const CT::Choice y_is_even = CT::Mask<uint8_t>::is_equal(bytes[0], 0x02).as_choice();
 
             if(auto x = GenericField::deserialize(curve, bytes.subspan(1, fe_bytes))) {
@@ -1013,9 +1023,6 @@ class GenericAffinePoint final {
                   return GenericAffinePoint(*x, y);
                }
             }
-         } else if(bytes.size() == 1 && bytes[0] == 0x00) {
-            // See SEC1 section 2.3.4
-            return GenericAffinePoint::identity(curve);
          }
 
          return {};
@@ -1547,6 +1554,10 @@ PrimeOrderCurve::AffinePoint GenericPrimeOrderCurve::generator() const {
    return PrimeOrderCurve::AffinePoint::_create(shared_from_this(), _params().base_x(), _params().base_y());
 }
 
+PrimeOrderCurve::AffinePoint GenericPrimeOrderCurve::point_identity() const {
+   return stash(GenericAffinePoint::identity(this));
+}
+
 PrimeOrderCurve::AffinePoint GenericPrimeOrderCurve::point_to_affine(const ProjectivePoint& pt) const {
    auto affine = to_affine<GenericCurve>(from_stash(pt));
 
@@ -1600,9 +1611,18 @@ std::optional<PrimeOrderCurve::Scalar> GenericPrimeOrderCurve::scalar_from_wide_
    }
 }
 
-std::optional<PrimeOrderCurve::AffinePoint> GenericPrimeOrderCurve::deserialize_point(
+std::optional<PrimeOrderCurve::AffinePoint> GenericPrimeOrderCurve::deserialize_point_uncompressed(
    std::span<const uint8_t> bytes) const {
-   if(auto pt = GenericAffinePoint::deserialize(this, bytes)) {
+   if(auto pt = GenericAffinePoint::deserialize_uncompressed(this, bytes)) {
+      return stash(pt.value());
+   } else {
+      return {};
+   }
+}
+
+std::optional<PrimeOrderCurve::AffinePoint> GenericPrimeOrderCurve::deserialize_point_compressed(
+   std::span<const uint8_t> bytes) const {
+   if(auto pt = GenericAffinePoint::deserialize_compressed(this, bytes)) {
       return stash(pt.value());
    } else {
       return {};

--- a/src/lib/math/pcurves/pcurves_generic/pcurves_generic.h
+++ b/src/lib/math/pcurves/pcurves_generic/pcurves_generic.h
@@ -66,6 +66,8 @@ class GenericPrimeOrderCurve final : public PrimeOrderCurve,
 
       AffinePoint generator() const override;
 
+      AffinePoint point_identity() const override;
+
       AffinePoint point_to_affine(const ProjectivePoint& pt) const override;
 
       ProjectivePoint point_add(const AffinePoint& a, const AffinePoint& b) const override;
@@ -82,7 +84,9 @@ class GenericPrimeOrderCurve final : public PrimeOrderCurve,
 
       std::optional<Scalar> scalar_from_wide_bytes(std::span<const uint8_t> bytes) const override;
 
-      std::optional<AffinePoint> deserialize_point(std::span<const uint8_t> bytes) const override;
+      std::optional<AffinePoint> deserialize_point_uncompressed(std::span<const uint8_t> bytes) const override;
+
+      std::optional<AffinePoint> deserialize_point_compressed(std::span<const uint8_t> bytes) const override;
 
       AffinePoint hash_to_curve_nu(std::function<void(std::span<uint8_t>)> expand_message) const override;
 

--- a/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
+++ b/src/lib/math/pcurves/pcurves_impl/pcurves_wrap.h
@@ -239,15 +239,10 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
          }
       }
 
-      std::optional<AffinePoint> deserialize_point(std::span<const uint8_t> bytes) const override {
-         // The identity element (see SEC1 section 2.3.4)
-         // TODO(Botan4) remove this - we should reject the identity encoding
-         if(bytes.size() == 1 && bytes[0] == 0x00) {
-            return stash(C::AffinePoint::identity());
-         }
+      AffinePoint point_identity() const override { return stash(C::AffinePoint::identity()); }
 
+      std::optional<AffinePoint> deserialize_point_uncompressed(std::span<const uint8_t> bytes) const override {
          constexpr size_t FieldElementBytes = C::FieldElement::BYTES;
-         constexpr size_t CompressedBytes = C::FieldElement::BYTES + 1;
          constexpr size_t UncompressedBytes = 2 * C::FieldElement::BYTES + 1;
 
          if(bytes.size() == UncompressedBytes && bytes[0] == 0x04) {
@@ -264,7 +259,16 @@ class PrimeOrderCurveImpl final : public PrimeOrderCurve {
                   return stash(typename C::AffinePoint(*x, *y));
                }
             }
-         } else if(bytes.size() == CompressedBytes && (bytes[0] == 0x02 || bytes[0] == 0x03)) {
+         }
+
+         return {};
+      }
+
+      std::optional<AffinePoint> deserialize_point_compressed(std::span<const uint8_t> bytes) const override {
+         constexpr size_t FieldElementBytes = C::FieldElement::BYTES;
+         constexpr size_t CompressedBytes = C::FieldElement::BYTES + 1;
+
+         if(bytes.size() == CompressedBytes && (bytes[0] == 0x02 || bytes[0] == 0x03)) {
             const CT::Choice y_is_even = CT::Mask<uint8_t>::is_equal(bytes[0], 0x02).as_choice();
 
             if(auto x = C::FieldElement::deserialize(bytes.subspan(1, FieldElementBytes))) {

--- a/src/lib/prov/tpm2/tpm2_key.cpp
+++ b/src/lib/prov/tpm2/tpm2_key.cpp
@@ -50,10 +50,13 @@ std::pair<EC_Group, EC_AffinePoint> ecc_pubkey_from_tss2_public(const TPM2B_PUBL
    auto curve = Botan::EC_Group::from_name(curve_name.value());
    // Create an EC_AffinePoint from the x and y coordinates as SEC1 uncompressed point.
    // According to the TPM2.0 specification Part 1 C.8, each coordinate is already padded to the curve's size.
-   auto point = EC_AffinePoint::deserialize(curve,
-                                            concat(std::vector<uint8_t>({0x04}),
-                                                   as_span(public_blob->publicArea.unique.ecc.x),
-                                                   as_span(public_blob->publicArea.unique.ecc.y)));
+
+   auto point = EC_AffinePoint::deserialize_uncompressed(
+      curve,
+      concat<std::vector<uint8_t>>(std::array<uint8_t, 1>{0x04},
+                                   as_span(public_blob->publicArea.unique.ecc.x),
+                                   as_span(public_blob->publicArea.unique.ecc.y)));
+
    if(!point) {
       throw Invalid_Argument("Invalid ECC Point");
    }

--- a/src/lib/pubkey/ec_group/ec_apoint.cpp
+++ b/src/lib/pubkey/ec_group/ec_apoint.cpp
@@ -34,8 +34,9 @@ EC_AffinePoint& EC_AffinePoint::operator=(EC_AffinePoint&& other) noexcept {
 }
 
 EC_AffinePoint::EC_AffinePoint(const EC_Group& group, std::span<const uint8_t> bytes) {
-   m_point = group._data()->point_deserialize(bytes);
-   if(!m_point) {
+   if(auto pt = EC_AffinePoint::deserialize(group, bytes)) {
+      m_point = std::move(pt->m_point);
+   } else {
       throw Decoding_Error("Failed to deserialize elliptic curve point");
    }
 }
@@ -77,8 +78,7 @@ bool EC_AffinePoint::operator==(const EC_AffinePoint& other) const {
 }
 
 EC_AffinePoint EC_AffinePoint::identity(const EC_Group& group) {
-   const uint8_t id_encoding[1] = {0};
-   return EC_AffinePoint(group, id_encoding);
+   return EC_AffinePoint(group._data()->point_identity());
 }
 
 EC_AffinePoint EC_AffinePoint::generator(const EC_Group& group) {
@@ -104,7 +104,7 @@ std::optional<EC_AffinePoint> EC_AffinePoint::from_bigint_xy(const EC_Group& gro
    x.serialize_to(std::span{sec1}.subspan(1, fe_bytes));
    y.serialize_to(std::span{sec1}.last(fe_bytes));
 
-   return EC_AffinePoint::deserialize(group, sec1);
+   return EC_AffinePoint::deserialize_uncompressed(group, sec1);
 }
 
 size_t EC_AffinePoint::field_element_bytes() const {
@@ -148,7 +148,56 @@ EC_AffinePoint EC_AffinePoint::hash_to_curve_nu(const EC_Group& group,
 EC_AffinePoint::~EC_AffinePoint() = default;
 
 std::optional<EC_AffinePoint> EC_AffinePoint::deserialize(const EC_Group& group, std::span<const uint8_t> bytes) {
-   if(auto pt = group._data()->point_deserialize(bytes)) {
+   if(bytes.empty()) {
+      return {};
+   }
+
+   switch(bytes[0]) {
+      case 0x00:
+         // The identity element (see SEC1 section 2.3.4)
+         // TODO(Botan4) remove this - we should reject the identity encoding
+         if(bytes.size() == 1) {
+            return EC_AffinePoint::identity(group);
+         } else {
+            return {};
+         }
+      case 0x02:
+      case 0x03:
+         return EC_AffinePoint::deserialize_compressed(group, bytes);
+      case 0x04:
+         return EC_AffinePoint::deserialize_uncompressed(group, bytes);
+      case 0x06:
+      case 0x07: {
+         // The deprecated "hybrid" point format
+         // TODO(Botan4) remove this
+         const bool hdr_y_is_even = bytes[0] == 0x06;
+         const bool y_is_even = (bytes.back() & 0x01) == 0;
+
+         if(hdr_y_is_even == y_is_even) {
+            std::vector<uint8_t> sec1(bytes.begin(), bytes.end());
+            sec1[0] = 0x04;
+            return EC_AffinePoint::deserialize_uncompressed(group, sec1);
+         } else {
+            return {};
+         }
+      }
+      default:
+         return {};
+   }
+}
+
+std::optional<EC_AffinePoint> EC_AffinePoint::deserialize_compressed(const EC_Group& group,
+                                                                     std::span<const uint8_t> bytes) {
+   if(auto pt = group._data()->point_deserialize_compressed(bytes)) {
+      return EC_AffinePoint(std::move(pt));
+   } else {
+      return {};
+   }
+}
+
+std::optional<EC_AffinePoint> EC_AffinePoint::deserialize_uncompressed(const EC_Group& group,
+                                                                       std::span<const uint8_t> bytes) {
+   if(auto pt = group._data()->point_deserialize_uncompressed(bytes)) {
       return EC_AffinePoint(std::move(pt));
    } else {
       return {};

--- a/src/lib/pubkey/ec_group/ec_apoint.h
+++ b/src/lib/pubkey/ec_group/ec_apoint.h
@@ -37,13 +37,41 @@ class BOTAN_PUBLIC_API(3, 6) EC_AffinePoint final {
    public:
       /// Point deserialization. Throws if wrong length or not a valid point
       ///
-      /// This accepts SEC1 compressed or uncompressed formats
+      /// This accepts SEC1 compressed or uncompressed formats. It also (for
+      /// backward compatibility) accepts the deprecated hybrid format, and
+      /// the encoding of the identity element as a single zero byte. Prefer
+      /// deserialize_compressed or deserialize_uncompressed, which accept
+      /// exactly one well-defined encoding.
       EC_AffinePoint(const EC_Group& group, std::span<const uint8_t> bytes);
 
       /// Point deserialization. Returns nullopt if wrong length or not a valid point
       ///
-      /// This accepts SEC1 compressed or uncompressed formats
+      /// This accepts SEC1 compressed or uncompressed formats. It also (for
+      /// backward compatibility) accepts the deprecated hybrid format, and
+      /// the encoding of the identity element as a single zero byte. Prefer
+      /// deserialize_compressed or deserialize_uncompressed, which accept
+      /// exactly one well-defined encoding.
       static std::optional<EC_AffinePoint> deserialize(const EC_Group& group, std::span<const uint8_t> bytes);
+
+      /// Point deserialization, accepting only the SEC1 compressed format
+      ///
+      /// The encoding must be exactly 1 + field_element_bytes long, with a
+      /// header byte of either 0x02 or 0x03. All other encodings (including
+      /// the uncompressed, hybrid, and identity encodings) are rejected.
+      ///
+      /// Returns nullopt if the encoding was rejected or not a valid point
+      static std::optional<EC_AffinePoint> deserialize_compressed(const EC_Group& group,
+                                                                  std::span<const uint8_t> bytes);
+
+      /// Point deserialization, accepting only the SEC1 uncompressed format
+      ///
+      /// The encoding must be exactly 1 + 2*field_element_bytes long, with a
+      /// header byte of 0x04. All other encodings (including the compressed,
+      /// hybrid, and identity encodings) are rejected.
+      ///
+      /// Returns nullopt if the encoding was rejected or not a valid point
+      static std::optional<EC_AffinePoint> deserialize_uncompressed(const EC_Group& group,
+                                                                    std::span<const uint8_t> bytes);
 
       /// Create a point from a pair (x,y) of integers
       ///

--- a/src/lib/pubkey/ec_group/ec_inner_data.cpp
+++ b/src/lib/pubkey/ec_group/ec_inner_data.cpp
@@ -380,37 +380,66 @@ std::unique_ptr<EC_Scalar_Data> EC_Group_Data::scalar_deserialize(std::span<cons
    }
 }
 
-std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_deserialize(std::span<const uint8_t> bytes) const {
-   // The deprecated "hybrid" point format
-   // TODO(Botan4) remove this
-   if(bytes.size() >= 1 + 2 * 4 && (bytes[0] == 0x06 || bytes[0] == 0x07)) {
-      const bool hdr_y_is_even = bytes[0] == 0x06;
-      const bool y_is_even = (bytes.back() & 0x01) == 0;
-
-      if(hdr_y_is_even == y_is_even) {
-         std::vector<uint8_t> sec1(bytes.begin(), bytes.end());
-         sec1[0] = 0x04;
-         return this->point_deserialize(sec1);
-      }
+std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_deserialize_uncompressed(
+   std::span<const uint8_t> bytes) const {
+   if(bytes.size() != 1 + 2 * p_bytes() || bytes[0] != 0x04) {
+      return {};
    }
 
-   try {
-      if(m_pcurve) {
-         if(auto pt = m_pcurve->deserialize_point(bytes)) {
-            return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), std::move(*pt));
-         } else {
-            return {};
-         }
+   if(m_pcurve) {
+      if(auto pt = m_pcurve->deserialize_point_uncompressed(bytes)) {
+         return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), std::move(*pt));
       } else {
+         return {};
+      }
+   } else {
 #if defined(BOTAN_HAS_LEGACY_EC_POINT)
+      try {
          auto pt = Botan::OS2ECP(bytes, m_curve);
          return std::make_unique<EC_AffinePoint_Data_BN>(shared_from_this(), std::move(pt));
-#else
-         throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
-#endif
+      } catch(...) {
+         return {};
       }
-   } catch(...) {
+#else
+      throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
+#endif
+   }
+}
+
+std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_deserialize_compressed(std::span<const uint8_t> bytes) const {
+   if(bytes.size() != 1 + p_bytes() || (bytes[0] != 0x02 && bytes[0] != 0x03)) {
       return {};
+   }
+
+   if(m_pcurve) {
+      if(auto pt = m_pcurve->deserialize_point_compressed(bytes)) {
+         return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), std::move(*pt));
+      } else {
+         return {};
+      }
+   } else {
+#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+      try {
+         auto pt = Botan::OS2ECP(bytes, m_curve);
+         return std::make_unique<EC_AffinePoint_Data_BN>(shared_from_this(), std::move(pt));
+      } catch(...) {
+         return {};
+      }
+#else
+      throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
+#endif
+   }
+}
+
+std::unique_ptr<EC_AffinePoint_Data> EC_Group_Data::point_identity() const {
+   if(m_pcurve) {
+      return std::make_unique<EC_AffinePoint_Data_PC>(shared_from_this(), m_pcurve->point_identity());
+   } else {
+#if defined(BOTAN_HAS_LEGACY_EC_POINT)
+      return std::make_unique<EC_AffinePoint_Data_BN>(shared_from_this(), EC_Point(m_curve));
+#else
+      throw Not_Implemented("Legacy EC interfaces disabled in this build configuration");
+#endif
    }
 }
 

--- a/src/lib/pubkey/ec_group/ec_inner_data.h
+++ b/src/lib/pubkey/ec_group/ec_inner_data.h
@@ -252,10 +252,20 @@ class EC_Group_Data final : public std::enable_shared_from_this<EC_Group_Data> {
 
       std::unique_ptr<EC_Scalar_Data> gk_x_mod_order(const EC_Scalar_Data& scalar, RandomNumberGenerator& rng) const;
 
-      /// Deserialize a point
+      /// Deserialize a point in the SEC1 uncompressed format
       ///
-      /// Returns nullptr if the point encoding was invalid or not on the curve
-      std::unique_ptr<EC_AffinePoint_Data> point_deserialize(std::span<const uint8_t> bytes) const;
+      /// Returns nullptr if the encoding was not in the uncompressed format,
+      /// or if the point is not on the curve
+      std::unique_ptr<EC_AffinePoint_Data> point_deserialize_uncompressed(std::span<const uint8_t> bytes) const;
+
+      /// Deserialize a point in the SEC1 compressed format
+      ///
+      /// Returns nullptr if the encoding was not in the compressed format,
+      /// or if the point is not on the curve
+      std::unique_ptr<EC_AffinePoint_Data> point_deserialize_compressed(std::span<const uint8_t> bytes) const;
+
+      /// Return the identity element (aka the point at infinity)
+      std::unique_ptr<EC_AffinePoint_Data> point_identity() const;
 
       std::unique_ptr<EC_AffinePoint_Data> point_hash_to_curve_ro(std::string_view hash_fn,
                                                                   std::span<const uint8_t> input,

--- a/src/lib/pubkey/ecc_key/ec_key_data.cpp
+++ b/src/lib/pubkey/ecc_key/ec_key_data.cpp
@@ -6,10 +6,36 @@
 
 #include <botan/internal/ec_key_data.h>
 
+#include <botan/exceptn.h>
 #include <botan/mem_ops.h>
 #include <botan/rng.h>
 
 namespace Botan {
+
+namespace {
+
+EC_AffinePoint decode_ec_public_key_point(const EC_Group& group, std::span<const uint8_t> bytes) {
+   /*
+   * RFC 5480 section 2.2:
+   *    The first octet of the OCTET STRING indicates whether the key is
+   *    compressed or uncompressed.  The uncompressed form is indicated
+   *    by 0x04 and the compressed form is indicated by either 0x02 or
+   *    0x03 (see 2.3.3 in [SEC1]).  The public key MUST be rejected if
+   *    any other value is included in the first octet.
+   */
+   if(auto pt_uncompressed = EC_AffinePoint::deserialize_uncompressed(group, bytes)) {
+      return std::move(pt_uncompressed).value();
+   } else if(auto pt_compressed = EC_AffinePoint::deserialize_compressed(group, bytes)) {
+      return std::move(pt_compressed).value();
+   } else {
+      throw Decoding_Error("Failed to deserialize elliptic curve point");
+   }
+}
+
+}  // namespace
+
+EC_PublicKey_Data::EC_PublicKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
+      EC_PublicKey_Data(group, decode_ec_public_key_point(group, bytes)) {}
 
 EC_PublicKey_Data::EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt) :
       m_group(std::move(group)), m_point(std::move(pt)) {

--- a/src/lib/pubkey/ecc_key/ec_key_data.h
+++ b/src/lib/pubkey/ecc_key/ec_key_data.h
@@ -25,8 +25,7 @@ class EC_PublicKey_Data final {
    public:
       EC_PublicKey_Data(EC_Group group, EC_AffinePoint pt);
 
-      EC_PublicKey_Data(const EC_Group& group, std::span<const uint8_t> bytes) :
-            EC_PublicKey_Data(group, EC_AffinePoint(group, bytes)) {}
+      EC_PublicKey_Data(const EC_Group& group, std::span<const uint8_t> bytes);
 
       const EC_Group& group() const { return m_group; }
 

--- a/src/lib/pubkey/ecdsa/ecdsa.cpp
+++ b/src/lib/pubkey/ecdsa/ecdsa.cpp
@@ -54,7 +54,7 @@ EC_AffinePoint recover_ecdsa_public_key(
       X[0] = 0x02 | y_odd;
       x.serialize_to(std::span{X}.subspan(1));
 
-      if(auto R = EC_AffinePoint::deserialize(group, X)) {
+      if(auto R = EC_AffinePoint::deserialize_compressed(group, X)) {
          // Compute r_inv * (-eG + s*R)
          const auto ne = EC_Scalar::from_bytes_with_trunc(group, msg).negate();
          const auto ss = EC_Scalar::from_bigint(group, s);

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -217,7 +217,20 @@ std::unique_ptr<Public_Key> TLS::Callbacks::tls_deserialize_peer_public_key(
 
    if(group_params.is_ecdh_named_curve()) {
       const auto ec_group = EC_Group::from_name(group_params.to_algorithm_spec().value());
-      return std::make_unique<ECDH_PublicKey>(ec_group, EC_AffinePoint(ec_group, key_bits));
+      // TLS 1.3 requires uncompressed points (checked when parsing the key
+      // share); TLS 1.2 may negotiate the compressed format. The deprecated
+      // hybrid encoding and the identity element are never accepted.
+
+      auto point = [&]() -> EC_AffinePoint {
+         if(auto pt_uncompressed = EC_AffinePoint::deserialize_uncompressed(ec_group, key_bits)) {
+            return std::move(pt_uncompressed).value();
+         } else if(auto pt_compressed = EC_AffinePoint::deserialize_compressed(ec_group, key_bits)) {
+            return std::move(pt_compressed).value();
+         } else {
+            throw Decoding_Error("Invalid ECDH public key encoding");
+         }
+      }();
+      return std::make_unique<ECDH_PublicKey>(ec_group, std::move(point));
    }
 
 #if defined(BOTAN_HAS_X25519)

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -836,6 +836,22 @@ class EC_PointEnc_Tests final : public Test {
 
             result.start_timer();
 
+            // The SEC1 encoding of the identity element; accepted by the
+            // permissive deserialization but not the strict variants
+            const std::vector<uint8_t> id_encoding{0x00};
+
+            result.test_is_true("Permissive deserialization accepts the identity encoding",
+                                Botan::EC_AffinePoint::deserialize(group, id_encoding).has_value());
+            result.test_is_false("deserialize_uncompressed rejects the identity encoding",
+                                 Botan::EC_AffinePoint::deserialize_uncompressed(group, id_encoding).has_value());
+            result.test_is_false("deserialize_compressed rejects the identity encoding",
+                                 Botan::EC_AffinePoint::deserialize_compressed(group, id_encoding).has_value());
+
+            result.test_is_false("deserialize_uncompressed rejects empty input",
+                                 Botan::EC_AffinePoint::deserialize_uncompressed(group, {}).has_value());
+            result.test_is_false("deserialize_compressed rejects empty input",
+                                 Botan::EC_AffinePoint::deserialize_compressed(group, {}).has_value());
+
             for(size_t trial = 0; trial != 100; ++trial) {
                const auto scalar = Botan::EC_Scalar::random(group, rng);
                const auto pt = Botan::EC_AffinePoint::g_mul(scalar, rng);
@@ -879,6 +895,53 @@ class EC_PointEnc_Tests final : public Test {
                } else {
                   result.test_failure("Failed to deserialize compressed point");
                }
+
+               // The deprecated hybrid encoding; accepted by the permissive
+               // deserialization (until Botan4) but not the strict variants
+               const auto pt_h = [&]() {
+                  auto x = pt_u;
+                  x[0] = ((pt_u[pt_u.size() - 1] & 0x01) == 0x01) ? 0x07 : 0x06;
+                  return x;
+               }();
+
+               if(auto d_pt_h = Botan::EC_AffinePoint::deserialize(group, pt_h)) {
+                  result.test_bin_eq(
+                     "Permissive deserialization accepts hybrid encoding", d_pt_h->serialize_uncompressed(), pt_u);
+               } else {
+                  result.test_failure("Failed to deserialize hybrid point");
+               }
+
+               if(auto d_pt_u = Botan::EC_AffinePoint::deserialize_uncompressed(group, pt_u)) {
+                  result.test_bin_eq(
+                     "deserialize_uncompressed accepts uncompressed", d_pt_u->serialize_uncompressed(), pt_u);
+               } else {
+                  result.test_failure("Failed to deserialize uncompressed point");
+               }
+
+               result.test_is_false("deserialize_uncompressed rejects compressed",
+                                    Botan::EC_AffinePoint::deserialize_uncompressed(group, pt_c).has_value());
+               result.test_is_false("deserialize_uncompressed rejects hybrid",
+                                    Botan::EC_AffinePoint::deserialize_uncompressed(group, pt_h).has_value());
+               result.test_is_false(
+                  "deserialize_uncompressed rejects truncated input",
+                  Botan::EC_AffinePoint::deserialize_uncompressed(group, std::span{pt_u}.first(pt_u.size() - 1))
+                     .has_value());
+
+               if(auto d_pt_c = Botan::EC_AffinePoint::deserialize_compressed(group, pt_c)) {
+                  result.test_bin_eq(
+                     "deserialize_compressed accepts compressed", d_pt_c->serialize_uncompressed(), pt_u);
+               } else {
+                  result.test_failure("Failed to deserialize compressed point");
+               }
+
+               result.test_is_false("deserialize_compressed rejects uncompressed",
+                                    Botan::EC_AffinePoint::deserialize_compressed(group, pt_u).has_value());
+               result.test_is_false("deserialize_compressed rejects hybrid",
+                                    Botan::EC_AffinePoint::deserialize_compressed(group, pt_h).has_value());
+               result.test_is_false(
+                  "deserialize_compressed rejects truncated input",
+                  Botan::EC_AffinePoint::deserialize_compressed(group, std::span{pt_c}.first(pt_c.size() - 1))
+                     .has_value());
             }
 
             result.end_timer();


### PR DESCRIPTION
The current deserialization function accepts compressed, uncompressed, identity element, and the deprecated hybrid encoding. In many contexts only 1 or 2 of these is actually allowed. Add explicit deserializer functions for compressed and uncompressed points.