### PR TITLE
Remove dependency on `Public_Key` class hierachy in TLS 1.3

### DIFF
--- a/src/lib/tls/tls13/tls_extensions_key_share.cpp
+++ b/src/lib/tls/tls13/tls_extensions_key_share.cpp
@@ -61,31 +61,7 @@ class Key_Share_Entry {
             throw TLS_Exception(Alert::InternalError, "Application did not provide a suitable ephemeral key pair");
          }
 
-         if(group.is_kem()) {
-            m_key_exchange = m_private_key->public_key_bits();
-         } else if(group.is_ecdh_named_curve()) {
-            auto* pkey = dynamic_cast<ECDH_PublicKey*>(m_private_key.get());
-            if(pkey == nullptr) {
-               throw TLS_Exception(Alert::InternalError, "Application did not provide a ECDH_PublicKey");
-            }
-
-            // RFC 8446 Ch. 4.2.8.2
-            //
-            //   Note: Versions of TLS prior to 1.3 permitted point format
-            //   negotiation; TLS 1.3 removes this feature in favor of a single point
-            //   format for each curve.
-            //
-            // Hence, we neither need to take Policy::use_ecc_point_compression() nor
-            // ClientHello::prefers_compressed_ec_points() into account here.
-            m_key_exchange = pkey->public_value(EC_Point_Format::Uncompressed);
-         } else {
-            auto* pkey = dynamic_cast<PK_Key_Agreement_Key*>(m_private_key.get());
-            if(pkey == nullptr) {
-               throw TLS_Exception(Alert::InternalError, "Application did not provide a key-agreement key");
-            }
-
-            m_key_exchange = pkey->public_value();
-         }
+         m_key_exchange = m_private_key->raw_public_key_bits();
       }
 
       bool empty() const { return (m_group == Group_Params::NONE) && m_key_exchange.empty(); }

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -352,7 +352,21 @@ std::unique_ptr<PK_Key_Agreement_Key> TLS::Callbacks::tls_generate_ephemeral_key
 
    if(group_params.is_ecdh_named_curve()) {
       const auto ec_group = EC_Group::from_name(group_params.to_algorithm_spec().value());
-      return std::make_unique<ECDH_PrivateKey>(rng, ec_group);
+      auto ecdh_key = std::make_unique<ECDH_PrivateKey>(rng, ec_group);
+
+      // RFC 8446 Ch. 4.2.8.2
+      //
+      //   Note: Versions of TLS prior to 1.3 permitted point format
+      //   negotiation; TLS 1.3 removes this feature in favor of a single point
+      //   format for each curve.
+      //
+      // Hence, TLS 1.3 won't take Policy::use_ecc_point_compression() or
+      // ClientHello::prefers_compressed_ec_points() into account but always use
+      // uncompressed point encoding. Note that TLS 1.2 uses the
+      // `tls12_generate_ephemeral_ecdh_key()` callback, which allows to specify
+      // the point encoding format.
+      ecdh_key->set_point_encoding(EC_Point_Format::Uncompressed);
+      return ecdh_key;
    }
 
 #if defined(BOTAN_HAS_X25519)


### PR DESCRIPTION
#5056 introduced a distinction between the ECDH ephemeral key generation callbacks of TLS 1.2 and TLS 1.3 to avoid using RTTI to down-cast objects of type `Botan::Public_Key` in TLS 1.2. This makes it much easier for downstream applications to pass objects of their own key implementation (e.g. to build a custom adapter for some proprietary crypto hardware).

Until now, the TLS 1.3 implementation still relied on RTTI much the same way as TLS 1.2 used to. Turns out that the same callback distinction can be leveraged to also remove the down-cast from TLS 1.3.

Note that this relies on the abstract `Public_Key::raw_public_key_bits()` API introduced in #3985. By design, for KEX keys the `raw_public_key_bits()` method is meant to be an alias for `PK_Key_Agreement_Key::public_value()` and is therefore exactly what TLS needs for public key serialization. For KEM keys TLS 1.3 used `public_key_bits()` until now, which is actually wrong. It only worked, because for all relevant KEMs `public_key_bits()` is currently an alias for `raw_public_key_bits()`.