### PR TITLE
Prefer ECDSA over RSA signatures in the default TLS policy

### DIFF
--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -28,6 +28,10 @@ const std::vector<Signature_Scheme>& Signature_Scheme::all_available_schemes() {
       //       EDDSA_25519,
       // #endif
 
+      ECDSA_SHA384,
+      ECDSA_SHA512,
+      ECDSA_SHA256,
+
       RSA_PSS_SHA384,
       RSA_PSS_SHA256,
       RSA_PSS_SHA512,
@@ -35,10 +39,6 @@ const std::vector<Signature_Scheme>& Signature_Scheme::all_available_schemes() {
       RSA_PKCS1_SHA384,
       RSA_PKCS1_SHA512,
       RSA_PKCS1_SHA256,
-
-      ECDSA_SHA384,
-      ECDSA_SHA512,
-      ECDSA_SHA256,
    };
 
    return all_schemes;

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -1524,7 +1524,28 @@ class Test_TLS_RFC8448_Client : public Test_TLS_RFC8448 {
 
          auto sort_our_extensions = [](Botan::TLS::Extensions& exts,
                                        Botan::TLS::Connection_Side /* side */,
-                                       Botan::TLS::Handshake_Type /* which_message */) {
+                                       Botan::TLS::Handshake_Type msg_type) {
+            if(msg_type == Handshake_Type::ClientHello) {
+               exts.remove_extension(Signature_Algorithms::static_type());
+               // This is the preference order of signature algorithms that we
+               // used when we first implemented this test case. To stay
+               // compatible with the now hard-coded transcript, we pin the
+               // algorithm order of preference.
+               //
+               // NOLINTNEXTLINE(*-owning-memory)
+               exts.add(new Signature_Algorithms({
+                  Signature_Scheme::RSA_PSS_SHA384,
+                  Signature_Scheme::RSA_PSS_SHA256,
+                  Signature_Scheme::RSA_PSS_SHA512,
+                  Signature_Scheme::RSA_PKCS1_SHA384,
+                  Signature_Scheme::RSA_PKCS1_SHA512,
+                  Signature_Scheme::RSA_PKCS1_SHA256,
+                  Signature_Scheme::ECDSA_SHA384,
+                  Signature_Scheme::ECDSA_SHA512,
+                  Signature_Scheme::ECDSA_SHA256,
+               }));
+            }
+
             // This is the order of extensions when we first introduced the PSK
             // implementation and generated the transcript. To stay compatible
             // with the now hard-coded transcript, we pin the extension order.


### PR DESCRIPTION
This came up during the extension of the `unit_tls` test case for TLS 1.3 where testing against the "strict policy" wouldn't let me perform a successful handshake with the RSA-1024 certificate (due to tighter security level requirement). The `unit_tls` test case provides two test certs though: one with RSA-1024 and another one with ECDSA on secp256r1. This just made TLS 1.3 select the ECDSA certificate over the too-short RSA-based one.

In any case: I would say it makes sense to prefer ECDSA over RSA in the default configuration these days.