### PR TITLE
VSCode's bogo.py reads `repo_config.env` for BoGo branch

### DIFF
--- a/src/editors/vscode/scripts/bogo.py
+++ b/src/editors/vscode/scripts/bogo.py
@@ -2,19 +2,30 @@
 
 import argparse
 import os
+import sys
 from common import run_cmd, get_concurrency
 
+def find_repo_root():
+    current_dir = os.path.dirname(os.path.abspath(__file__))
+    while not os.path.isfile(os.path.join(current_dir, "news.rst")):
+        parent_dir = os.path.dirname(current_dir)
+        if parent_dir == current_dir:
+            raise RuntimeError("Could not find the repository root")
+        current_dir = parent_dir
+    return current_dir
 
-BORING_REPO = "https://github.com/randombit/boringssl.git"
-BORING_BRANCH = "rene/runner-20241016"
+REPO_ROOT = find_repo_root()
 
-BORING_PATH = "build_deps/boringssl"
+sys.path.insert(0, os.path.join(REPO_ROOT, 'src', 'scripts'))
+from repo_config import RepoConfig  # noqa: E402 pylint: disable=wrong-import-position
+
+BORING_PATH = os.path.join(REPO_ROOT, "build_deps", "boringssl")
 BOGO_PATH = os.path.join(BORING_PATH, "ssl", "test", "runner")
 
-SHIM_PATH = "./botan_bogo_shim"
-SHIM_CONFIG_NO_TLS13 = "src/bogo_shim/config_no_tls13.json"
-SHIM_CONFIG_NO_TLS12 = "src/bogo_shim/config_no_tls12.json"
-SHIM_CONFIG = "src/bogo_shim/config.json"
+SHIM_PATH = os.path.join(REPO_ROOT, "botan_bogo_shim")
+SHIM_CONFIG_NO_TLS13 = os.path.join(REPO_ROOT, "src", "bogo_shim", "config_no_tls13.json")
+SHIM_CONFIG_NO_TLS12 = os.path.join(REPO_ROOT, "src", "bogo_shim", "config_no_tls12.json")
+SHIM_CONFIG = os.path.join(REPO_ROOT, "src", "bogo_shim", "config.json")
 
 
 def main():
@@ -28,6 +39,8 @@ def main():
     parser.add_argument('bogo_args', nargs=argparse.REMAINDER, help='Extra args for the bogo runner')
     args = parser.parse_args()
 
+    repo_config = RepoConfig()
+
     # Select config depending on the option
     if args.without_tls_13:
         config_path = SHIM_CONFIG_NO_TLS13
@@ -38,11 +51,11 @@ def main():
 
     if not os.path.isdir(BORING_PATH):
         # check out our fork of boring ssl
-        run_cmd("git clone --depth 1 --branch %s %s %s" %
-                (BORING_BRANCH, BORING_REPO, BORING_PATH))
+        run_cmd("git clone --depth 1 --branch %s https://github.com/%s.git %s" %
+                (repo_config["BORINGSSL_BRANCH"], repo_config["BORINGSSL_REPO"], BORING_PATH))
 
     # make doubly sure we're on the correct branch
-    run_cmd("git -C %s checkout %s" % (BORING_PATH, BORING_BRANCH))
+    run_cmd("git -C %s checkout %s" % (BORING_PATH, repo_config["BORINGSSL_BRANCH"]))
 
     bogo_args = ';'.join(args.bogo_args) if args.bogo_args else ''
     extra_args = "-wait-for-debugger " if args.wait_for_debugger else ""
@@ -50,8 +63,8 @@ def main():
     extra_args += "-skip-tls13 " if args.without_tls_13 else ""
     extra_args += "-debug -test '%s'" % bogo_args if bogo_args else ''
 
-    run_cmd("go test -pipe -num-workers %d -shim-path %s -shim-config %s %s" %
-            (get_concurrency(), os.path.abspath(SHIM_PATH), os.path.abspath(config_path), extra_args),
+    run_cmd("go test -pipe -allow-unimplemented -num-workers %d -shim-path %s -shim-config %s %s" %
+            (get_concurrency(), SHIM_PATH, config_path, extra_args),
             BOGO_PATH)
 
 if __name__ == '__main__':


### PR DESCRIPTION
The information about the boringssl fork we're currenly using was duplicated into the VSCode integration script. Now it's reading `repo_config.env` for that information. Also, the test parameter `-allow-unimplemented` is retrofitted from #5523. 