### PR TITLE
Fix some issues in the compression wrappers

### DIFF
--- a/src/lib/compression/compress_utils.cpp
+++ b/src/lib/compression/compress_utils.cpp
@@ -18,7 +18,7 @@ namespace Botan {
 Compression_Error::Compression_Error(const char* func_name, ErrorType type, int rc) :
       Exception(fmt("Compression API {} failed with return code {}", func_name, rc)), m_type(type), m_rc(rc) {}
 
-void* Compression_Alloc_Info::do_malloc(size_t n, size_t size) {
+void* Compression_Alloc_Info::do_malloc(size_t n, size_t size) noexcept {
    // Precheck for integer overflow in the multiplication
    // before passing to calloc, which may or may not check.
    if(!checked_mul(n, size)) {
@@ -27,27 +27,51 @@ void* Compression_Alloc_Info::do_malloc(size_t n, size_t size) {
 
    void* ptr = std::calloc(n, size);  // NOLINT(*-no-malloc,*-owning-memory,*-const-correctness)
 
+   if(ptr == nullptr) {
+      return nullptr;
+   }
+
    /*
    * Return null rather than throwing here as we are being called by a
    * C library and it may not be possible for an exception to unwind
    * the call stack from here. The compression library is expecting a
    * function written in C and a null return on error, which it will
-   * send upwards to the compression wrappers.
+   * send upwards to the compression wrappers. So if recording the
+   * allocation throws (eg bad_alloc growing the map), free the block and
+   * report failure the same way.
    */
-
-   if(ptr != nullptr) {
+   try {
       m_current_allocs[ptr] = n * size;
+   } catch(...) {
+      std::free(ptr);  // NOLINT(*-no-malloc,*-owning-memory)
+      return nullptr;
    }
 
    return ptr;
 }
 
-void Compression_Alloc_Info::do_free(void* ptr) {
+void Compression_Alloc_Info::do_free(void* ptr) noexcept {
    if(ptr != nullptr) {
       auto i = m_current_allocs.find(ptr);
 
       if(i == m_current_allocs.end()) {
-         throw Internal_Error("Compression_Alloc_Info::free got pointer not allocated by us");
+         /*
+         * The compression library tried to free a pointer that was not allocated by
+         * a call to the allocation function. We do not have any particularly good
+         * options here.
+         *
+         * - Throwing is not possible since it would unwind through a C ABI library,
+         *   which results in undefined behavior.
+         *
+         * - We could panic (fprintf to stderr and abort) but causing a unilateral
+         *   and unrecoverable process crash isn't necessarily the right choice either.
+         *
+         * - We could skip the scrub step and pass the pointer along directly to
+         *   std::free, but that risks corrupting the system heap.
+         *
+         * So instead we just ignore the request entirely
+         */
+         return;
       }
 
       secure_scrub_memory(ptr, i->second);

--- a/src/lib/compression/compress_utils.h
+++ b/src/lib/compression/compress_utils.h
@@ -10,7 +10,9 @@
 
 #include <botan/compression.h>
 
+#include <botan/exceptn.h>
 #include <botan/mem_ops.h>
+#include <limits>
 #include <memory>
 #include <unordered_map>
 
@@ -22,15 +24,15 @@ namespace Botan {
 class Compression_Alloc_Info final {
    public:
       template <typename T>
-      static void* malloc(void* self, T n, T size) {
+      static void* malloc(void* self, T n, T size) noexcept {
          return static_cast<Compression_Alloc_Info*>(self)->do_malloc(n, size);
       }
 
-      static void free(void* self, void* ptr) { static_cast<Compression_Alloc_Info*>(self)->do_free(ptr); }
+      static void free(void* self, void* ptr) noexcept { static_cast<Compression_Alloc_Info*>(self)->do_free(ptr); }
 
    private:
-      void* do_malloc(size_t n, size_t size);
-      void do_free(void* ptr);
+      void* do_malloc(size_t n, size_t size) noexcept;
+      void do_free(void* ptr) noexcept;
 
       std::unordered_map<void*, size_t> m_current_allocs;
 };
@@ -42,11 +44,17 @@ template <typename Stream, typename ByteType, typename StreamLenType = size_t>
 class Zlib_Style_Stream : public Compression_Stream {
    public:
       void next_in(uint8_t* b, size_t len) override {
+         if(len > std::numeric_limits<StreamLenType>::max()) {
+            throw Not_Implemented("Compression chunk is too large for this backend's length field");
+         }
          m_stream.next_in = reinterpret_cast<ByteType*>(b);
          m_stream.avail_in = static_cast<StreamLenType>(len);
       }
 
       void next_out(uint8_t* b, size_t len) override {
+         if(len > std::numeric_limits<StreamLenType>::max()) {
+            throw Not_Implemented("Compression chunk is too large for this backend's length field");
+         }
          m_stream.next_out = reinterpret_cast<ByteType*>(b);
          m_stream.avail_out = static_cast<StreamLenType>(len);
       }

--- a/src/lib/compression/lzma/lzma.cpp
+++ b/src/lib/compression/lzma/lzma.cpp
@@ -74,7 +74,9 @@ class LZMA_Compression_Stream final : public LZMA_Stream {
 class LZMA_Decompression_Stream final : public LZMA_Stream {
    public:
       LZMA_Decompression_Stream() {
-         const lzma_ret rc = ::lzma_stream_decoder(streamp(), UINT64_MAX, LZMA_TELL_UNSUPPORTED_CHECK);
+         // LZMA's highest preset compression level uses 64 MiB of dictionary
+         constexpr uint64_t memory_limit = static_cast<uint64_t>(128) * 1024 * 1024;
+         const lzma_ret rc = ::lzma_stream_decoder(streamp(), memory_limit, LZMA_TELL_UNSUPPORTED_CHECK);
 
          if(rc != LZMA_OK) {
             throw Compression_Error("lzma_stream_decoder", ErrorType::LzmaError, rc);


### PR DESCRIPTION
Zlib and bzip2 uses 32-bit integers for input lengths which could lead to silent truncation of data if presented in chunks over 4 Gb. Instead detect this and throw.

When tracking allocation metadata in the compression wrappers, if the map allocation failed and threw bad_alloc this could cause a stack unwind through a C library, which is undefined behavior.

In LZMA enforce a reasonable memory limit when decompressing. Even the highest preset level uses only 64 Mb of dictionary, so allowing 1 Gb+ doesn't seem reasonable.