### PR TITLE
Use RFC 5280's prescribed method for generating subject public key ID values

### DIFF
--- a/src/examples/pkcs10_csr_on_tpm2.cpp
+++ b/src/examples/pkcs10_csr_on_tpm2.cpp
@@ -99,8 +99,7 @@ int main() {
       alt_name.add_email("rene.meusel@rohde-schwarz.com");
       return alt_name;
    }()));
-   extensions.add_new(
-      std::make_unique<Botan::Cert_Extension::Subject_Key_ID>(cert_private_key->public_key_bits(), "SHA-256"));
+   extensions.add_new(std::make_unique<Botan::Cert_Extension::Subject_Key_ID>(*cert_private_key->public_key()));
 
    // All done, create the CSR
    auto csr = Botan::PKCS10_Request::create(*cert_private_key, dn, extensions, "SHA-256", tpm_rng, "PSS(SHA-256)");

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -42,7 +42,11 @@ X509_CA::~X509_CA() = default;
 
 Extensions X509_CA::choose_extensions(const PKCS10_Request& req,
                                       const X509_Certificate& ca_cert,
-                                      std::string_view hash_fn) {
+                                      std::string_view /*hash_fn*/) {
+   return choose_extensions(req, ca_cert);
+}
+
+Extensions X509_CA::choose_extensions(const PKCS10_Request& req, const X509_Certificate& ca_cert) {
    const auto constraints = req.is_CA() ? Key_Constraints::ca_constraints() : req.constraints();
 
    auto key = req.subject_public_key();
@@ -60,7 +64,7 @@ Extensions X509_CA::choose_extensions(const PKCS10_Request& req,
    }
 
    extensions.replace(std::make_unique<Cert_Extension::Authority_Key_ID>(ca_cert.subject_key_id()));
-   extensions.replace(std::make_unique<Cert_Extension::Subject_Key_ID>(req.raw_public_key(), hash_fn));
+   extensions.replace(std::make_unique<Cert_Extension::Subject_Key_ID>(*key));
 
    extensions.replace(std::make_unique<Cert_Extension::Subject_Alternative_Name>(req.subject_alt_name()));
 
@@ -74,7 +78,7 @@ X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
                                        const BigInt& serial_number,
                                        const X509_Time& not_before,
                                        const X509_Time& not_after) const {
-   auto extensions = choose_extensions(req, m_ca_cert, m_hash_fn);
+   auto extensions = choose_extensions(req, m_ca_cert);
 
    return make_cert(*m_signer,
                     rng,
@@ -95,7 +99,7 @@ X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
                                        RandomNumberGenerator& rng,
                                        const X509_Time& not_before,
                                        const X509_Time& not_after) const {
-   auto extensions = choose_extensions(req, m_ca_cert, m_hash_fn);
+   auto extensions = choose_extensions(req, m_ca_cert);
 
    return make_cert(*m_signer,
                     rng,

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -131,9 +131,11 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
       * so you can call it directly and then modify the extensions before
       * creating a certificate using X509_CA::make_cert.
       */
-      static Extensions choose_extensions(const PKCS10_Request& req,
-                                          const X509_Certificate& ca_certificate,
-                                          std::string_view hash_fn);
+      static Extensions choose_extensions(const PKCS10_Request& req, const X509_Certificate& ca_certificate);
+
+      BOTAN_DEPRECATED("Use the overload that does not take a hash function name (SKID is now always SHA-1)")
+      static Extensions
+         choose_extensions(const PKCS10_Request& req, const X509_Certificate& ca_certificate, std::string_view hash_fn);
 
       /**
       * Interface for creating new certificates

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -14,6 +14,7 @@
 #include <botan/ber_dec.h>
 #include <botan/der_enc.h>
 #include <botan/hash.h>
+#include <botan/pk_keys.h>
 #include <botan/x509cert.h>
 #include <botan/internal/fmt.h>
 #include <botan/internal/int_utils.h>
@@ -545,6 +546,24 @@ void Subject_Key_ID::decode_inner(const std::vector<uint8_t>& in) {
       throw Decoding_Error(
          fmt("SubjectKeyIdentifier length {} exceeds limit of {} bytes", m_key_id.size(), MaximumKeyIdentifierLength));
    }
+}
+
+/*
+* Subject_Key_ID Constructor
+*/
+Subject_Key_ID::Subject_Key_ID(const Public_Key& pub_key) {
+   /*
+   * RFC 5280 4.2.1.2:
+   *    (1) The keyIdentifier is composed of the 160-bit SHA-1 hash of the
+   *    value of the BIT STRING subjectPublicKey (excluding the tag, length,
+   *    and number of unused bits).
+   */
+   auto hash = HashFunction::create_or_throw("SHA-1");
+
+   m_key_id.resize(hash->output_length());
+
+   hash->update(pub_key.public_key_bits());
+   hash->final(m_key_id.data());
 }
 
 /*

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -111,6 +111,17 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
 
       explicit Subject_Key_ID(const std::vector<uint8_t>& k) : m_key_id(k) {}
 
+      /**
+      * Derive the key identifier from the public key, using the first
+      * method given in RFC 5280 4.2.1.2:
+      *
+      *    (1) The keyIdentifier is composed of the 160-bit SHA-1 hash of
+      *    the value of the BIT STRING subjectPublicKey (excluding the tag,
+      *    length, and number of unused bits).
+      */
+      explicit Subject_Key_ID(const Public_Key& pub_key);
+
+      BOTAN_DEPRECATED("Use Subject_Key_ID(const Public_Key&)")
       Subject_Key_ID(const std::vector<uint8_t>& public_key, std::string_view hash_fn);
 
       std::unique_ptr<Certificate_Extension> copy() const override {

--- a/src/lib/x509/x509self.cpp
+++ b/src/lib/x509/x509self.cpp
@@ -103,7 +103,7 @@ X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
       extensions.add_new(std::make_unique<Cert_Extension::Key_Usage>(constraints), true);
    }
 
-   auto skid = std::make_unique<Cert_Extension::Subject_Key_ID>(pub_key, signer->hash_function());
+   auto skid = std::make_unique<Cert_Extension::Subject_Key_ID>(key);
 
    extensions.add_new(std::make_unique<Cert_Extension::Authority_Key_ID>(skid->get_key_id()));
    extensions.add_new(std::move(skid));

--- a/src/scripts/test_cli.py
+++ b/src/scripts/test_cli.py
@@ -559,7 +559,7 @@ mlLtJ5JvZ0/p6zP3x+Y9yPIrAR8L/acG5ItSrAKXzzuqQQZMv4aN
 
     if cert_info.find('Subject: CN="CA",C="VT"') < 0:
         logging.error('Unexpected output for cert_info command %s', cert_info)
-    if cert_info.find('Subject keyid: 69DD911C9EEE3400C67CBC3F3056CBE711BD56AF9495013F') < 0:
+    if cert_info.find('Subject keyid: F4E2C7A1E26C971BEC4EE971363D8A28AD437F01') < 0:
         logging.error('Unexpected output for cert_info command %s', cert_info)
 
     test_cli("gen_pkcs10", "%s User --output=%s" % (priv_key, crt_req))

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -696,6 +696,22 @@ Test::Result test_x509_utf8() {
    return result;
 }
 
+Test::Result test_x509_subject_key_id_derivation() {
+   Test::Result result("X509 subject key id derivation");
+
+   /*
+   * Externally generated certificates whose subject key identifier was
+   * derived using RFC 5280 4.2.1.2 method (1), covering RSA and ECDSA keys
+   */
+   for(const auto* file : {"name_constraints/root.pem", "misc/aruba.pem", "misc/contains_any_extended_key_usage.pem"}) {
+      const Botan::X509_Certificate cert(Test::data_file(std::string("x509/") + file));
+      const Botan::Cert_Extension::Subject_Key_ID skid(*cert.subject_public_key());
+      result.test_bin_eq(std::string(file) + " subject key id", skid.get_key_id(), cert.subject_key_id());
+   }
+
+   return result;
+}
+
 Test::Result test_x509_any_key_extended_usage() {
    using Botan::Key_Constraints;
    using Botan::Usage_Type;
@@ -1086,6 +1102,11 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
    {
       result.test_is_true("ca key usage cert", ca_cert.constraints().includes(Botan::Key_Constraints::KeyCertSign));
       result.test_is_true("ca key usage crl", ca_cert.constraints().includes(Botan::Key_Constraints::CrlSign));
+
+      // The subject key id is derived using SHA-1 regardless of the signature hash
+      result.test_bin_eq("ca cert subject key id is SHA-1 of subjectPublicKey",
+                         ca_cert.subject_key_id(),
+                         ca_cert.subject_public_key_bitstring_sha1());
    }
 
    /* Create user #1's key and cert request */
@@ -1119,6 +1140,10 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
 
    result.test_sz_eq("User1 serial size matches expected", user1_cert.serial_number().size(), 1);
    result.test_sz_eq("User1 serial matches expected", user1_cert.serial_number().at(0), size_t(99));
+
+   result.test_bin_eq("user1 subject key id is SHA-1 of subjectPublicKey",
+                      user1_cert.subject_key_id(),
+                      user1_cert.subject_public_key_bitstring_sha1());
 
    const Botan::X509_Certificate user2_cert =
       ca.sign_request(user2_req, rng, from_date(-1, 01, 01), from_date(2, 01, 01));
@@ -2085,6 +2110,7 @@ class X509_Cert_Unit_Tests final : public Test {
 
    #if defined(BOTAN_TARGET_OS_HAS_FILESYSTEM)
          results.push_back(test_x509_utf8());
+         results.push_back(test_x509_subject_key_id_derivation());
          results.push_back(test_x509_any_key_extended_usage());
          results.push_back(test_x509_bmpstring());
          results.push_back(test_x509_teletex());


### PR DESCRIPTION
Using exactly SHA-1 is assumed by many different systems, and in fact there are basically no security issues with using SHA-1 in this context.