### PR TITLE
Support decoding of X509 authority key ID fields with a DN + serial

### DIFF
--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -668,7 +668,11 @@ BER_Decoder& BER_Decoder::operator=(BER_Decoder&&) noexcept = default;
 /*
 * Request for an object to decode itself
 */
-BER_Decoder& BER_Decoder::decode(ASN1_Object& obj, ASN1_Type /*unused*/, ASN1_Class /*unused*/) {
+BER_Decoder& BER_Decoder::decode(ASN1_Object& obj, ASN1_Type type_tag, ASN1_Class class_tag) {
+   // TODO support this case properly
+   if(type_tag != ASN1_Type::NoObject || class_tag != ASN1_Class::NoObject) {
+      throw Not_Implemented("BER_Decoder::decode(ASN1_Object) does not support implicit tagged decoding");
+   }
    obj.decode_from(*this);
    return (*this);
 }

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 namespace Botan {
@@ -456,7 +457,12 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       BER_Decoder& decode_implicit(BER_Object obj, T& out, ASN1_Type real_type, ASN1_Class real_class) {
          obj.set_tagging(real_type, real_class);
          push_back(std::move(obj));
-         return decode(out, real_type, real_class);
+         if constexpr(std::is_base_of_v<ASN1_Object, T>) {
+            // The object was re-tagged above; decode_from checks the real tag itself
+            return decode(out);
+         } else {
+            return decode(out, real_type, real_class);
+         }
       }
 
       template <typename T>
@@ -584,7 +590,13 @@ BER_Decoder& BER_Decoder::decode_optional(std::optional<T>& optval, ASN1_Type ty
          BER_Decoder(obj, m_limits).decode(out).verify_end();
       } else {
          this->push_back(std::move(obj));
-         this->decode(out, type_tag, class_tag);
+         if constexpr(std::is_base_of_v<ASN1_Object, T>) {
+            // Object types check the tag in decode_from; a re-tagging
+            // implicit override of an object is not supported here
+            this->decode(out);
+         } else {
+            this->decode(out, type_tag, class_tag);
+         }
       }
       optval = std::move(out);
    } else {

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -30,6 +30,22 @@ namespace {
 
 constexpr size_t MaximumKeyIdentifierLength = 64;
 
+/*
+* Encode an AlternativeName as `GeneralNames` but with an outer IMPLICIT
+* context-specific tag rather than the universal SEQUENCE tag. Used for
+* fullName [0] / cRLIssuer [2] / similar.
+*/
+void emit_general_names_implicit(DER_Encoder& der, const AlternativeName& names, uint32_t tag) {
+   // RFC 5280 4.2.1.6: GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+   if(!names.has_items()) {
+      throw Encoding_Error("Cannot encode empty GeneralNames");
+   }
+   if(std::ranges::any_of(names.directory_names(), [](const X509_DN& dn) { return dn.empty(); })) {
+      throw Encoding_Error("GeneralNames must not contain an empty directoryName");
+   }
+   der.encode_implicit(names, ASN1_Type(tag));
+}
+
 template <std::derived_from<Certificate_Extension> T>
 auto make_extension([[maybe_unused]] const OID& oid) {
    BOTAN_DEBUG_ASSERT(oid == T::static_oid());
@@ -589,10 +605,16 @@ Subject_Key_ID::Subject_Key_ID(const std::vector<uint8_t>& pub_key, std::string_
 */
 std::vector<uint8_t> Authority_Key_ID::encode_inner() const {
    std::vector<uint8_t> output;
-   DER_Encoder(output)
-      .start_sequence()
-      .encode(m_key_id, ASN1_Type::OctetString, ASN1_Type(0), ASN1_Class::ContextSpecific)
-      .end_cons();
+   DER_Encoder der(output);
+   der.start_sequence();
+   if(!m_key_id.empty()) {
+      der.encode(m_key_id, ASN1_Type::OctetString, ASN1_Type(0), ASN1_Class::ContextSpecific);
+   }
+   if(m_authority_cert.has_value()) {
+      emit_general_names_implicit(der, m_authority_cert->issuer, 1);
+      der.encode(m_authority_cert->serial_number.to_bigint(), ASN1_Type(2), ASN1_Class::ContextSpecific);
+   }
+   der.end_cons();
    return output;
 }
 
@@ -611,9 +633,38 @@ void Authority_Key_ID::decode_inner(const std::vector<uint8_t>& in) {
    BER_Decoder ber(in, BER_Decoder::Limits::DER());
    BER_Decoder seq = ber.start_sequence();
 
-   const bool key_id_present = seq.peek_next_object().is_a(0, ASN1_Class::ContextSpecific);
+   m_key_id.clear();
+   m_authority_cert.reset();
 
-   seq.decode_optional_string(m_key_id, ASN1_Type::OctetString, 0).discard_remaining().end_cons();
+   bool key_id_present = false;
+   std::optional<AlternativeName> authority_cert_issuer;
+   std::optional<X509_Serial_Number> authority_cert_serial;
+
+   seq.decode_optional_field(0,
+                             ASN1_Class::ContextSpecific,
+                             [&](BER_Decoder& d) {
+                                d.decode(m_key_id, ASN1_Type::OctetString, ASN1_Type(0), ASN1_Class::ContextSpecific);
+                                key_id_present = true;
+                             })
+      .decode_optional_field(1,
+                             ASN1_Class::ContextSpecific | ASN1_Class::Constructed,
+                             [&](BER_Decoder& d) {
+                                AlternativeName names;
+                                d.decode_implicit(names,
+                                                  ASN1_Type(1),
+                                                  ASN1_Class::ContextSpecific | ASN1_Class::Constructed,
+                                                  ASN1_Type::Sequence,
+                                                  ASN1_Class::Constructed);
+                                authority_cert_issuer = std::move(names);
+                             })
+      .decode_optional_field(2, ASN1_Class::ContextSpecific, [&](BER_Decoder& d) {
+         X509_Serial_Number serial;
+         d.decode_implicit(
+            serial, ASN1_Type(2), ASN1_Class::ContextSpecific, ASN1_Type::Integer, ASN1_Class::Universal);
+         authority_cert_serial = std::move(serial);
+      });
+
+   seq.end_cons();
    ber.verify_end();
 
    if(key_id_present) {
@@ -625,6 +676,27 @@ void Authority_Key_ID::decode_inner(const std::vector<uint8_t>& in) {
                                   m_key_id.size(),
                                   MaximumKeyIdentifierLength));
       }
+   }
+
+   // RFC 5280 4.2.1.6: GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
+   if(authority_cert_issuer.has_value() && authority_cert_issuer->is_empty()) {
+      throw Decoding_Error("AuthorityKeyIdentifier authorityCertIssuer must contain at least one GeneralName");
+   }
+
+   /*
+   * RFC 5280 Appendix A.2:
+   *
+   *    authorityCertIssuer and authorityCertSerialNumber MUST both be
+   *    present or both be absent
+   */
+   if(authority_cert_issuer.has_value() != authority_cert_serial.has_value()) {
+      throw Decoding_Error(
+         "AuthorityKeyIdentifier authorityCertIssuer and authorityCertSerialNumber must both be present or absent");
+   }
+
+   if(authority_cert_issuer.has_value()) {
+      m_authority_cert =
+         Authority_Cert_Identifier{std::move(*authority_cert_issuer), std::move(*authority_cert_serial)};
    }
 }
 
@@ -1214,22 +1286,6 @@ void CRL_ReasonCode::decode_inner(const std::vector<uint8_t>& in) {
 }
 
 namespace {
-
-/*
-* Encode an AlternativeName as `GeneralNames` but with an outer IMPLICIT
-* context-specific tag rather than the universal SEQUENCE tag. Used for
-* fullName [0] / cRLIssuer [2] / similar.
-*/
-void emit_general_names_implicit(DER_Encoder& der, const AlternativeName& names, uint32_t tag) {
-   // RFC 5280 4.2.1.6: GeneralNames ::= SEQUENCE SIZE (1..MAX) OF GeneralName
-   if(!names.has_items()) {
-      throw Encoding_Error("Cannot encode empty GeneralNames");
-   }
-   if(std::ranges::any_of(names.directory_names(), [](const X509_DN& dn) { return dn.empty(); })) {
-      throw Encoding_Error("GeneralNames must not contain an empty directoryName");
-   }
-   der.encode_implicit(names, ASN1_Type(tag));
-}
 
 constexpr size_t ReasonFlagsNamedBitWidth = 9;
 

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -152,15 +152,30 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
 */
 class BOTAN_PUBLIC_API(2, 0) Authority_Key_ID final : public Certificate_Extension {
    public:
-      std::unique_ptr<Certificate_Extension> copy() const override {
-         return std::make_unique<Authority_Key_ID>(m_key_id);
-      }
+      std::unique_ptr<Certificate_Extension> copy() const override { return std::make_unique<Authority_Key_ID>(*this); }
 
       Authority_Key_ID() = default;
 
       explicit Authority_Key_ID(const std::vector<uint8_t>& k) : m_key_id(k) {}
 
+      /**
+      * The authorityCertIssuer and authorityCertSerialNumber fields, which
+      * identify the certificate holding the authority's signing key.
+      */
+      struct Authority_Cert_Identifier final {
+            AlternativeName issuer;
+            X509_Serial_Number serial_number;
+      };
+
+      Authority_Key_ID(const std::vector<uint8_t>& k, Authority_Cert_Identifier authority_cert) :
+            m_key_id(k), m_authority_cert(std::move(authority_cert)) {}
+
       const std::vector<uint8_t>& get_key_id() const { return m_key_id; }
+
+      /**
+      * The authorityCertIssuer/authorityCertSerialNumber fields, if present
+      */
+      const std::optional<Authority_Cert_Identifier>& authority_cert_identifier() const { return m_authority_cert; }
 
       static OID static_oid() { return OID({2, 5, 29, 35}); }
 
@@ -171,12 +186,13 @@ class BOTAN_PUBLIC_API(2, 0) Authority_Key_ID final : public Certificate_Extensi
 
       bool is_appropriate_context(Extension_Context context) const override;
 
-      bool should_encode() const override { return (!m_key_id.empty()); }
+      bool should_encode() const override { return !m_key_id.empty() || m_authority_cert.has_value(); }
 
       std::vector<uint8_t> encode_inner() const override;
       void decode_inner(const std::vector<uint8_t>& in) override;
 
       std::vector<uint8_t> m_key_id;
+      std::optional<Authority_Cert_Identifier> m_authority_cert;
 };
 
 /**

--- a/src/scripts/run_limbo_tests.py
+++ b/src/scripts/run_limbo_tests.py
@@ -35,8 +35,6 @@ tests_that_succeed_unexpectedly = {
     'rfc5280::ski::root-missing-ski': 'Conflates CA and verifier requirements',
 
     'webpki::aki::root-with-aki-missing-keyidentifier': 'Conflates CA and verifier requirements',
-    'webpki::aki::root-with-aki-authoritycertissuer': 'Conflates CA and verifier requirements',
-    'webpki::aki::root-with-aki-authoritycertserialnumber': 'Conflates CA and verifier requirements',
     'webpki::aki::root-with-aki-all-fields': 'Conflates CA and verifier requirements',
     'webpki::ee-basicconstraints-ca': 'Conflates CA and verifier requirements',
     'webpki::eku::ee-without-eku': 'Conflates CA and verifier requirements',

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -1740,7 +1740,10 @@ class String_Extension final : public Botan::Certificate_Extension {
 
       void decode_inner(const std::vector<uint8_t>& in) override {
          Botan::ASN1_String str;
-         Botan::BER_Decoder(in).decode(str, Botan::ASN1_Type::Utf8String).verify_end();
+         Botan::BER_Decoder(in).decode(str).verify_end();
+         if(str.tagging() != Botan::ASN1_Type::Utf8String) {
+            throw Botan::Decoding_Error("String_Extension expected a UTF8 string");
+         }
          m_contents = str.value();
       }
 


### PR DESCRIPTION
Currently these values are not used for path building.