### PR TITLE
Remove a couple of unused functions in the tests

### DIFF
--- a/src/tests/test_tls_handshake_layer_13.cpp
+++ b/src/tests/test_tls_handshake_layer_13.cpp
@@ -29,13 +29,6 @@ bool has_message(Test::Result& test_result, const std::optional<Handshake_Messag
    return std::holds_alternative<T>(read_result.value());
 }
 
-template <typename T>
-const Handshake_Message_13& get_message(Test::Result& test_result,
-                                        const std::optional<Handshake_Message_13>& read_result) {
-   test_result.require("has the expected message", has_message<T>(test_result, read_result));
-   return std::get<T>(read_result.value());
-}
-
 // NOLINTBEGIN(cert-err58-cpp,bugprone-throwing-static-initialization)
 const auto client_hello_message = Botan::hex_decode_locked(  // from RFC 8448
    "01 00 00 c0 03 03 cb"

--- a/src/tests/test_x509_cdp_aia.cpp
+++ b/src/tests/test_x509_cdp_aia.cpp
@@ -58,15 +58,6 @@ const Botan::Cert_Extension::Authority_Information_Access* require_aia(Test::Res
    return aia;
 }
 
-// Fetch the typed extension T from `exts`, recording a not-null failure if it is
-// absent. Returns nullptr in that case so callers can early-return.
-template <typename T>
-const T* require_cert_ext(Test::Result& result, const Botan::Extensions& exts, const char* what) {
-   const auto* ext = exts.get_extension_object_as<T>();
-   result.test_not_null(what, ext);
-   return ext;
-}
-
 // Wrap a single extension (oid, optional critical flag, extn_value OCTET STRING)
 // in the Extensions wire form (SEQUENCE OF Extension) and decode it. This is the
 // public path that reaches an extension's decode_inner; a body that fails to


### PR DESCRIPTION
Oddly the only thing that seems to be complaining about these is a recently updated version of Emscripten.