### PR TITLE
Output filename and line number with deprecation messages on MSVC

### DIFF
--- a/src/lib/utils/api.h
+++ b/src/lib/utils/api.h
@@ -76,8 +76,14 @@
       #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("message \"this header is deprecated\"")
       #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) _Pragma("message \"this header will be made internal in the future\"")
    #elif defined(_MSC_VER)
-      #define BOTAN_DEPRECATED_HEADER(hdr) __pragma(message("this header is deprecated"))
-      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) __pragma(message("this header will be made internal in the future"))
+      #if !defined(BOTAN_STRINGIFY) && !defined(BOTAN_STRINGIFY_2)
+         #define BOTAN_STRINGIFY_2(x) #x
+         #define BOTAN_STRINGIFY(x) BOTAN_STRINGIFY_2(x)
+      #endif
+      #define BOTAN_DEPRECATED_HEADER(hdr) \
+         __pragma(message(__FILE__ "(" BOTAN_STRINGIFY(__LINE__) "): this header is deprecated"))
+      #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \
+         __pragma(message(__FILE__ "(" BOTAN_STRINGIFY(__LINE__) "): this header will be made internal in the future"))
    #elif defined(__GNUC__)
       #define BOTAN_DEPRECATED_HEADER(hdr) _Pragma("GCC warning \"this header is deprecated\"")
       #define BOTAN_FUTURE_INTERNAL_HEADER(hdr) \


### PR DESCRIPTION
Unlike other compilers, MSVC does not by default output the filename with pragma messages. So the build log would literally show deprecation warnings as just "this header is deprecated", with no hint about what header, or whose header, i.e. not even a hint that this message is coming from Botan.