### PR TITLE
Rename URI::parse to ::from_string

### DIFF
--- a/src/cli/utils.cpp
+++ b/src/cli/utils.cpp
@@ -314,7 +314,7 @@ class HTTP_Get final : public Command {
          const std::chrono::milliseconds timeout(get_arg_sz("timeout"));
          const size_t redirects = get_arg_sz("redirects");
 
-         auto uri = Botan::URI::parse(url);
+         auto uri = Botan::URI::from_string(url);
          if(!uri) {
             throw CLI_Usage_Error("Could not parse URL '" + url + "'");
          }

--- a/src/fuzzer/uri.cpp
+++ b/src/fuzzer/uri.cpp
@@ -15,6 +15,6 @@ void fuzz(std::span<const uint8_t> input) {
    }
 
    const std::string s(reinterpret_cast<const char*>(input.data()), input.size());
-   const auto uri = Botan::URI::parse(s);
-   const auto authority = Botan::URI::Authority::parse(s);
+   const auto uri = Botan::URI::from_string(s);
+   const auto authority = Botan::URI::Authority::from_string(s);
 }

--- a/src/lib/utils/http_util/http_util.cpp
+++ b/src/lib/utils/http_util/http_util.cpp
@@ -171,7 +171,7 @@ void check_no_crlf_nul(std::string_view field, std::string_view value) {
 * relative, dot-segments) are rejected.
 */
 std::optional<URI> resolve_location(const URI& base, std::string_view location) {
-   if(auto absolute = URI::parse(location)) {
+   if(auto absolute = URI::from_string(location)) {
       return absolute;
    }
    if(location.starts_with("/") && !location.starts_with("//")) {
@@ -180,7 +180,7 @@ std::optional<URI> resolve_location(const URI& base, std::string_view location) 
          return std::nullopt;
       }
       const std::string composed = base.scheme() + "://" + std::string(*raw_authority) + std::string(location);
-      return URI::parse(composed);
+      return URI::from_string(composed);
    }
    return std::nullopt;
 }

--- a/src/lib/utils/socket/socket_udp.cpp
+++ b/src/lib/utils/socket/socket_udp.cpp
@@ -418,7 +418,7 @@ std::unique_ptr<OS::SocketUDP> OS::open_socket_udp(std::string_view hostname,
 }
 
 std::unique_ptr<OS::SocketUDP> OS::open_socket_udp(std::string_view uri_string, std::chrono::microseconds timeout) {
-   const auto authority = URI::Authority::parse(uri_string);
+   const auto authority = URI::Authority::from_string(uri_string);
    if(!authority.has_value() || !authority->port().has_value()) {
       throw Invalid_Argument("UDP port not specified");
    }

--- a/src/lib/utils/uri/uri.cpp
+++ b/src/lib/utils/uri/uri.cpp
@@ -161,7 +161,7 @@ bool URI::Authority::operator==(const URI::Authority& other) const {
 }
 
 //static
-std::optional<URI> URI::parse(std::string_view raw) {
+std::optional<URI> URI::from_string(std::string_view raw) {
    // Empty string is not a valid URI
    if(raw.empty()) {
       return {};
@@ -207,7 +207,7 @@ std::optional<URI> URI::parse(std::string_view raw) {
 
       // Parse and validate non-empty authority strings (hostname, IPv4, or IPv6 address)
       if(!authority.empty()) {
-         parsed_authority = Authority::parse(authority);
+         parsed_authority = Authority::from_string(authority);
          if(!parsed_authority.has_value()) {
             return {};
          }
@@ -245,7 +245,7 @@ std::optional<URI> URI::parse(std::string_view raw) {
 }
 
 //static
-std::optional<URI::Authority> URI::Authority::parse(std::string_view raw) {
+std::optional<URI::Authority> URI::Authority::from_string(std::string_view raw) {
    if(raw.empty()) {
       return {};
    }

--- a/src/lib/utils/uri/uri.h
+++ b/src/lib/utils/uri/uri.h
@@ -48,7 +48,7 @@ class BOTAN_PUBLIC_API(3, 13) URI final {
             * Parse a bare authority "host[:port]" or "[ipv6][:port]".
             * Returns nullopt for any parse failure.
             */
-            static std::optional<Authority> parse(std::string_view raw);
+            static std::optional<Authority> from_string(std::string_view raw);
 
             /**
             * Parsed host: a DNS name, an IPv4 literal, or an IPv6 literal.
@@ -106,7 +106,7 @@ class BOTAN_PUBLIC_API(3, 13) URI final {
       /**
       * Parse a URI, return nullopt on failure
       */
-      static std::optional<URI> parse(std::string_view raw);
+      static std::optional<URI> from_string(std::string_view raw);
 
       /**
       * Return the scheme, lowercase normalized

--- a/src/lib/x509/alt_name.cpp
+++ b/src/lib/x509/alt_name.cpp
@@ -18,7 +18,7 @@ void AlternativeName::add_uri(std::string_view uri) {
    if(uri.empty()) {
       return;
    }
-   if(auto parsed = URI::parse(uri)) {
+   if(auto parsed = URI::from_string(uri)) {
       add_uri(std::move(*parsed));
    } else {
       throw Decoding_Error("Invalid URI in SubjectAlternativeName");

--- a/src/lib/x509/name_constraint.cpp
+++ b/src/lib/x509/name_constraint.cpp
@@ -89,7 +89,7 @@ std::optional<GeneralName::URIConstraint> GeneralName::URIConstraint::from_strin
 }
 
 std::optional<GeneralName::URIConstraint> GeneralName::URIConstraint::from_san_value(std::string_view full_uri) {
-   if(URI::parse(full_uri).has_value()) {
+   if(URI::from_string(full_uri).has_value()) {
       return URIConstraint(std::string(full_uri));
    } else {
       return std::nullopt;

--- a/src/lib/x509/ocsp.cpp
+++ b/src/lib/x509/ocsp.cpp
@@ -696,7 +696,7 @@ Response online_check(const X509_Certificate& issuer,
       throw Invalid_Argument("No OCSP responder specified");
    }
 
-   if(auto uri = URI::parse(ocsp_responder)) {
+   if(auto uri = URI::from_string(ocsp_responder)) {
       return online_check(issuer, subject_serial, *uri, timeout);
    } else {
       throw Invalid_Argument("Unparsable URI for OCSP responder");

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -948,7 +948,7 @@ std::vector<URI> parse_aia_uris(const std::vector<std::string>& uris, const char
    std::vector<URI> out;
    out.reserve(uris.size());
    for(const auto& uri : uris) {
-      if(auto parsed = URI::parse(uri)) {
+      if(auto parsed = URI::from_string(uri)) {
          out.push_back(std::move(*parsed));
       } else {
          throw Invalid_Argument(fmt("Invalid URI in {}", context));
@@ -984,7 +984,7 @@ Authority_Information_Access::Authority_Information_Access(std::string_view ocsp
                                                            const std::vector<std::string>& ca_issuers) :
       m_ca_issuers(parse_aia_uris(ca_issuers, "AuthorityInformationAccess CA issuers")) {
    if(!ocsp.empty()) {
-      if(auto parsed = URI::parse(ocsp)) {
+      if(auto parsed = URI::from_string(ocsp)) {
          m_ocsp_responders.push_back(std::move(*parsed));
       } else {
          throw Invalid_Argument("Invalid URI in AuthorityInformationAccess OCSP responder");
@@ -1062,13 +1062,13 @@ void populate_uri_view_from_access_description(const Authority_Information_Acces
    const auto oid_ca_issuers = OID::from_string("PKIX.CertificateAuthorityIssuers");
    if(const auto uri_str = ad.location_as_uri_string()) {
       if(ad.access_method() == oid_ocsp_responders) {
-         if(auto uri = URI::parse(*uri_str)) {
+         if(auto uri = URI::from_string(*uri_str)) {
             ocsp_responders.push_back(std::move(*uri));
          } else {
             throw Invalid_Argument("Invalid URI in AuthorityInformationAccess OCSP responder");
          }
       } else if(ad.access_method() == oid_ca_issuers) {
-         if(auto uri = URI::parse(*uri_str)) {
+         if(auto uri = URI::from_string(*uri_str)) {
             ca_issuers.push_back(std::move(*uri));
          } else {
             throw Invalid_Argument("Invalid URI in AuthorityInformationAccess CA issuers");
@@ -1174,13 +1174,13 @@ void Authority_Information_Access::decode_inner(const std::vector<uint8_t>& in) 
 
       if(name.is_a(6, ASN1_Class::ContextSpecific)) {
          if(oid == ocsp_responder) {
-            if(auto parsed = URI::parse(ASN1::to_string(name))) {
+            if(auto parsed = URI::from_string(ASN1::to_string(name))) {
                m_ocsp_responders.push_back(std::move(*parsed));
             } else {
                throw Decoding_Error("Invalid URI in AuthorityInformationAccess OCSP responder");
             }
          } else if(oid == ca_issuer) {
-            if(auto parsed = URI::parse(ASN1::to_string(name))) {
+            if(auto parsed = URI::from_string(ASN1::to_string(name))) {
                m_ca_issuers.push_back(std::move(*parsed));
             } else {
                throw Decoding_Error("Invalid URI in AuthorityInformationAccess CA issuers");

--- a/src/tests/test_alt_name.cpp
+++ b/src/tests/test_alt_name.cpp
@@ -103,7 +103,7 @@ class X509_Alt_Name_Tests final : public Test {
 
          result.test_sz_eq("Expected number of URIs", recoded.uri_names().size(), uri_names.size());
          for(const auto& name : uri_names) {
-            auto parsed = Botan::URI::parse(name);
+            auto parsed = Botan::URI::from_string(name);
             result.test_is_true("URI parses: " + name, parsed.has_value());
             if(parsed.has_value()) {
                result.test_is_true("Has expected URI name: " + name, recoded.uri_names().contains(*parsed));

--- a/src/tests/test_http.cpp
+++ b/src/tests/test_http.cpp
@@ -476,7 +476,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_get_request_shape() {
          Test::Result result("HTTP::GET_sync request shape");
          MockServer mock({make_response(200, "OK", {{"Content-Length", "0"}}, "")});
-         const auto uri = Botan::URI::parse("http://example.com/path/to/resource").value();
+         const auto uri = Botan::URI::from_string("http://example.com/path/to/resource").value();
 
          (void)Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", std::vector<uint8_t>(), Botan::HTTP::RequestLimits());
@@ -495,7 +495,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_post_request_shape() {
          Test::Result result("HTTP::POST_sync request shape");
          MockServer mock({make_response(200, "OK", {{"Content-Length", "2"}}, "ok")});
-         const auto uri = Botan::URI::parse("http://example.com/submit").value();
+         const auto uri = Botan::URI::from_string("http://example.com/submit").value();
          const std::vector<uint8_t> body{'h', 'i'};
 
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "POST", uri, "text/plain", body, Botan::HTTP::RequestLimits());
@@ -510,7 +510,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_query_in_request_target() {
          Test::Result result("HTTP request target includes query");
          MockServer mock({make_response(200)});
-         const auto uri = Botan::URI::parse("http://example.com/api?id=42&n=1").value();
+         const auto uri = Botan::URI::from_string("http://example.com/api?id=42&n=1").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits());
          result.test_str_eq("query preserved", request_target(mock.request(0)), "/api?id=42&n=1");
          return result;
@@ -519,7 +519,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_fragment_excluded_from_request_target() {
          Test::Result result("HTTP request target excludes fragment (RFC 9110 7.1)");
          MockServer mock({make_response(200)});
-         const auto uri = Botan::URI::parse("http://example.com/page#section").value();
+         const auto uri = Botan::URI::from_string("http://example.com/page#section").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits());
          result.test_str_eq("no fragment in target", request_target(mock.request(0)), "/page");
          return result;
@@ -528,11 +528,11 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_empty_path_defaults_to_slash() {
          Test::Result result("HTTP request target defaults empty path to /");
          MockServer mock({make_response(200), make_response(200)});
-         const auto bare = Botan::URI::parse("http://example.com").value();
+         const auto bare = Botan::URI::from_string("http://example.com").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", bare, "", {}, Botan::HTTP::RequestLimits());
          result.test_str_eq("no path => /", request_target(mock.request(0)), "/");
 
-         const auto query_only = Botan::URI::parse("http://example.com?q=1").value();
+         const auto query_only = Botan::URI::from_string("http://example.com?q=1").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", query_only, "", {}, Botan::HTTP::RequestLimits());
          result.test_str_eq("no path with query => /?q=1", request_target(mock.request(1)), "/?q=1");
          return result;
@@ -541,7 +541,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_ipv6_host_header_bracketed() {
          Test::Result result("HTTP Host header brackets IPv6");
          MockServer mock({make_response(200)});
-         const auto uri = Botan::URI::parse("http://[::1]:8080/").value();
+         const auto uri = Botan::URI::from_string("http://[::1]:8080/").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits());
          result.test_is_true("Host has brackets and port", message_contains(mock.request(0), "Host: [::1]:8080\r\n"));
          result.test_str_eq("service is the port", mock.service(0), "8080");
@@ -551,7 +551,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_https_scheme_rejected() {
          Test::Result result("HTTP rejects non-http scheme");
          MockServer mock({});
-         const auto uri = Botan::URI::parse("https://example.com/").value();
+         const auto uri = Botan::URI::from_string("https://example.com/").value();
          result.test_throws<Botan::HTTP::HTTP_Error>("https URI", [&] {
             (void)Botan::HTTP::http_sync(mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits());
          });
@@ -562,7 +562,7 @@ class HTTP_Request_Tests final : public Test {
       static Test::Result test_max_body_size_propagated() {
          Test::Result result("HTTP max_body_size reaches the transact callback");
          MockServer mock({make_response(200)});
-         const auto uri = Botan::URI::parse("http://example.com/").value();
+         const auto uri = Botan::URI::from_string("http://example.com/").value();
          (void)Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_body_size(8192));
          result.test_is_true("max_body_size present", mock.max_body_size(0).has_value());
@@ -597,7 +597,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(301, "Moved", {{"Location", "http://other.example/new"}}),
             make_response(200, "OK", {{"Content-Length", "2"}}, "ok"),
          });
-         const auto uri = Botan::URI::parse("http://example.com/old").value();
+         const auto uri = Botan::URI::from_string("http://example.com/old").value();
          const auto resp = Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(2));
          result.test_sz_eq("two calls", mock.calls(), 2);
@@ -613,7 +613,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(303, "See Other", {{"Location", "http://example.com/result"}}),
             make_response(200, "OK"),
          });
-         const auto uri = Botan::URI::parse("http://example.com/submit").value();
+         const auto uri = Botan::URI::from_string("http://example.com/submit").value();
          const std::vector<uint8_t> body{'p', 'a', 'y', 'l', 'o', 'a', 'd'};
 
          (void)Botan::HTTP::http_sync(
@@ -632,7 +632,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(307, "Temporary Redirect", {{"Location", "http://example.com/v2"}}),
             make_response(200, "OK", {{"Content-Length", "2"}}, "ok"),
          });
-         const auto uri = Botan::URI::parse("http://example.com/submit").value();
+         const auto uri = Botan::URI::from_string("http://example.com/submit").value();
          const std::vector<uint8_t> body{'p', 'a', 'y', 'l', 'o', 'a', 'd'};
 
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(),
@@ -656,7 +656,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(308, "Permanent Redirect", {{"Location", "http://example.com/new"}}),
             make_response(200, "OK"),
          });
-         const auto uri = Botan::URI::parse("http://example.com/old").value();
+         const auto uri = Botan::URI::from_string("http://example.com/old").value();
          (void)Botan::HTTP::http_sync(mock.as_exch_fn(),
                                       "POST",
                                       uri,
@@ -673,7 +673,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(301, "Moved", {{"Location", "http://example.com/a"}}),
             make_response(301, "Moved", {{"Location", "http://example.com/b"}}),
          });
-         const auto uri = Botan::URI::parse("http://example.com/start").value();
+         const auto uri = Botan::URI::from_string("http://example.com/start").value();
          result.test_throws<Botan::HTTP::HTTP_Error>("exceeds redirect budget", [&] {
             (void)Botan::HTTP::http_sync(
                mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
@@ -687,7 +687,7 @@ class HTTP_Redirect_Tests final : public Test {
          MockServer mock({
             make_response(301, "Moved", {{"Location", "::not a url::"}}),
          });
-         const auto uri = Botan::URI::parse("http://example.com/").value();
+         const auto uri = Botan::URI::from_string("http://example.com/").value();
          result.test_throws<Botan::HTTP::HTTP_Error>("invalid Location", [&] {
             (void)Botan::HTTP::http_sync(
                mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
@@ -700,7 +700,7 @@ class HTTP_Redirect_Tests final : public Test {
          MockServer mock({
             make_response(301, "Moved", {{"Location", "https://example.com/"}}),
          });
-         const auto uri = Botan::URI::parse("http://example.com/").value();
+         const auto uri = Botan::URI::from_string("http://example.com/").value();
          result.test_throws<Botan::HTTP::HTTP_Error>("https Location", [&] {
             (void)Botan::HTTP::http_sync(
                mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
@@ -714,7 +714,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(301, "Moved", {{"Location", "/v2/resource?id=1"}}),
             make_response(200, "OK"),
          });
-         const auto uri = Botan::URI::parse("http://example.com:8080/v1/old").value();
+         const auto uri = Botan::URI::from_string("http://example.com:8080/v1/old").value();
          (void)Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
          result.test_sz_eq("two calls", mock.calls(), 2);
@@ -730,7 +730,7 @@ class HTTP_Redirect_Tests final : public Test {
          MockServer mock({
             make_response(301, "Moved", {{"Location", "//evil.example/new"}}),
          });
-         const auto uri = Botan::URI::parse("http://example.com/").value();
+         const auto uri = Botan::URI::from_string("http://example.com/").value();
          result.test_throws<Botan::HTTP::HTTP_Error>("// prefix not resolved", [&] {
             (void)Botan::HTTP::http_sync(
                mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
@@ -744,7 +744,7 @@ class HTTP_Redirect_Tests final : public Test {
             make_response(301, "Moved", {{"Location", "/elsewhere"}}),
             make_response(200, "OK"),
          });
-         const auto uri = Botan::URI::parse("http://user:pass@example.com/start").value();
+         const auto uri = Botan::URI::from_string("http://user:pass@example.com/start").value();
          (void)Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
          result.test_sz_eq("two calls", mock.calls(), 2);
@@ -758,7 +758,7 @@ class HTTP_Redirect_Tests final : public Test {
       static Test::Result test_redirect_without_location_returned() {
          Test::Result result("HTTP 3xx without Location returned to caller");
          MockServer mock({make_response(301, "Moved")});
-         const auto uri = Botan::URI::parse("http://example.com/").value();
+         const auto uri = Botan::URI::from_string("http://example.com/").value();
          const auto resp = Botan::HTTP::http_sync(
             mock.as_exch_fn(), "GET", uri, "", {}, Botan::HTTP::RequestLimits().set_max_redirects(1));
          result.test_sz_eq("one call only", mock.calls(), 1);

--- a/src/tests/test_name_constraint.cpp
+++ b/src/tests/test_name_constraint.cpp
@@ -265,7 +265,7 @@ class Name_Constraint_Factory_Validation_Tests final : public Test {
          check_valid(result, "URI SAN", m, "HTTPS://Example.COM/", "HTTPS://Example.COM/");
          check_valid(result, "URI SAN", m, "https://localhost/", "https://localhost/");
          check_valid(result, "URI SAN", m, "mailto:root@example.com", "mailto:root@example.com");
-         // Inputs URI::parse rejects (RFC 3986 syntax violations,
+         // Inputs URI::from_string rejects (RFC 3986 syntax violations,
          // constraint-shape values that aren't URIs).
          for(const auto& bad : {"",
                                 "example.com",

--- a/src/tests/test_uri.cpp
+++ b/src/tests/test_uri.cpp
@@ -22,7 +22,7 @@ class URI_Tests final : public Test {
       using HostKind = Botan::URI::Authority::HostKind;
 
       static Test::Result test_authority_parse() {
-         Test::Result result("URI::Authority::parse");
+         Test::Result result("URI::Authority::from_string");
 
          struct Case {
                std::string input;
@@ -45,8 +45,8 @@ class URI_Tests final : public Test {
          };
 
          for(const auto& c : cases) {
-            const auto authority = Botan::URI::Authority::parse(c.input);
-            if(!result.test_is_true("Authority::parse succeeds: " + c.input, authority.has_value())) {
+            const auto authority = Botan::URI::Authority::from_string(c.input);
+            if(!result.test_is_true("Authority::from_string succeeds: " + c.input, authority.has_value())) {
                continue;
             }
             result.test_str_eq("host: " + c.input, authority->host_to_string(), c.host);
@@ -83,14 +83,15 @@ class URI_Tests final : public Test {
             "_acme-challenge.example.com",
          };
          for(const auto& s : invalid) {
-            result.test_is_false("rejects invalid authority '" + s + "'", Botan::URI::Authority::parse(s).has_value());
+            result.test_is_false("rejects invalid authority '" + s + "'",
+                                 Botan::URI::Authority::from_string(s).has_value());
          }
 
          return result;
       }
 
       static Test::Result test_parse() {
-         Test::Result result("URI::parse");
+         Test::Result result("URI::from_string");
 
          struct Case {
                std::string input;
@@ -110,7 +111,7 @@ class URI_Tests final : public Test {
          };
 
          for(const auto& c : cases) {
-            const auto uri = Botan::URI::parse(c.input);
+            const auto uri = Botan::URI::from_string(c.input);
             if(!result.test_is_true("parse succeeds: " + c.input, uri.has_value())) {
                continue;
             }
@@ -146,7 +147,7 @@ class URI_Tests final : public Test {
          };
 
          for(const auto& c : no_authority_cases) {
-            const auto uri = Botan::URI::parse(c.input);
+            const auto uri = Botan::URI::from_string(c.input);
             if(!result.test_is_true("parse succeeds without authority: " + c.input, uri.has_value())) {
                continue;
             }
@@ -179,7 +180,7 @@ class URI_Tests final : public Test {
          };
 
          for(const auto& c : empty_authority_cases) {
-            const auto uri = Botan::URI::parse(c.input);
+            const auto uri = Botan::URI::from_string(c.input);
             if(!result.test_is_true("parse succeeds with empty authority: " + c.input, uri.has_value())) {
                continue;
             }
@@ -229,7 +230,7 @@ class URI_Tests final : public Test {
             "https://user%00null@example.com/",
          };
          for(const auto& s : invalid) {
-            result.test_is_false("rejects invalid URI '" + s + "'", Botan::URI::parse(s).has_value());
+            result.test_is_false("rejects invalid URI '" + s + "'", Botan::URI::from_string(s).has_value());
          }
 
          return result;
@@ -242,32 +243,32 @@ class URI_Tests final : public Test {
          // are distinct identities. Critical for SPIFFE-style workload
          // IDs encoded as URI SANs - otherwise `uri_names().contains()`
          // could be satisfied by the wrong workload identity.
-         const auto a = Botan::URI::parse("spiffe://trust.example/ns/dev/sa/attacker").value();
-         const auto b = Botan::URI::parse("spiffe://trust.example/ns/prod/sa/server").value();
+         const auto a = Botan::URI::from_string("spiffe://trust.example/ns/dev/sa/attacker").value();
+         const auto b = Botan::URI::from_string("spiffe://trust.example/ns/prod/sa/server").value();
          result.test_is_false("SPIFFE: differing paths are not equal", a == b);
          result.test_is_true("SPIFFE: equal with the same path",
-                             a == Botan::URI::parse("spiffe://trust.example/ns/dev/sa/attacker").value());
+                             a == Botan::URI::from_string("spiffe://trust.example/ns/dev/sa/attacker").value());
 
          // Scheme and host casing don't break equality (we canonicalize).
          result.test_is_true("scheme/host case folded for equality",
-                             Botan::URI::parse("HTTPS://Example.COM/path").value() ==
-                                Botan::URI::parse("https://example.com/path").value());
+                             Botan::URI::from_string("HTTPS://Example.COM/path").value() ==
+                                Botan::URI::from_string("https://example.com/path").value());
 
          // Path case IS significant (RFC 3986 - paths are not
          // case-canonicalized).
          result.test_is_false("path case is significant",
-                              Botan::URI::parse("https://example.com/Path").value() ==
-                                 Botan::URI::parse("https://example.com/path").value());
+                              Botan::URI::from_string("https://example.com/Path").value() ==
+                                 Botan::URI::from_string("https://example.com/path").value());
 
          // Userinfo is preserved verbatim and participates in identity
          // (RFC 3986 6.2 case-normalizes only scheme and host; RFC 5280
          // 7.4 requires URI comparison to be exact-match after that).
-         const auto uri_with_userinfo = Botan::URI::parse("https://alice:s3cret@example.com/").value();
+         const auto uri_with_userinfo = Botan::URI::from_string("https://alice:s3cret@example.com/").value();
 
          result.test_is_true("userinfo distinguishes identity",
-                             uri_with_userinfo != Botan::URI::parse("https://example.com/").value());
+                             uri_with_userinfo != Botan::URI::from_string("https://example.com/").value());
          result.test_is_true("userinfo equal when matching",
-                             uri_with_userinfo == Botan::URI::parse("https://alice:s3cret@example.com/").value());
+                             uri_with_userinfo == Botan::URI::from_string("https://alice:s3cret@example.com/").value());
          // The authority's original_input() includes the userinfo
          result.test_is_true("authority present with userinfo", uri_with_userinfo.authority().has_value());
          result.test_str_eq("authority original_input preserves userinfo",
@@ -275,19 +276,19 @@ class URI_Tests final : public Test {
                             "alice:s3cret@example.com");
          // Userinfo case IS significant (no case normalization).
          result.test_is_false("userinfo case is significant",
-                              Botan::URI::parse("https://Alice@example.com/").value() ==
-                                 Botan::URI::parse("https://alice@example.com/").value());
+                              Botan::URI::from_string("https://Alice@example.com/").value() ==
+                                 Botan::URI::from_string("https://alice@example.com/").value());
          // Empty userinfo is distinct from no userinfo (RFC 3986
          // authority grammar: "@" delimiter presence is significant).
-         const auto absent = Botan::URI::parse("https://example.com/").value();
-         const auto empty = Botan::URI::parse("https://@example.com/").value();
+         const auto absent = Botan::URI::from_string("https://example.com/").value();
+         const auto empty = Botan::URI::from_string("https://@example.com/").value();
          result.test_is_true("empty userinfo != absent userinfo", absent != empty);
          result.test_is_false("absent userinfo: accessor reports nullopt", absent.authority()->userinfo().has_value());
          result.test_is_true("empty userinfo: accessor reports present", empty.authority()->userinfo().has_value());
          result.test_str_eq("empty userinfo: accessor reports empty string", *empty.authority()->userinfo(), "");
 
          // Path, query, and fragment are split out and exposed separately.
-         const auto full = Botan::URI::parse("https://example.com/path?q=1#frag").value();
+         const auto full = Botan::URI::from_string("https://example.com/path?q=1#frag").value();
          result.test_str_eq("path component", full.path(), "/path");
          result.test_is_true("query present", full.query().has_value());
          result.test_str_eq("query component", *full.query(), "q=1");
@@ -295,31 +296,32 @@ class URI_Tests final : public Test {
          result.test_str_eq("fragment component", *full.fragment(), "frag");
 
          // Empty path is preserved as empty (not defaulted to "/").
-         const auto no_path = Botan::URI::parse("https://example.com").value();
+         const auto no_path = Botan::URI::from_string("https://example.com").value();
          result.test_str_eq("empty path stays empty", no_path.path(), "");
          result.test_is_false("no query", no_path.query().has_value());
          result.test_is_false("no fragment", no_path.fragment().has_value());
 
-         const auto mailto = Botan::URI::parse("mailto:root@example.com").value();
+         const auto mailto = Botan::URI::from_string("mailto:root@example.com").value();
          result.test_is_false("mailto has no authority", mailto.authority().has_value());
          result.test_is_false("mailto has no raw authority", mailto.raw_authority().has_value());
          result.test_is_false(
             "authorityful URI differs from authorityless URI",
-            Botan::URI::parse("foo://example.com/path").value() == Botan::URI::parse("foo:/path").value());
-         result.test_is_false("empty authority differs from absent authority",
-                              Botan::URI::parse("foo:///path").value() == Botan::URI::parse("foo:/path").value());
+            Botan::URI::from_string("foo://example.com/path").value() == Botan::URI::from_string("foo:/path").value());
+         result.test_is_false(
+            "empty authority differs from absent authority",
+            Botan::URI::from_string("foo:///path").value() == Botan::URI::from_string("foo:/path").value());
 
          // Query without path: empty path, present query.
-         const auto query_only = Botan::URI::parse("https://example.com?q=1").value();
+         const auto query_only = Botan::URI::from_string("https://example.com?q=1").value();
          result.test_str_eq("query-only: path is empty", query_only.path(), "");
          result.test_is_true("query-only: query present", query_only.query().has_value());
          result.test_str_eq("query-only: query value", *query_only.query(), "q=1");
 
          // Present-but-empty query / fragment are distinct from absent.
-         const auto empty_query = Botan::URI::parse("https://example.com/p?").value();
+         const auto empty_query = Botan::URI::from_string("https://example.com/p?").value();
          result.test_is_true("empty query: present", empty_query.query().has_value());
          result.test_str_eq("empty query: value", *empty_query.query(), "");
-         const auto empty_frag = Botan::URI::parse("https://example.com/p#").value();
+         const auto empty_frag = Botan::URI::from_string("https://example.com/p#").value();
          result.test_is_true("empty fragment: present", empty_frag.fragment().has_value());
          result.test_str_eq("empty fragment: value", *empty_frag.fragment(), "");
 

--- a/src/tests/test_x509_cdp_aia.cpp
+++ b/src/tests/test_x509_cdp_aia.cpp
@@ -864,8 +864,8 @@ Test::Result test_aia_uri_constructor_then_add_access_description_keeps_all() {
    const std::string ocsp2 = "http://ocsp2.example.com/";
 
    Botan::Cert_Extension::Authority_Information_Access aia(
-      std::vector<Botan::URI>{Botan::URI::parse(ocsp1).value()},
-      std::vector<Botan::URI>{Botan::URI::parse(ca_issuer).value()});
+      std::vector<Botan::URI>{Botan::URI::from_string(ocsp1).value()},
+      std::vector<Botan::URI>{Botan::URI::from_string(ca_issuer).value()});
 
    const Botan::OID ocsp_oid = Botan::OID::from_string("PKIX.OCSP");
    const std::vector<uint8_t> ocsp2_bytes(ocsp2.begin(), ocsp2.end());
@@ -910,7 +910,7 @@ Test::Result test_aia_builder_rejects_malformed_uri_access_locations() {
    const Botan::OID ocsp = Botan::OID::from_string("PKIX.OCSP");
    const Botan::OID ca_issuer = Botan::OID::from_string("PKIX.CertificateAuthorityIssuers");
 
-   // URI::parse rejects strings that don't begin with an ASCII-alpha scheme
+   // URI::from_string rejects strings that don't begin with an ASCII-alpha scheme
    // followed by ':'. "not a uri" fails the first-character ALPHA check.
    const std::string bad_uri = "not a uri";
    const std::vector<uint8_t> bad_bytes(bad_uri.begin(), bad_uri.end());

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -498,14 +498,14 @@ Test::Result test_x509_encode_authority_info_access_extension() {
 
    // CA Issuer information
    const std::vector<Botan::URI> ca_issuers = {
-      Botan::URI::parse("http://www.d-trust.net/cgi-bin/Bdrive_Test_CA_1-2_2017.crt").value(),
-      Botan::URI::parse(
+      Botan::URI::from_string("http://www.d-trust.net/cgi-bin/Bdrive_Test_CA_1-2_2017.crt").value(),
+      Botan::URI::from_string(
          "ldap://directory.d-trust.net/CN=Bdrive%20Test%20CA%201-2%202017,O=Bundesdruckerei%20GmbH,C=DE?cACertificate?base?")
          .value()};
 
    // OCSP
    const std::string_view ocsp_uri{"http://staging.ocsp.d-trust.net"};
-   const auto ocsp_uri_parsed = Botan::URI::parse(ocsp_uri).value();
+   const auto ocsp_uri_parsed = Botan::URI::from_string(ocsp_uri).value();
 
    // create a CA
    auto ca_key = make_a_private_key(sig_algo, *rng);


### PR DESCRIPTION
All the other types, i.e. `EmailAddress`, `DNSName`, `IPv4Address` and `IPv6Address` name their string creation methods `::from_string`, except for `URI`.
This makes it annoying to write generic code that works for all of them.

In tests I changed direct mentions of `::parse` to `::from_string`, but otherwise kept the parse terminology