### PR TITLE
[TLS 1.3] Add TLS::Policy::minimum_record_size() to obfuscate plaintext lengths

### DIFF
--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -37,6 +37,15 @@ bool is_error_alert(const Botan::TLS::Alert& alert) {
 
 namespace Botan::TLS {
 
+namespace {
+
+const auto& checked_deref(const auto& ptr) {
+   BOTAN_ASSERT_NONNULL(ptr);
+   return *ptr;
+}
+
+}  // namespace
+
 Channel_Impl_13::Channel_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
                                  const std::shared_ptr<Session_Manager>& session_manager,
                                  const std::shared_ptr<Credentials_Manager>& credentials_manager,
@@ -49,7 +58,7 @@ Channel_Impl_13::Channel_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
       m_credentials_manager(credentials_manager),
       m_rng(rng),
       m_policy(policy),
-      m_record_layer(m_side),
+      m_record_layer(m_side, checked_deref(m_policy)),
       m_handshake_layer(m_side),
       m_can_read(true),
       m_can_write(true),

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -2,6 +2,7 @@
 * TLS record layer implementation for TLS 1.3
 * (C) 2022 Jack Lloyd
 *     2022 Hannes Rantzsch, René Meusel - neXenio GmbH
+*     2026 Amos Treiber, René Meusel - Rohde & Schwarz Networks and Cybersecurity GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -10,6 +11,7 @@
 
 #include <botan/tls_alert.h>
 #include <botan/tls_exceptn.h>
+#include <botan/tls_policy.h>
 #include <botan/tls_version.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
@@ -144,10 +146,11 @@ class TLSPlaintext_Header final {
 
 }  // namespace
 
-Record_Layer::Record_Layer(Connection_Side side) :
+Record_Layer::Record_Layer(Connection_Side side, const Policy& policy) :
       m_side(side),
       m_outgoing_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */),
-      m_incoming_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */)
+      m_incoming_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */),
+      m_outgoing_minimum_record_size(policy.minimum_record_size().value_or(0))
 
       // RFC 8446 5.1
       //    legacy_record_version: MUST be set to 0x0303 for all records
@@ -169,7 +172,10 @@ Record_Layer::Record_Layer(Connection_Side side) :
       // the marshalling responsibility to our TLS 1.2 implementation.
       ,
       m_sending_compat_mode(m_side == Connection_Side::Client),
-      m_receiving_compat_mode(true) {}
+      m_receiving_compat_mode(true) {
+   BOTAN_ARG_CHECK(m_outgoing_minimum_record_size <= m_outgoing_record_size_limit,
+                   "Configured minimum record size is larger than the specified plaintext size limit");
+}
 
 void Record_Layer::copy_data(std::span<const uint8_t> data) {
    // Compact consumed data before appending new data
@@ -233,8 +239,9 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
       output_length +=
          (records - 1) * cipher_state->encrypt_output_length(max_plaintext_size + content_type_tag_length);
       // last record with size of remaining data
-      output_length += cipher_state->encrypt_output_length(data.size() - ((records - 1) * max_plaintext_size) +
-                                                           content_type_tag_length);
+      const auto remaining_bytes = data.size() - ((records - 1) * max_plaintext_size) + content_type_tag_length;
+      const auto padded_remaining_bytes = std::max<size_t>(remaining_bytes, m_outgoing_minimum_record_size);
+      output_length += cipher_state->encrypt_output_length(padded_remaining_bytes);
    } else {
       output_length += data.size();
    }
@@ -250,8 +257,13 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
    // NOLINTNEXTLINE(*-avoid-do-while)
    do {
       const size_t pt_size = std::min<size_t>(to_process, max_plaintext_size);
-      const size_t ct_size =
-         (!protect) ? pt_size : cipher_state->encrypt_output_length(pt_size + content_type_tag_length);
+      const size_t pt_size_with_type = pt_size + content_type_tag_length;
+      const size_t pt_size_with_type_and_padding = std::max<size_t>(pt_size_with_type, m_outgoing_minimum_record_size);
+      BOTAN_ASSERT_IMPLICATION(protect,
+                               pt_size_with_type_and_padding <= m_outgoing_record_size_limit,
+                               "Padded record size is within the negotiated record size limit");
+
+      const size_t ct_size = (!protect) ? pt_size : cipher_state->encrypt_output_length(pt_size_with_type_and_padding);
       const auto pt_type = (!protect) ? type : Record_Type::ApplicationData;
 
       // RFC 8446 5.1
@@ -270,7 +282,12 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
          // assemble TLSInnerPlaintext structure
          fragment.insert(fragment.end(), pt_fragment.begin(), pt_fragment.end());
          fragment.push_back(static_cast<uint8_t>(type));
-         // TODO: zero padding could go here, see RFC 8446 5.4
+
+         // RFC 9846 5.4
+         //    When generating a TLSCiphertext record, implementations MAY
+         //    choose to pad. [...] Implementations MUST set the padding octets
+         //    to all zeros before encrypting.
+         fragment.insert(fragment.end(), pt_size_with_type_and_padding - pt_size_with_type, 0x00);
 
          cipher_state->encrypt_record_fragment(record_header, fragment);
          BOTAN_ASSERT_NOMSG(fragment.size() == ct_size);
@@ -420,6 +437,8 @@ void Record_Layer::set_record_size_limits(const uint16_t outgoing_limit, const u
    BOTAN_ARG_CHECK(outgoing_limit >= 64, "Invalid outgoing record size limit");
    BOTAN_ARG_CHECK(incoming_limit >= 64 && incoming_limit <= MAX_PLAINTEXT_SIZE + 1,
                    "Invalid incoming record size limit");
+   BOTAN_ARG_CHECK(outgoing_limit >= m_outgoing_minimum_record_size,
+                   "Configured minimum record size is not compatible with the negotiated outgoing record size limit");
 
    // RFC 8449 4.
    //    Even if a larger record size limit is provided by a peer, an endpoint

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -36,6 +36,7 @@ struct Record {
 using BytesNeeded = size_t;
 
 class Cipher_State;
+class Policy;
 
 /**
  * Implementation of the TLS 1.3 record protocol layer
@@ -45,7 +46,7 @@ class Cipher_State;
  */
 class BOTAN_TEST_API Record_Layer {
    public:
-      explicit Record_Layer(Connection_Side side);
+      Record_Layer(Connection_Side side, const Policy& policy);
 
       template <typename ResT>
       using ReadResult = std::variant<BytesNeeded, ResT>;
@@ -112,6 +113,9 @@ class BOTAN_TEST_API Record_Layer {
       // or the ones negotiated via the "record_size_limit" extension (RFC 8449).
       uint16_t m_outgoing_record_size_limit;
       uint16_t m_incoming_record_size_limit;
+
+      // For Record Padding as defined in RFC 9846 5.4
+      uint16_t m_outgoing_minimum_record_size;
 
       // Those status flags are required for version validation where the initial
       // records for sending and receiving is handled differently for backward

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -426,6 +426,10 @@ std::optional<uint16_t> Policy::record_size_limit() const {
    return std::nullopt;
 }
 
+std::optional<uint16_t> Policy::minimum_record_size() const {
+   return std::nullopt;
+}
+
 bool Policy::support_cert_status_message() const {
    return true;
 }
@@ -724,6 +728,9 @@ void Policy::print(std::ostream& o) const {
    print_bool(o, "hash_hello_random", hash_hello_random());
    if(record_size_limit().has_value()) {
       o << "record_size_limit = " << record_size_limit().value() << '\n';
+   }
+   if(minimum_record_size().has_value()) {
+      o << "minimum_record_size = " << minimum_record_size().value() << '\n';
    }
    o << "maximum_session_tickets_per_client_hello = " << maximum_session_tickets_per_client_hello() << '\n';
    o << "session_ticket_lifetime = " << session_ticket_lifetime().count() << '\n';

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -467,6 +467,22 @@ class BOTAN_PUBLIC_API(2, 0) Policy /* NOLINT(*-special-member-functions) */ {
       virtual std::optional<uint16_t> record_size_limit() const;
 
       /**
+       * Defines the minimum plaintext size of any protected TLS 1.3 record.
+       * If an outgoing record contains less plaintext payload than this value,
+       * it will be transparently padded to reach the specified minimum size.
+       *
+       * This may be used to reduce the amount of information leaked by the
+       * length of TLS records.
+       *
+       * The value must be compatible with the negotiated record size limit.
+       *
+       * @note This feature is available in TLS 1.3 only (see RFC 9846 5.4).
+       *
+       * Default: std::nullopt (no minimum record size is enforced)
+       */
+      virtual std::optional<uint16_t> minimum_record_size() const;
+
+      /**
       * Indicates whether certificate status messages should be supported
       */
       virtual bool support_cert_status_message() const;
@@ -818,6 +834,8 @@ class BOTAN_PUBLIC_API(2, 0) Text_Policy : public Policy {
       bool require_extended_master_secret() const override;
 
       std::optional<uint16_t> record_size_limit() const override;
+
+      std::optional<uint16_t> minimum_record_size() const override;
 
       bool support_cert_status_message() const override;
 

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -107,6 +107,12 @@ std::optional<uint16_t> Text_Policy::record_size_limit() const {
    return (limit > 0) ? std::make_optional(static_cast<uint16_t>(limit)) : std::nullopt;
 }
 
+std::optional<uint16_t> Text_Policy::minimum_record_size() const {
+   const auto limit = get_len("minimum_record_size", 0);
+   BOTAN_ARG_CHECK(limit <= record_size_limit().value_or(16385), "TLS 1.3 minimum record size too large");
+   return (limit > 0) ? std::make_optional(static_cast<uint16_t>(limit)) : std::nullopt;
+}
+
 bool Text_Policy::support_cert_status_message() const {
    return get_bool("support_cert_status_message", Policy::support_cert_status_message());
 }

--- a/src/tests/test_tls_record_layer_13.cpp
+++ b/src/tests/test_tls_record_layer_13.cpp
@@ -1,6 +1,7 @@
 /*
 * (C) 2021 Jack Lloyd
 * (C) 2021 Hannes Rantzsch, René Meusel - neXenio
+* (C) 2026 Amos Treiber, René Meusel - Rohde & Schwarz Networks and Cybersecurity GmbH
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -13,6 +14,7 @@
    #include <botan/tls_ciphersuite.h>
    #include <botan/tls_exceptn.h>
    #include <botan/tls_magic.h>
+   #include <botan/tls_policy.h>
    #include <botan/internal/concat_util.h>
    #include <botan/internal/tls_channel_impl_13.h>
    #include <botan/internal/tls_cipher_state.h>
@@ -28,8 +30,21 @@ namespace TLS = Botan::TLS;
 
 using Records = std::vector<TLS::Record>;
 
-TLS::Record_Layer record_layer_client(const bool skip_client_hello = false) {
-   auto rl = TLS::Record_Layer(TLS::Connection_Side::Client);
+class Test_Policy : public Botan::TLS::Policy {
+   public:
+      explicit Test_Policy(std::optional<uint16_t> minimum_record_size = std::nullopt) :
+            m_minimum_record_size(minimum_record_size) {}
+
+      std::optional<uint16_t> minimum_record_size() const override { return m_minimum_record_size; }
+
+   private:
+      std::optional<uint16_t> m_minimum_record_size;
+};
+
+TLS::Record_Layer record_layer_client(const bool skip_client_hello = false,
+                                      std::optional<uint16_t> minimum_record_size = {}) {
+   auto policy = Test_Policy(minimum_record_size);
+   auto rl = TLS::Record_Layer(TLS::Connection_Side::Client, policy);
 
    // this is relevant for tests that rely on the legacy version in the record
    if(skip_client_hello) {
@@ -39,8 +54,10 @@ TLS::Record_Layer record_layer_client(const bool skip_client_hello = false) {
    return rl;
 }
 
-TLS::Record_Layer record_layer_server(const bool skip_client_hello = false) {
-   auto rl = TLS::Record_Layer(TLS::Connection_Side::Server);
+TLS::Record_Layer record_layer_server(const bool skip_client_hello = false,
+                                      std::optional<uint16_t> minimum_record_size = {}) {
+   auto policy = Test_Policy(minimum_record_size);
+   auto rl = TLS::Record_Layer(TLS::Connection_Side::Server, policy);
 
    // this is relevant for tests that rely on the legacy version in the record
    if(skip_client_hello) {
@@ -742,32 +759,49 @@ std::vector<Test::Result> write_encrypted_records() {
                result.test_bin_eq("CCS record is well-formed", record, "140303000101");
             }),
 
-      CHECK("write a lot of data producing two protected records", [&](Test::Result& result) {
-         std::vector<uint8_t> big_data(TLS::MAX_PLAINTEXT_SIZE + TLS::MAX_PLAINTEXT_SIZE / 2);
-         auto ct = record_layer_client(true).prepare_records(TLS::Record_Type::ApplicationData, big_data, cs.get());
-         result.require("encryption added some MAC and record headers",
-                        ct.size() > big_data.size() + Botan::TLS::TLS_HEADER_SIZE * 2);
+      CHECK("write a lot of data producing two protected records",
+            [&](Test::Result& result) {
+               std::vector<uint8_t> big_data(TLS::MAX_PLAINTEXT_SIZE + TLS::MAX_PLAINTEXT_SIZE / 2);
+               auto ct =
+                  record_layer_client(true).prepare_records(TLS::Record_Type::ApplicationData, big_data, cs.get());
+               result.require("encryption added some MAC and record headers",
+                              ct.size() > big_data.size() + Botan::TLS::TLS_HEADER_SIZE * 2);
 
-         auto read_record_header = [&](auto& reader) {
-            result.test_u8_eq(
-               "APPLICATION_DATA", reader.get_byte(), static_cast<uint8_t>(TLS::Record_Type::ApplicationData));
-            result.test_u16_eq("TLS legacy version", reader.get_uint16_t(), uint16_t(0x0303));
+               auto read_record_header = [&](auto& reader) {
+                  result.test_u8_eq(
+                     "APPLICATION_DATA", reader.get_byte(), static_cast<uint8_t>(TLS::Record_Type::ApplicationData));
+                  result.test_u16_eq("TLS legacy version", reader.get_uint16_t(), uint16_t(0x0303));
 
-            const auto fragment_length = reader.get_uint16_t();
-            result.test_sz_lte("TLS limits", fragment_length, TLS::MAX_CIPHERTEXT_SIZE_TLS13);
-            result.require("enough data", fragment_length + Botan::TLS::TLS_HEADER_SIZE < ct.size());
-            return fragment_length;
-         };
+                  const auto fragment_length = reader.get_uint16_t();
+                  result.test_sz_lte("TLS limits", fragment_length, TLS::MAX_CIPHERTEXT_SIZE_TLS13);
+                  result.require("enough data", fragment_length + Botan::TLS::TLS_HEADER_SIZE < ct.size());
+                  return fragment_length;
+               };
 
-         TLS::TLS_Data_Reader reader("test reader", ct);
-         const auto fragment_length1 = read_record_header(reader);
-         reader.discard_next(fragment_length1);
+               TLS::TLS_Data_Reader reader("test reader", ct);
+               const auto fragment_length1 = read_record_header(reader);
+               reader.discard_next(fragment_length1);
 
-         const auto fragment_length2 = read_record_header(reader);
-         reader.discard_next(fragment_length2);
+               const auto fragment_length2 = read_record_header(reader);
+               reader.discard_next(fragment_length2);
 
-         result.test_is_true("consumed all bytes", !reader.has_remaining());
-      })};
+               result.test_is_true("consumed all bytes", !reader.has_remaining());
+            }),
+
+      CHECK("write a record with padding",
+            [&](Test::Result& result) {
+               std::vector<uint8_t> data(5);
+               auto rl = record_layer_client(true, 128);
+
+               auto ct = rl.prepare_records(TLS::Record_Type::Handshake, data, cs.get());
+
+               // The content type byte that is appended to the plaintext does
+               // count as ordinary plaintext, so the padding is added to six
+               // bytes of plaintext, not five.
+               const auto expected_length = cs->encrypt_output_length(128) + Botan::TLS::TLS_HEADER_SIZE;
+               result.test_sz_eq("encryption added some padding", ct.size(), expected_length);
+            }),
+   };
 }
 
 std::vector<Test::Result> legacy_version_handling() {
@@ -1014,6 +1048,53 @@ std::vector<Test::Result> record_size_limits() {
                result.test_throws("overflow detected",
                                   "Received an encrypted record that exceeds maximum plaintext size",
                                   [&] { rls.next_record(css.get()); });
+            }),
+
+      CHECK("record size limits incompatible with the padding size are rejected",
+            [&](Test::Result& result) {
+               constexpr uint16_t minimum_record_size = 1024;
+               auto rl = record_layer_client(true, minimum_record_size);
+
+               const uint16_t valid_record_size_limit = minimum_record_size;
+               const uint16_t invalid_record_size_limit = minimum_record_size - 1;
+
+               result.test_no_throw("padding size is compatible with record size limit", [&] {
+                  rl.set_record_size_limits(valid_record_size_limit, valid_record_size_limit);
+               });
+
+               result.test_throws(
+                  "padding size exceeds record size limit",
+                  "Configured minimum record size is not compatible with the negotiated outgoing record size limit",
+                  [&] { rl.set_record_size_limits(invalid_record_size_limit, invalid_record_size_limit); });
+
+               result.test_no_throw("incoming record size limit is not relevant", [&] {
+                  rl.set_record_size_limits(valid_record_size_limit, invalid_record_size_limit);
+               });
+
+               const uint16_t content_type_byte = 1;
+               const uint16_t absolute_plaintext_size_limit = Botan::TLS::MAX_PLAINTEXT_SIZE + content_type_byte;
+               const uint16_t invalid_plaintext_size_limit = absolute_plaintext_size_limit + 1;
+
+               result.test_no_throw("padding size exceeds record size limit",
+                                    [&] { record_layer_client(true, absolute_plaintext_size_limit); });
+               result.test_throws("padding size exceeds record size limit",
+                                  "Configured minimum record size is larger than the specified plaintext size limit",
+                                  [&] { record_layer_client(true, invalid_plaintext_size_limit); });
+            }),
+
+      CHECK("preparing a record where minimum_record_size == maximum_size_limit",
+            [&](Test::Result& result) {
+               constexpr uint16_t limit = 1024;
+               auto rl = record_layer_client(true, /* minimum_record_size = */ limit);
+               rl.set_record_size_limits(/* outgoing_limit = */ limit,
+                                         /* incoming_limit = */ limit);
+
+               auto cs = rfc8448_rtt1_handshake_traffic();
+               const std::array<uint8_t, 5> data = {0x01, 0x02, 0x03, 0x04, 0x05};
+               const auto ct = rl.prepare_records(TLS::Record_Type::ApplicationData, data, cs.get());
+
+               const auto expected_length = cs->encrypt_output_length(limit) + Botan::TLS::TLS_HEADER_SIZE;
+               result.test_sz_eq("encryption result has the correct length", ct.size(), expected_length);
             }),
    };
 }

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -1372,6 +1372,15 @@ class TLS_Unit_Tests final : public Test {
                               "AEAD",
                               {{"groups", "ffdhe/ietf/2048"}});
 
+         test_modern_versions("AES-128/GCM with record padding",
+                              results,
+                              creds,
+                              rng,
+                              "ECDH",
+                              "AES-128/GCM",
+                              "AEAD",
+                              {{"minimum_record_size", "2048"}});
+
          auto creds_with_client_cert = create_creds(*rng, true);
          if(creds_with_client_cert) {
             test_modern_versions(


### PR DESCRIPTION
This implements the optional generation of padding bytes as specified in [RFC 9846 5.4](https://www.rfc-editor.org/info/rfc9846/#section-5.4). In TLS 1.3 this is purely optional, but this padding mechanism is used in DTLS 1.3 under certain circumstances [to facilitate sequence number encryption](https://www.rfc-editor.org/rfc/rfc9147.html#section-4.2.3).

### Pull Request Dependencies

* #5729 