### PR TITLE
Fix FIPS 186-5 Lucas parameter selection

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -47,7 +47,7 @@ Version 3.13.0, Not Yet Released
 * Various ASN.1 hardening and decoder strictness improvements (GH #5693 #5703 #5710 #5720)
 
 * Various BigInt and number-theoretic hardening and bug fixes.
-  (GH #5581 #5585 #5586 #5588 #5592 #5650 #5688)
+  (GH #5581 #5585 #5586 #5588 #5592 #5620 #5650 #5688)
 
 * Reject RSA signature and ciphertext values which are not exactly the length of
   the modulus (GH #5592 #5630 #5675)

--- a/src/lib/math/numbertheory/primality.cpp
+++ b/src/lib/math/numbertheory/primality.cpp
@@ -34,7 +34,8 @@ bool is_lucas_probable_prime(const BigInt& C, const Barrett_Reduction& mod_C) {
          return false;
       }
 
-      if(j == -1) {
+      const BigInt Q = (BigInt::one() - D) / 4;
+      if(j == -1 && gcd(C, Q) == 1) {
          break;
       }
 

--- a/src/lib/math/numbertheory/primality.h
+++ b/src/lib/math/numbertheory/primality.h
@@ -19,7 +19,7 @@ class RandomNumberGenerator;
 
 /**
 * Perform Lucas primality test
-* @see FIPS 186-4 C.3.3
+* @see FIPS 186-5 B.3.3
 *
 * @warning it is possible to construct composite integers which pass
 * this test alone.


### PR DESCRIPTION
## Summary

- require the Lucas parameter `D` to satisfy both the Jacobi and GCD conditions from FIPS 186-5 B.3.3
- update the API reference and release-note issue list for the newer standard

## Validation

- `python3 configure.py --build-targets=static,tests --without-documentation && make -j2`
- `./botan-test bn_lucas` (5,000 checks)
- all BigInt tests, including `bn_gcd`, `bn_jacobi`, `bn_isprime`, and `bn_lucas` (182,547 checks)
- clang-format 17 source check
- `git diff --check`

The full cross-platform test matrix is left to CI.

Fixes #5620
