### PR TITLE
Pin CI imports by version or git tag

### DIFF
--- a/doc/dev_ref/release_process.rst
+++ b/doc/dev_ref/release_process.rst
@@ -23,7 +23,7 @@ In the week prior to a release, after feature freeze goes into effect
 - [ ] Perform a full clang-tidy run with latest available Clang
 - [ ] Test build configurations using `src/scripts/test_all_configs.py`
 - [ ] Test a few builds on platforms not in CI (eg OpenBSD, FreeBSD, Solaris)
-- [ ] Update relevant third party test suites (eg Limbo, BoGo, TLS-Anvil, ...)
+- [ ] Update relevant third party test suites (eg Limbo, ACVP, Wycheproof, BoGo, TLS-Anvil, ...)
 
 Tag the Release
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/configs/repo_config.env
+++ b/src/configs/repo_config.env
@@ -33,8 +33,14 @@ TLS_ANVIL_VERSION_TAG="@sha256:4234d0096daedeb4b2200d507428e65a0f7db2374bdc42a53
 # Git repository URL for Wycheproof test vectors
 WYCHEPROOF_GIT_URL=https://github.com/C2SP/wycheproof.git
 
+# Git revision for Wycheproof test vectors
+WYCHEPROOF_GIT_REV=b61843a9a5115bb758134b6a1f5d5e502d445342
+
 # Git repository URL for NIST ACVP test vectors
 ACVP_SERVER_GIT_URL=https://github.com/usnistgov/ACVP-Server.git
+
+# Git revision for ACVP tests
+ACVP_GIT_REV=2972def23bf9f3680c2c531561ed9bdd0f1086ad
 
 # The maximum size of the compiler cache in CI
 # Those variables are directly consumed by ccache and sccache respectively

--- a/src/scripts/ci/setup_gh_actions.sh
+++ b/src/scripts/ci/setup_gh_actions.sh
@@ -56,20 +56,20 @@ if type -p "apt-get"; then
         "${SCRIPT_LOCATION}"/download_ci_dep.py limbo "${SCRIPT_LOCATION}/../../../limbo.json"
 
     elif [ "$TARGET" = "lint" ]; then
-        pip install ruff
+        pip install "ruff~=0.15.0"
 
     elif [ "$TARGET" = "typos" ]; then
-        cargo install typos-cli
+        cargo install typos-cli@1.48.0
 
     elif [ "$TARGET" = "coverage" ]; then
         "${SCRIPT_LOCATION}"/download_ci_dep.py coveralls --extract 'tar -xz -C /usr/local/bin -f {file}'
 
     elif [ "$TARGET" = "wycheproof" ]; then
-        git clone --depth 1 "${WYCHEPROOF_GIT_URL}" wycheproof-git
+        git clone --depth 1 "${WYCHEPROOF_GIT_URL}" --revision "${WYCHEPROOF_GIT_REV}" wycheproof-git
         echo "WYCHEPROOF_DIR=$(pwd)/wycheproof-git" >> "$GITHUB_ENV"
 
     elif [ "$TARGET" = "acvp" ]; then
-        git clone --depth 1 "${ACVP_SERVER_GIT_URL}" acvp-server-git
+        git clone --depth 1 "${ACVP_SERVER_GIT_URL}" --revision "${ACVP_GIT_REV}" acvp-server-git
         echo "ACVP_TESTDATA_DIR=$(pwd)/acvp-server-git/gen-val/json-files" >> "$GITHUB_ENV"
     fi
 


### PR DESCRIPTION
All 4 of these unpinned deps has at one time or another caused unnecessary CI breakage.