### PR TITLE
Refactor: Handle TLS 1.3 Compat Mode via the TLS state machine

### DIFF
--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -308,6 +308,7 @@ void Channel_Impl_13::to_peer(std::span<const uint8_t> data) {
 void Channel_Impl_13::send_alert(const Alert& alert) {
    if(alert.is_valid() && m_can_write) {
       try {
+         maybe_handle_compatibility_mode(Compat_Mode_Situation::BeforeSendingAlert);
          send_record(Record_Type::Alert, alert.serialize());
       } catch(...) { /* swallow it */
       }
@@ -354,7 +355,15 @@ void Channel_Impl_13::send_record(Record_Type type, const std::vector<uint8_t>& 
    BOTAN_STATE_CHECK(!is_downgrading());
    BOTAN_STATE_CHECK(m_can_write);
 
-   auto to_write = m_record_layer.prepare_records(type, record, m_cipher_state.get());
+   // RFC 9846 5.
+   //    An implementation which [...] receives a protected change_cipher_spec
+   //    record MUST abort the handshake [...].
+   //
+   // I.e. Change Cipher Spec records must always be sent unprotected, even if
+   // the cipher state is already set up for handshake message encryption.
+   auto* cipher_state = (type != Record_Type::ChangeCipherSpec) ? m_cipher_state.get() : nullptr;
+
+   auto to_write = m_record_layer.prepare_records(type, record, cipher_state);
 
    // After the initial handshake message is sent, the record layer must
    // adhere to a more strict record specification. Note that for the
@@ -363,14 +372,6 @@ void Channel_Impl_13::send_record(Record_Type type, const std::vector<uint8_t>& 
    if(!m_first_message_sent && type == Record_Type::Handshake) {
       m_record_layer.disable_sending_compat_mode();
       m_first_message_sent = true;
-   }
-
-   // The dummy CCS must not be prepended if the following record is
-   // an unprotected Alert record.
-   if(prepend_ccs() && (m_cipher_state || type != Record_Type::Alert)) {
-      std::array<uint8_t, 1> ccs_content = {0x01};
-      const auto ccs = m_record_layer.prepare_records(Record_Type::ChangeCipherSpec, ccs_content, m_cipher_state.get());
-      to_write = concat(ccs, to_write);
    }
 
    callbacks().tls_emit_data(to_write);

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -275,12 +275,16 @@ std::vector<uint8_t> Channel_Impl_13::AggregatedMessages::send() {
 }
 
 void Channel_Impl_13::send_dummy_change_cipher_spec() {
-   // RFC 8446 5.
+   // RFC 9846 5.
    //    The change_cipher_spec record is used only for compatibility purposes
-   //    (see Appendix D.4).
+   //    (see Appendix E.4).
    //
-   // The only allowed CCS message content is 0x01, all other CCS records MUST
-   // be rejected by TLS 1.3 implementations.
+   //    An implementation may receive an unencrypted record of type
+   //    change_cipher_spec consisting of the single byte value 0x01 at any time
+   //    after the first ClientHello message has been sent or received and
+   //    before the peer's Finished message has been received.
+   BOTAN_STATE_CHECK(!is_handshake_complete());
+
    send_record(Record_Type::ChangeCipherSpec, {0x01});
 }
 

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -222,14 +222,16 @@ class Channel_Impl_13 : public Channel_Impl,
       virtual void process_post_handshake_msg(Post_Handshake_Message_13 msg) = 0;
       virtual void process_dummy_change_cipher_spec() = 0;
 
-      /**
-       * @return whether a change cipher spec record should be prepended _now_
-       *
-       * This method can be used by subclasses to indicate that send_record
-       * should prepend a CCS before the actual record. This is useful for
-       * middlebox compatibility mode. See RFC 8446 D.4.
-       */
-      virtual bool prepend_ccs() { return false; }
+      enum class Compat_Mode_Situation : uint8_t {
+         BeforeSendingAlert,
+         AfterSendingFirstClientHello,
+         BeforeSendingSecondClientHello,
+         BeforeSendingEncryptedClientFlight,
+         AfterSendingFirstServerHello,
+         AfterSendingHelloRetryRequest,
+      };
+
+      virtual void maybe_handle_compatibility_mode(Compat_Mode_Situation situation) = 0;
 
       void handle(const Key_Update& key_update);
 

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -63,15 +63,7 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
       preserve_client_hello(msg);
    }
 
-   // RFC 8446 Appendix D.4
-   //    If not offering early data, the client sends a dummy change_cipher_spec
-   //    record [...] immediately before its second flight. This may either be before
-   //    its second ClientHello or before its encrypted handshake flight.
-   //
-   // TODO: don't schedule ccs here when early data is used
-   if(policy->tls_13_middlebox_compatibility_mode()) {
-      m_handshake->should_send_ccs = true;
-   }
+   maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingFirstClientHello);
 
    m_handshake->transitions.set_expected_next({Handshake_Type::ServerHello, Handshake_Type::HelloRetryRequest});
 }
@@ -395,6 +387,7 @@ void Client_Impl_13::handle(const Hello_Retry_Request& hrr) {
 
    callbacks().tls_examine_extensions(hrr.extensions(), Connection_Side::Server, Handshake_Type::HelloRetryRequest);
 
+   maybe_handle_compatibility_mode(Compat_Mode_Situation::BeforeSendingSecondClientHello);
    send_handshake_message(std::reference_wrapper(ch));
 
    // RFC 8446 4.1.4
@@ -642,6 +635,7 @@ void Client_Impl_13::handle(const Finished_13& finished_msg) {
    // send client finished handshake message (still using handshake traffic secrets)
    flight.add(m_handshake->state.sending(Finished_13(m_cipher_state.get(), m_transcript_hash.current())));
 
+   maybe_handle_compatibility_mode(Compat_Mode_Situation::BeforeSendingEncryptedClientFlight);
    flight.send();
 
    // derives the sending application traffic secrets
@@ -774,8 +768,65 @@ std::optional<std::string> Client_Impl_13::external_psk_identity() const {
    return std::nullopt;
 }
 
-bool Client_Impl_13::prepend_ccs() {
-   return m_handshake && std::exchange(m_handshake->should_send_ccs, false);
+void Client_Impl_13::maybe_handle_compatibility_mode(Compat_Mode_Situation situation) {
+   // RFC 9846 E.4
+   //    This "compatibility mode" is partially negotiated: the client can opt
+   //    [in] or not [...].
+   if(!policy().tls_13_middlebox_compatibility_mode()) {
+      return;
+   }
+
+   // RFC 9846 5.
+   //    An implementation [...] which receives a protected change_cipher_spec
+   //    record MUST abort the handshake with an "unexpected_message" alert.
+   if(m_handshake == nullptr) {
+      return;
+   }
+
+   switch(situation) {
+      case Compat_Mode_Situation::AfterSendingFirstClientHello:
+         // RFC 9846 E.4
+         //    If offering early data, the record is placed immediately after
+         //    the first ClientHello.
+         //
+         // TODO: Implement early data support
+         break;
+
+      case Compat_Mode_Situation::BeforeSendingSecondClientHello:
+         // RFC 9846 E.4
+         //    [...] the client sends a dummy change_cipher_spec record [...]
+         //    immediately before its second flight. This may either be before
+         //    its second ClientHello [...].
+         BOTAN_ASSERT_NOMSG(m_handshake->state.has_hello_retry_request());
+         send_dummy_change_cipher_spec();
+         break;
+
+      case Compat_Mode_Situation::BeforeSendingEncryptedClientFlight:
+         // RFC 9846 E.4
+         //    [...] or before its encrypted handshake flight.
+         BOTAN_ASSERT_NOMSG(m_handshake->state.has_server_finished());
+         if(!m_handshake->state.has_hello_retry_request()) {
+            send_dummy_change_cipher_spec();
+         }
+         break;
+
+      case Compat_Mode_Situation::BeforeSendingAlert:
+         // RFC 9846 E.4
+         //    [...] or before its encrypted handshake flight.
+         //
+         // Note that an encrypted alert message also counts as an encrypted
+         // handshake flight, so we also send a dummy CCS in that case. Except
+         // if we did receive a HelloRetryRequest, in which case we already sent
+         // a dummy CCS before the second ClientHello.
+         if(m_cipher_state != nullptr && !m_handshake->state.has_hello_retry_request()) {
+            send_dummy_change_cipher_spec();
+         }
+         break;
+
+      case Compat_Mode_Situation::AfterSendingFirstServerHello:
+      case Compat_Mode_Situation::AfterSendingHelloRetryRequest:
+         BOTAN_ASSERT_UNREACHABLE();  // These situations occur on the server side.
+   }
 }
 
 void Client_Impl_13::maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const {

--- a/src/lib/tls/tls13/tls_client_impl_13.h
+++ b/src/lib/tls/tls13/tls_client_impl_13.h
@@ -85,7 +85,7 @@ class Client_Impl_13 final : public Channel_Impl_13 {
       void process_dummy_change_cipher_spec() override;
 
       void maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const override;
-      bool prepend_ccs() override;
+      void maybe_handle_compatibility_mode(Compat_Mode_Situation situation) override;
 
       using Channel_Impl_13::handle;
       void handle(const Server_Hello_12_Shim& server_hello_msg);
@@ -107,7 +107,6 @@ class Client_Impl_13 final : public Channel_Impl_13 {
       struct Pending_Handshake {
             Client_Handshake_State_13 state;
             Handshake_Transitions transitions;
-            bool should_send_ccs = false;
             std::optional<Session_with_Handle> resumed_session;
             std::optional<std::string> psk_identity;
       };

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -220,15 +220,18 @@ void Server_Impl_13::downgrade() {
    m_handshake->transitions.set_expected_next({});
 }
 
-void Server_Impl_13::maybe_handle_compatibility_mode() {
-   BOTAN_ASSERT_NOMSG(m_handshake->state.has_client_hello());
-   BOTAN_ASSERT_NOMSG(m_handshake->state.has_hello_retry_request() || m_handshake->state.has_server_hello());
-
-   // RFC 8446 Appendix D.4  (Middlebox Compatibility Mode)
-   //    The server sends a dummy change_cipher_spec record immediately after
-   //    its first handshake message. This may either be after a ServerHello or
-   //    a HelloRetryRequest.
+void Server_Impl_13::maybe_handle_compatibility_mode(Compat_Mode_Situation situation) {
+   // RFC 9846 E.4
+   //    This "compatibility mode" is partially negotiated: the client can opt
+   //    to provide a session ID or not, [...].
    //
+   // I.e., before we received a ClientHello, we cannot know whether the client
+   // requested middlebox compatibility mode or not.
+   if(m_handshake == nullptr || !m_handshake->state.has_client_hello()) {
+      return;
+   }
+
+   // RFC 9846 E.4
    //    This "compatibility mode" is partially negotiated: the client can opt
    //    to provide a session ID or not, and the server has to echo it. Either
    //    side can send change_cipher_spec at any time during the handshake, as
@@ -240,17 +243,34 @@ void Server_Impl_13::maybe_handle_compatibility_mode() {
    // sending a non-empty session ID. Nevertheless, when the policy requests
    // it we send a CCS regardless. Note that this is perfectly legal and also
    // satisfies some BoGo tests that expect this behaviour.
-   //
-   // Send a CCS immediately after the _first_ handshake message. I.e. either
-   // after Hello Retry Request (exclusively) or after a Server Hello that was
-   // not preseded by a Hello Retry Request.
-   const bool just_after_first_handshake_message =
-      m_handshake->state.has_hello_retry_request() ^ m_handshake->state.has_server_hello();
    const bool client_requested_compatibility_mode = !m_handshake->state.client_hello().session_id().empty();
+   if(!policy().tls_13_middlebox_compatibility_mode() && !client_requested_compatibility_mode) {
+      return;
+   }
 
-   if(just_after_first_handshake_message &&
-      (policy().tls_13_middlebox_compatibility_mode() || client_requested_compatibility_mode)) {
-      send_dummy_change_cipher_spec();
+   switch(situation) {
+      case Compat_Mode_Situation::AfterSendingFirstServerHello:
+      case Compat_Mode_Situation::AfterSendingHelloRetryRequest:
+         // RFC 9846 E.4
+         //    The server sends a dummy change_cipher_spec record immediately after
+         //    its first handshake message. This may either be after a ServerHello or
+         //    a HelloRetryRequest.
+         send_dummy_change_cipher_spec();
+         break;
+
+      case Compat_Mode_Situation::BeforeSendingAlert:
+         // RFC 9846 E.4
+         //    The server sends a dummy change_cipher_spec record immediately after
+         //    its first handshake message.
+         //
+         // The server cannot send an encrypted alert message as its first
+         // message. Hence, it won't ever need a dummy CCS before an alert.
+         break;
+
+      case Compat_Mode_Situation::AfterSendingFirstClientHello:
+      case Compat_Mode_Situation::BeforeSendingSecondClientHello:
+      case Compat_Mode_Situation::BeforeSendingEncryptedClientFlight:
+         BOTAN_ASSERT_UNREACHABLE();  // These situations occur on the client side.
    }
 }
 
@@ -320,7 +340,10 @@ void Server_Impl_13::handle_reply_to_client_hello(Server_Hello_13 server_hello) 
    //       references to the Server Hello will need to consult the handshake
    //       state object!
    send_handshake_message(m_handshake->state.sending(std::move(server_hello)));
-   maybe_handle_compatibility_mode();
+
+   if(!m_handshake->state.has_hello_retry_request()) {
+      maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingFirstServerHello);
+   }
 
    // Setup encryption for all the remaining handshake messages
    m_cipher_state = [&] {
@@ -449,7 +472,7 @@ void Server_Impl_13::handle_reply_to_client_hello(Hello_Retry_Request hello_retr
    BOTAN_ASSERT_NOMSG(cipher.has_value());  // should work, since we chose that suite
 
    send_handshake_message(m_handshake->state.sending(std::move(hello_retry_request)));
-   maybe_handle_compatibility_mode();
+   maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingHelloRetryRequest);
 
    m_transcript_hash = Transcript_Hash_State::recreate_after_hello_retry_request(cipher->prf_algo(), m_transcript_hash);
 

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -52,7 +52,7 @@ class Server_Impl_13 final : public Channel_Impl_13 {
       void handle_reply_to_client_hello(Server_Hello_13 server_hello);
       void handle_reply_to_client_hello(Hello_Retry_Request hello_retry_request);
 
-      void maybe_handle_compatibility_mode();
+      void maybe_handle_compatibility_mode(Compat_Mode_Situation situation) override;
       void maybe_log_secret(std::string_view label, std::span<const uint8_t> secret) const override;
 
       void downgrade();


### PR DESCRIPTION
This refactors [the TLS 1.3 middlebox compatibility mode](https://www.rfc-editor.org/rfc/rfc9846.html#name-middlebox-compatibility-mod) handling to fully rely on the TLS state machine. Essentially the state machine now calls `maybe_handle_compatibility_mode()` in all locations where a dummy ChangeCipherSpec might need to be emitted.

Before, this handling was partially implemented within the fairly generic `send_record()` method in the `TLS::Channel` base class. That didn't fit the level of abstraction within `send_record()` and resulted in hard-to-understand control flow. Also, while adding DTLS (#5000) this code smell became even more involved.

So here's a refactoring to clean this up.