### PR TITLE
Add configurable RFC 7093 subject key identifiers

### DIFF
--- a/doc/api_ref/x509.rst
+++ b/doc/api_ref/x509.rst
@@ -232,7 +232,12 @@ handling.
    versions are present, then the KeyIdentifier will be used, and the
    GeneralNames ignored.
 
- - Subject Key Identifier: No problems known.
+ - Subject Key Identifier: When generating certificates, Botan uses RFC 5280
+   section 4.2.1.2 method 1 (SHA-1 over the value of the
+   ``subjectPublicKey`` BIT STRING) by default. The
+   ``Subject_Key_ID_Method`` enum can be used to explicitly select RFC 7093
+   methods 1, 2, or 3 instead. These use the leftmost 160 bits of SHA-256,
+   SHA-384, or SHA-512 over the same BIT STRING value.
 
  - Name Constraints: No problems known (though encoding is not supported).
 
@@ -645,6 +650,23 @@ new certificate:
                          const X509_Time& not_before, \
                          const X509_Time& not_after)
 
+This overload derives the subject key identifier using RFC 5280 method 1.
+An additional overload accepts a final ``Subject_Key_ID_Method`` argument to
+explicitly select an RFC 5280 or RFC 7093 derivation method:
+
+.. cpp:function:: X509_Certificate \
+   X509_CA::sign_request(const PKCS10_Request& req, \
+                         RandomNumberGenerator& rng, \
+                         const X509_Time& not_before, \
+                         const X509_Time& not_after, \
+                         Subject_Key_ID_Method subject_key_id_method)
+
+The equivalent overload that accepts an explicit certificate serial number
+also accepts ``subject_key_id_method`` as its final argument. This selection is
+independent of the hash function used for the certificate signature. The
+authority key identifier continues to be copied from the issuer certificate's
+subject key identifier.
+
 If you need more control over the signing process, you can use the methods
 
 .. cpp:function:: static X509_Certificate X509_CA::make_cert(PK_Signer& signer, \
@@ -659,12 +681,13 @@ If you need more control over the signing process, you can use the methods
                                         const Extensions& extensions)
 
 .. cpp:function:: static Extensions X509_CA::choose_extensions(const PKCS10_Request& req, \
-                                          const X509_Certificate& ca_certificate, \
-                                          const std::string& hash_fn)
+                                          const X509_Certificate& ca_certificate)
 
    Returns the extensions that would be created by sign_request if it was used.
    You can call this and then modify the extensions list before invoking
-   :cpp:func:`X509_CA::make_cert`
+   :cpp:func:`X509_CA::make_cert`. An overload accepting
+   ``Subject_Key_ID_Method`` selects the subject key identifier derivation
+   method.
 
 Generating CRLs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -730,6 +753,18 @@ protocols. The library provides a utility function for this:
    and ``opts`` is an structure that has various bits of information
    that will be used in creating the certificate (this structure, and
    its use, is discussed below).
+
+The default overload derives the subject key identifier using RFC 5280
+method 1. To select one of the RFC 7093 methods, use the overload accepting a
+``Subject_Key_ID_Method``:
+
+.. cpp:function:: X509_Certificate create_self_signed_cert( \
+   const X509_Cert_Options& opts, const Private_Key& key, \
+   const std::string& hash_fn, Subject_Key_ID_Method subject_key_id_method, \
+   RandomNumberGenerator& rng)
+
+For a self-signed certificate, the authority key identifier is set to the same
+value as the newly derived subject key identifier.
 
 Creating PKCS #10 Requests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/news.rst
+++ b/news.rst
@@ -33,6 +33,11 @@ Version 3.13.0, Not Yet Released
 
 * Improve handling of the authority and subject key identifier extensions (GH #5735 #5737)
 
+* Add explicit subject key identifier derivation methods for RFC 5280
+  method 1 and RFC 7093 methods 1, 2, and 3. The existing SHA-1 default
+  remains unchanged, while certificate issuance and self-signed certificate
+  generation can opt into SHA-256, SHA-384, or SHA-512 derivation. (GH #3479)
+
 * Properly decode and handle the X509 CRL Distribution Point and Authority Information Access
   extensions (GH #5712)
 

--- a/src/lib/x509/pkix_enums.h
+++ b/src/lib/x509/pkix_enums.h
@@ -121,6 +121,36 @@ enum class Certificate_Status_Code : uint16_t {
 BOTAN_PUBLIC_API(2, 0) const char* to_string(Certificate_Status_Code code);
 
 /**
+* Methods described in RFC 5280 and RFC 7093 for deriving an X.509
+* subject key identifier from a public key.
+*/
+enum class Subject_Key_ID_Method : uint8_t {
+   /**
+   * RFC 5280 Section 4.2.1.2 method 1: SHA-1 over the subjectPublicKey
+   * BIT STRING value.
+   */
+   RFC5280_SHA1,
+
+   /**
+   * RFC 7093 Section 2 method 1: the leftmost 160 bits of SHA-256 over
+   * the subjectPublicKey BIT STRING value.
+   */
+   RFC7093_SHA256,
+
+   /**
+   * RFC 7093 Section 2 method 2: the leftmost 160 bits of SHA-384 over
+   * the subjectPublicKey BIT STRING value.
+   */
+   RFC7093_SHA384,
+
+   /**
+   * RFC 7093 Section 2 method 3: the leftmost 160 bits of SHA-512 over
+   * the subjectPublicKey BIT STRING value.
+   */
+   RFC7093_SHA512,
+};
+
+/**
 * X.509v3 Key Constraints.
 * If updating update copy in ffi.h
 */

--- a/src/lib/x509/x509_ca.cpp
+++ b/src/lib/x509/x509_ca.cpp
@@ -47,6 +47,12 @@ Extensions X509_CA::choose_extensions(const PKCS10_Request& req,
 }
 
 Extensions X509_CA::choose_extensions(const PKCS10_Request& req, const X509_Certificate& ca_cert) {
+   return choose_extensions(req, ca_cert, Subject_Key_ID_Method::RFC5280_SHA1);
+}
+
+Extensions X509_CA::choose_extensions(const PKCS10_Request& req,
+                                      const X509_Certificate& ca_cert,
+                                      Subject_Key_ID_Method subject_key_id_method) {
    const auto constraints = req.is_CA() ? Key_Constraints::ca_constraints() : req.constraints();
 
    auto key = req.subject_public_key();
@@ -64,7 +70,7 @@ Extensions X509_CA::choose_extensions(const PKCS10_Request& req, const X509_Cert
    }
 
    extensions.replace(std::make_unique<Cert_Extension::Authority_Key_ID>(ca_cert.subject_key_id()));
-   extensions.replace(std::make_unique<Cert_Extension::Subject_Key_ID>(*key));
+   extensions.replace(std::make_unique<Cert_Extension::Subject_Key_ID>(*key, subject_key_id_method));
 
    extensions.replace(std::make_unique<Cert_Extension::Subject_Alternative_Name>(req.subject_alt_name()));
 
@@ -78,7 +84,16 @@ X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
                                        const BigInt& serial_number,
                                        const X509_Time& not_before,
                                        const X509_Time& not_after) const {
-   auto extensions = choose_extensions(req, m_ca_cert);
+   return sign_request(req, rng, serial_number, not_before, not_after, Subject_Key_ID_Method::RFC5280_SHA1);
+}
+
+X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
+                                       RandomNumberGenerator& rng,
+                                       const BigInt& serial_number,
+                                       const X509_Time& not_before,
+                                       const X509_Time& not_after,
+                                       Subject_Key_ID_Method subject_key_id_method) const {
+   auto extensions = choose_extensions(req, m_ca_cert, subject_key_id_method);
 
    return make_cert(*m_signer,
                     rng,
@@ -99,7 +114,15 @@ X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
                                        RandomNumberGenerator& rng,
                                        const X509_Time& not_before,
                                        const X509_Time& not_after) const {
-   auto extensions = choose_extensions(req, m_ca_cert);
+   return sign_request(req, rng, not_before, not_after, Subject_Key_ID_Method::RFC5280_SHA1);
+}
+
+X509_Certificate X509_CA::sign_request(const PKCS10_Request& req,
+                                       RandomNumberGenerator& rng,
+                                       const X509_Time& not_before,
+                                       const X509_Time& not_after,
+                                       Subject_Key_ID_Method subject_key_id_method) const {
+   auto extensions = choose_extensions(req, m_ca_cert, subject_key_id_method);
 
    return make_cert(*m_signer,
                     rng,

--- a/src/lib/x509/x509_ca.h
+++ b/src/lib/x509/x509_ca.h
@@ -61,6 +61,22 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
                                     const X509_Time& not_after) const;
 
       /**
+      * Sign a PKCS#10 Request using an explicit subject key identifier
+      * derivation method.
+      * @param req the request to sign
+      * @param rng the rng to use
+      * @param not_before the starting time for the certificate
+      * @param not_after the expiration time for the certificate
+      * @param subject_key_id_method the subject key identifier derivation method
+      * @return resulting certificate
+      */
+      X509_Certificate sign_request(const PKCS10_Request& req,
+                                    RandomNumberGenerator& rng,
+                                    const X509_Time& not_before,
+                                    const X509_Time& not_after,
+                                    Subject_Key_ID_Method subject_key_id_method) const;
+
+      /**
       * Sign a PKCS#10 Request.
       * @param req the request to sign
       * @param rng the rng to use
@@ -74,6 +90,24 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
                                     const BigInt& serial_number,
                                     const X509_Time& not_before,
                                     const X509_Time& not_after) const;
+
+      /**
+      * Sign a PKCS#10 Request using an explicit subject key identifier
+      * derivation method.
+      * @param req the request to sign
+      * @param rng the rng to use
+      * @param serial_number the serial number the cert will be assigned
+      * @param not_before the starting time for the certificate
+      * @param not_after the expiration time for the certificate
+      * @param subject_key_id_method the subject key identifier derivation method
+      * @return resulting certificate
+      */
+      X509_Certificate sign_request(const PKCS10_Request& req,
+                                    RandomNumberGenerator& rng,
+                                    const BigInt& serial_number,
+                                    const X509_Time& not_before,
+                                    const X509_Time& not_after,
+                                    Subject_Key_ID_Method subject_key_id_method) const;
 
       /**
       * Create a new and empty CRL for this CA.
@@ -132,6 +166,18 @@ class BOTAN_PUBLIC_API(2, 0) X509_CA final {
       * creating a certificate using X509_CA::make_cert.
       */
       static Extensions choose_extensions(const PKCS10_Request& req, const X509_Certificate& ca_certificate);
+
+      /**
+      * Return the set of extensions that will be used for a certificate,
+      * deriving its subject key identifier with the requested method.
+      *
+      * @param req the certificate request
+      * @param ca_certificate the issuing CA certificate
+      * @param subject_key_id_method the subject key identifier derivation method
+      */
+      static Extensions choose_extensions(const PKCS10_Request& req,
+                                          const X509_Certificate& ca_certificate,
+                                          Subject_Key_ID_Method subject_key_id_method);
 
       BOTAN_DEPRECATED("Use the overload that does not take a hash function name (SKID is now always SHA-1)")
       static Extensions

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -29,6 +29,22 @@ namespace Botan {
 namespace {
 
 constexpr size_t MaximumKeyIdentifierLength = 64;
+constexpr size_t StandardKeyIdentifierLength = 160 / 8;
+
+std::string_view subject_key_id_hash(Subject_Key_ID_Method method) {
+   switch(method) {
+      case Subject_Key_ID_Method::RFC5280_SHA1:
+         return "SHA-1";
+      case Subject_Key_ID_Method::RFC7093_SHA256:
+         return "SHA-256";
+      case Subject_Key_ID_Method::RFC7093_SHA384:
+         return "SHA-384";
+      case Subject_Key_ID_Method::RFC7093_SHA512:
+         return "SHA-512";
+   }
+
+   throw Invalid_Argument("Unknown subject key identifier derivation method");
+}
 
 /*
 * Encode an AlternativeName as `GeneralNames` but with an outer IMPLICIT
@@ -567,19 +583,24 @@ void Subject_Key_ID::decode_inner(const std::vector<uint8_t>& in) {
 /*
 * Subject_Key_ID Constructor
 */
-Subject_Key_ID::Subject_Key_ID(const Public_Key& pub_key) {
-   /*
-   * RFC 5280 4.2.1.2:
-   *    (1) The keyIdentifier is composed of the 160-bit SHA-1 hash of the
-   *    value of the BIT STRING subjectPublicKey (excluding the tag, length,
-   *    and number of unused bits).
-   */
-   auto hash = HashFunction::create_or_throw("SHA-1");
+Subject_Key_ID::Subject_Key_ID(const Public_Key& pub_key) :
+      Subject_Key_ID(pub_key, Subject_Key_ID_Method::RFC5280_SHA1) {}
 
-   m_key_id.resize(hash->output_length());
+/*
+* Subject_Key_ID Constructor
+*/
+Subject_Key_ID::Subject_Key_ID(const Public_Key& pub_key, Subject_Key_ID_Method method) {
+   /*
+   * RFC 5280 4.2.1.2 method 1 uses SHA-1. RFC 7093 Section 2 methods
+   * 1, 2, and 3 use SHA-256, SHA-384, and SHA-512, respectively, and
+   * truncate the digest to the leftmost 160 bits. All four methods hash
+   * the value of the BIT STRING subjectPublicKey.
+   */
+   auto hash = HashFunction::create_or_throw(subject_key_id_hash(method));
 
    hash->update(pub_key.public_key_bits());
-   hash->final(m_key_id.data());
+   m_key_id = hash->final_stdvec();
+   m_key_id.resize(StandardKeyIdentifierLength);
 }
 
 /*

--- a/src/lib/x509/x509_ext.h
+++ b/src/lib/x509/x509_ext.h
@@ -121,6 +121,15 @@ class BOTAN_PUBLIC_API(2, 0) Subject_Key_ID final : public Certificate_Extension
       */
       explicit Subject_Key_ID(const Public_Key& pub_key);
 
+      /**
+      * Derive the key identifier from the public key using a method
+      * described in RFC 5280 or RFC 7093.
+      *
+      * @param pub_key the public key from which to derive the identifier
+      * @param method the subject key identifier derivation method
+      */
+      Subject_Key_ID(const Public_Key& pub_key, Subject_Key_ID_Method method);
+
       BOTAN_DEPRECATED("Use Subject_Key_ID(const Public_Key&)")
       Subject_Key_ID(const std::vector<uint8_t>& public_key, std::string_view hash_fn);
 

--- a/src/lib/x509/x509self.cpp
+++ b/src/lib/x509/x509self.cpp
@@ -82,6 +82,14 @@ X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
                                          const Private_Key& key,
                                          std::string_view hash_fn,
                                          RandomNumberGenerator& rng) {
+   return create_self_signed_cert(opts, key, hash_fn, Subject_Key_ID_Method::RFC5280_SHA1, rng);
+}
+
+X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
+                                         const Private_Key& key,
+                                         std::string_view hash_fn,
+                                         Subject_Key_ID_Method subject_key_id_method,
+                                         RandomNumberGenerator& rng) {
    const std::vector<uint8_t> pub_key = X509::BER_encode(key);
    auto signer = X509_Object::choose_sig_format(key, rng, hash_fn, opts.padding_scheme);
    const AlgorithmIdentifier sig_algo = signer->algorithm_identifier();
@@ -103,7 +111,7 @@ X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
       extensions.add_new(std::make_unique<Cert_Extension::Key_Usage>(constraints), true);
    }
 
-   auto skid = std::make_unique<Cert_Extension::Subject_Key_ID>(key);
+   auto skid = std::make_unique<Cert_Extension::Subject_Key_ID>(key, subject_key_id_method);
 
    extensions.add_new(std::make_unique<Cert_Extension::Authority_Key_ID>(skid->get_key_id()));
    extensions.add_new(std::move(skid));

--- a/src/lib/x509/x509self.h
+++ b/src/lib/x509/x509self.h
@@ -206,6 +206,24 @@ X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
                                          RandomNumberGenerator& rng);
 
 /**
+* Create a self-signed X.509 certificate using an explicit subject key
+* identifier derivation method.
+* @param opts the options defining the certificate to create
+* @param key the private key used for signing, i.e. the key
+* associated with this self-signed certificate
+* @param hash_fn the hash function to use for the certificate signature
+* @param subject_key_id_method the subject key identifier derivation method
+* @param rng the rng to use
+* @return newly created self-signed certificate
+*/
+BOTAN_PUBLIC_API(3, 13)
+X509_Certificate create_self_signed_cert(const X509_Cert_Options& opts,
+                                         const Private_Key& key,
+                                         std::string_view hash_fn,
+                                         Subject_Key_ID_Method subject_key_id_method,
+                                         RandomNumberGenerator& rng);
+
+/**
 * Create a PKCS#10 certificate request.
 * @param opts the options defining the request to create
 * @param key the key used to sign this request

--- a/src/tests/unit_x509.cpp
+++ b/src/tests/unit_x509.cpp
@@ -18,6 +18,7 @@
    #include <botan/rng.h>
    #include <botan/x509_ca.h>
    #include <botan/x509_ext.h>
+   #include <botan/x509_key.h>
    #include <botan/x509path.h>
    #include <botan/x509self.h>
    #include <botan/internal/calendar.h>
@@ -867,6 +868,39 @@ Test::Result test_x509_subject_key_id_derivation() {
       result.test_bin_eq(std::string(file) + " subject key id", skid.get_key_id(), cert.subject_key_id());
    }
 
+      #if defined(BOTAN_HAS_ECDSA) && defined(BOTAN_HAS_SHA2_32)
+   /*
+   * The P-256 SubjectPublicKeyInfo and SHA-256 result are from RFC 7093
+   * Section 3. The remaining results use the same published key.
+   */
+   const auto rfc7093_key =
+      Botan::X509::load_key(Botan::hex_decode("3059301306072A8648CE3D020106082A8648CE3D030107034200"
+                                              "047F7F35A79794C950060B8029FC8F363A28F11159692D9D34E6AC948190434735"
+                                              "F833B1A66652DC514337AFF7F5C9C75D670C019D95A5D639B72744C64A9128BB"));
+
+   if(result.test_not_null("loaded RFC 7093 public key", rfc7093_key.get())) {
+      const auto check = [&](Botan::Subject_Key_ID_Method method, std::string_view name, std::string_view expected) {
+         const Botan::Cert_Extension::Subject_Key_ID skid(*rfc7093_key, method);
+         result.test_bin_eq(std::string(name), skid.get_key_id(), expected);
+      };
+
+      check(Botan::Subject_Key_ID_Method::RFC5280_SHA1, "RFC 5280 SHA-1", "6FEF9162C0A3F2E7608956D41C37DA0C8E87F0AE");
+      check(
+         Botan::Subject_Key_ID_Method::RFC7093_SHA256, "RFC 7093 SHA-256", "BF37B3E5808FD46D54B28E846311BCCE1CAD2E1A");
+
+         #if defined(BOTAN_HAS_SHA2_64)
+      check(
+         Botan::Subject_Key_ID_Method::RFC7093_SHA384, "RFC 7093 SHA-384", "39AB33561A203C3E782D69B1A0F4F8AD50A773DF");
+      check(
+         Botan::Subject_Key_ID_Method::RFC7093_SHA512, "RFC 7093 SHA-512", "907E7E9D05878A273D597F2AEA91BDB6056245CB");
+         #endif
+
+      result.test_throws("rejects an unknown subject key identifier method", [&] {
+         Botan::Cert_Extension::Subject_Key_ID skid(*rfc7093_key, static_cast<Botan::Subject_Key_ID_Method>(0xFF));
+      });
+   }
+      #endif
+
    return result;
 }
 
@@ -1302,6 +1336,53 @@ Test::Result test_x509_cert(const Botan::Private_Key& ca_key,
    result.test_bin_eq("user1 subject key id is SHA-1 of subjectPublicKey",
                       user1_cert.subject_key_id(),
                       user1_cert.subject_public_key_bitstring_sha1());
+
+   #if defined(BOTAN_HAS_SHA2_32)
+   if(sig_algo == "ECDSA") {
+      const auto check_issued_certificate = [&](const Botan::X509_Certificate& cert,
+                                                Botan::Subject_Key_ID_Method method,
+                                                std::string_view name) {
+         const Botan::Cert_Extension::Subject_Key_ID expected(*cert.subject_public_key(), method);
+         result.test_bin_eq(std::string(name) + " subject key id", cert.subject_key_id(), expected.get_key_id());
+         result.test_bin_eq(std::string(name) + " authority key id", cert.authority_key_id(), ca_cert.subject_key_id());
+      };
+
+      const auto explicit_sha1_cert = ca.sign_request(
+         user1_req, rng, from_date(-1, 01, 01), from_date(2, 01, 01), Botan::Subject_Key_ID_Method::RFC5280_SHA1);
+      result.test_bin_eq("explicit RFC 5280 method preserves the default",
+                         explicit_sha1_cert.subject_key_id(),
+                         user1_cert.subject_key_id());
+
+      const BigInt rfc7093_serial(100);
+      const auto sha256_cert = ca.sign_request(user1_req,
+                                               rng,
+                                               rfc7093_serial,
+                                               from_date(-1, 01, 01),
+                                               from_date(2, 01, 01),
+                                               Botan::Subject_Key_ID_Method::RFC7093_SHA256);
+      check_issued_certificate(sha256_cert, Botan::Subject_Key_ID_Method::RFC7093_SHA256, "RFC 7093 SHA-256");
+
+      #if defined(BOTAN_HAS_SHA2_64)
+      const auto sha384_cert = ca.sign_request(
+         user1_req, rng, from_date(-1, 01, 01), from_date(2, 01, 01), Botan::Subject_Key_ID_Method::RFC7093_SHA384);
+      check_issued_certificate(sha384_cert, Botan::Subject_Key_ID_Method::RFC7093_SHA384, "RFC 7093 SHA-384");
+
+      const auto sha512_cert = ca.sign_request(
+         user1_req, rng, from_date(-1, 01, 01), from_date(2, 01, 01), Botan::Subject_Key_ID_Method::RFC7093_SHA512);
+      check_issued_certificate(sha512_cert, Botan::Subject_Key_ID_Method::RFC7093_SHA512, "RFC 7093 SHA-512");
+      #endif
+
+      const auto sha256_self_signed = Botan::X509::create_self_signed_cert(
+         ca_opts(sig_padding), ca_key, hash_fn, Botan::Subject_Key_ID_Method::RFC7093_SHA256, rng);
+      const Botan::Cert_Extension::Subject_Key_ID expected_self_signed(*sha256_self_signed.subject_public_key(),
+                                                                       Botan::Subject_Key_ID_Method::RFC7093_SHA256);
+      result.test_bin_eq(
+         "RFC 7093 self-signed subject key id", sha256_self_signed.subject_key_id(), expected_self_signed.get_key_id());
+      result.test_bin_eq("RFC 7093 self-signed authority key id",
+                         sha256_self_signed.authority_key_id(),
+                         sha256_self_signed.subject_key_id());
+   }
+   #endif
 
    const Botan::X509_Certificate user2_cert =
       ca.sign_request(user2_req, rng, from_date(-1, 01, 01), from_date(2, 01, 01));


### PR DESCRIPTION


## Summary

- add `Subject_Key_ID_Method` with explicit choices for RFC 5280
  section 4.2.1.2 method 1 and RFC 7093 section 2 methods 1, 2, and 3
- add a `Subject_Key_ID(const Public_Key&, Subject_Key_ID_Method)`
  constructor
- expose the same explicit selection through `X509_CA::choose_extensions()`,
  both `X509_CA::sign_request()` variants, and
  `X509::create_self_signed_cert()`
- keep the existing RFC 5280/SHA-1 behavior as the default for every
  existing call
- test the SHA-256 implementation against RFC 7093 section 3's published
  P-256 vector, and cover SHA-1, SHA-384, SHA-512, invalid input, CA-issued
  certificates, and self-signed certificates

RFC 5280 method 1 hashes the value of the `subjectPublicKey` BIT STRING
with SHA-1 and produces 20 bytes. RFC 7093 methods 1, 2, and 3 hash the
same BIT STRING value with SHA-256, SHA-384, or SHA-512 and retain the
leftmost 160 bits.

The certificate signature hash and the SKI derivation method remain
independent. For example, a certificate may be signed with SHA-256 while
retaining the existing RFC 5280/SHA-1 SKI default, or it may explicitly
request an RFC 7093/SHA-256 SKI.

AKI handling is unchanged. A CA-issued certificate continues to copy the
issuer certificate's SKI byte-for-byte into its AKI. A self-signed
certificate uses its newly derived SKI as its AKI.

## Compatibility

This change is additive. Existing source calls retain their signatures and
behavior:

- `Subject_Key_ID(const Public_Key&)` still uses RFC 5280 method 1
- existing `X509_CA::sign_request()` overloads still use RFC 5280 method 1
- the existing `X509_CA::choose_extensions()` overload still uses RFC 5280
  method 1
- the existing `X509::create_self_signed_cert()` overload still uses RFC
  5280 method 1
- the deprecated byte-vector/hash-name constructor and the deprecated
  `choose_extensions()` compatibility overload remain available and
  unchanged

Consequently, RFC 7093 output is produced only when a caller uses a new
overload and explicitly selects an RFC 7093 enum value.

The automatic SHA-1 behavior was introduced independently by #5735. Before
#5735, automatic certificate generation used the certificate signature hash
over the DER-encoded `SubjectPublicKeyInfo` and truncated digests longer than
24 bytes. Thus, upgrading across #5735 can change SKI values without a caller
changing its source code. This PR does not introduce another implicit
behavior change; it preserves #5735's default and adds an explicit opt-in.

RFC 7093 method 4 is deliberately out of scope. It hashes the DER-encoded
`SubjectPublicKeyInfo` rather than the `subjectPublicKey` BIT STRING and does
not prescribe the same fixed 160-bit result as methods 1 through 3.

Related: #3479 and #5735

## Testing

- `make -j4 tests`
- `env LD_LIBRARY_PATH=. ./botan-test x509_unit`
  - 1,841 tests passed
  - `X509 subject key id derivation`: 9 tests passed
  - `X509 Unit`: 339 tests passed
- minimized static build with `x509`, ECDSA/P-256, RSA, SHA-1, and SHA-256,
  but without the `sha2_64` module
  - `x509_unit`: 658 tests passed
- `python3 src/scripts/ci_check_headers.py build/build_config.json`
- `python3 src/scripts/ci_check_generated_files.py --base upstream/master`
- `make docs`
- `git diff --check`

## Disclosure
This patch was developed with GPT-5.6. Sol.