### PR TITLE
Support ECDSA with brainpool in TLS 1.3

### DIFF
--- a/src/lib/tls/tls_signature_scheme.cpp
+++ b/src/lib/tls/tls_signature_scheme.cpp
@@ -39,6 +39,10 @@ const std::vector<Signature_Scheme>& Signature_Scheme::all_available_schemes() {
       RSA_PSS_SHA256,
       RSA_PSS_SHA512,
 
+      ECDSA_BRAINPOOL384R1_TLS13_SHA384,
+      ECDSA_BRAINPOOL256R1_TLS13_SHA256,
+      ECDSA_BRAINPOOL512R1_TLS13_SHA512,
+
       RSA_PKCS1_SHA384,
       RSA_PKCS1_SHA512,
       RSA_PKCS1_SHA256,
@@ -84,6 +88,16 @@ Signature_Scheme Signature_Scheme::from_string(std::string_view str) {
       return RSA_PSS_SHA512;
    }
 
+   if(str == "ECDSA_BRAINPOOL256R1_TLS13_SHA256") {
+      return ECDSA_BRAINPOOL256R1_TLS13_SHA256;
+   }
+   if(str == "ECDSA_BRAINPOOL384R1_TLS13_SHA384") {
+      return ECDSA_BRAINPOOL384R1_TLS13_SHA384;
+   }
+   if(str == "ECDSA_BRAINPOOL512R1_TLS13_SHA512") {
+      return ECDSA_BRAINPOOL512R1_TLS13_SHA512;
+   }
+
    // Parse signature schemes passed as hexadecimal code points (e.g. "0x081A")
    if(str.size() == 6 && str.starts_with("0x")) {
       try {
@@ -112,6 +126,9 @@ bool Signature_Scheme::is_available() const noexcept {
       case RSA_PKCS1_SHA384:
       case RSA_PKCS1_SHA512:
       case RSA_PKCS1_SHA256:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
       case ECDSA_SHA384:
       case ECDSA_SHA512:
       case ECDSA_SHA256:
@@ -145,6 +162,13 @@ std::string Signature_Scheme::to_string() const {
       case ECDSA_SHA512:
          return "ECDSA_SHA512";
 
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
+         return "ECDSA_BRAINPOOL256R1_TLS13_SHA256";
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
+         return "ECDSA_BRAINPOOL384R1_TLS13_SHA384";
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
+         return "ECDSA_BRAINPOOL512R1_TLS13_SHA512";
+
       case RSA_PSS_SHA256:
          return "RSA_PSS_SHA256";
       case RSA_PSS_SHA384:
@@ -171,16 +195,19 @@ std::string Signature_Scheme::hash_function_name() const {
       case ECDSA_SHA256:
       case RSA_PKCS1_SHA256:
       case RSA_PSS_SHA256:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
          return "SHA-256";
 
       case ECDSA_SHA384:
       case RSA_PKCS1_SHA384:
       case RSA_PSS_SHA384:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
          return "SHA-384";
 
       case ECDSA_SHA512:
       case RSA_PKCS1_SHA512:
       case RSA_PSS_SHA512:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
          return "SHA-512";
 
       case EDDSA_25519:
@@ -206,10 +233,13 @@ std::string Signature_Scheme::padding_string() const {
       case ECDSA_SHA1:
          return "SHA-1";
       case ECDSA_SHA256:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
          return "SHA-256";
       case ECDSA_SHA384:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
          return "SHA-384";
       case ECDSA_SHA512:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
          return "SHA-512";
 
       case RSA_PSS_SHA256:
@@ -243,6 +273,9 @@ std::string Signature_Scheme::algorithm_name() const {
       case ECDSA_SHA256:
       case ECDSA_SHA384:
       case ECDSA_SHA512:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
          return "ECDSA";
 
       case EDDSA_25519:
@@ -274,6 +307,13 @@ AlgorithmIdentifier Signature_Scheme::key_algorithm_identifier() const {
          return {"ECDSA", der_encode_oid("secp384r1")};
       case ECDSA_SHA512:
          return {"ECDSA", der_encode_oid("secp521r1")};
+
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
+         return {"ECDSA", der_encode_oid("brainpool256r1")};
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
+         return {"ECDSA", der_encode_oid("brainpool384r1")};
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
+         return {"ECDSA", der_encode_oid("brainpool512r1")};
 
       case EDDSA_25519:
          return {"Ed25519", AlgorithmIdentifier::USE_EMPTY_PARAM};
@@ -308,10 +348,13 @@ AlgorithmIdentifier Signature_Scheme::algorithm_identifier() const {
       case ECDSA_SHA1:
          return AlgorithmIdentifier(OID::from_string("ECDSA/SHA-1"), AlgorithmIdentifier::USE_EMPTY_PARAM);
       case ECDSA_SHA256:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
          return AlgorithmIdentifier(OID::from_string("ECDSA/SHA-256"), AlgorithmIdentifier::USE_EMPTY_PARAM);
       case ECDSA_SHA384:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
          return AlgorithmIdentifier(OID::from_string("ECDSA/SHA-384"), AlgorithmIdentifier::USE_EMPTY_PARAM);
       case ECDSA_SHA512:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
          return AlgorithmIdentifier(OID::from_string("ECDSA/SHA-512"), AlgorithmIdentifier::USE_EMPTY_PARAM);
 
       case RSA_PSS_SHA256:
@@ -344,6 +387,9 @@ std::optional<Signature_Format> Signature_Scheme::format() const noexcept {
       case ECDSA_SHA256:
       case ECDSA_SHA384:
       case ECDSA_SHA512:
+      case ECDSA_BRAINPOOL256R1_TLS13_SHA256:
+      case ECDSA_BRAINPOOL384R1_TLS13_SHA384:
+      case ECDSA_BRAINPOOL512R1_TLS13_SHA512:
          return Signature_Format::DerSequence;
 
       default:
@@ -385,16 +431,18 @@ bool Signature_Scheme::is_suitable_for(const Private_Key& private_key) const {
       return false;
    }
 
-   if(m_code == ECDSA_SHA256 && !(keylen >= 250 && keylen <= 350)) {
-      return false;
-   }
+   if(algorithm_name() == "ECDSA") {
+      if(hash_function_name() == "SHA-256" && !(keylen >= 250 && keylen <= 350)) {
+         return false;
+      }
 
-   if(m_code == ECDSA_SHA384 && !(keylen >= 350 && keylen <= 450)) {
-      return false;
-   }
+      if(hash_function_name() == "SHA-384" && !(keylen >= 350 && keylen <= 450)) {
+         return false;
+      }
 
-   if(m_code == ECDSA_SHA512 && !(keylen >= 450 && keylen <= 550)) {
-      return false;
+      if(hash_function_name() == "SHA-512" && !(keylen >= 450 && keylen <= 550)) {
+         return false;
+      }
    }
 
    return true;

--- a/src/lib/tls/tls_signature_scheme.h
+++ b/src/lib/tls/tls_signature_scheme.h
@@ -52,6 +52,11 @@ class BOTAN_PUBLIC_API(3, 0) Signature_Scheme final {
          RSA_PSS_SHA384 = 0x0805,
          RSA_PSS_SHA512 = 0x0806,
 
+         // RFC 8734
+         ECDSA_BRAINPOOL256R1_TLS13_SHA256 = 0x081A,
+         ECDSA_BRAINPOOL384R1_TLS13_SHA384 = 0x081B,
+         ECDSA_BRAINPOOL512R1_TLS13_SHA512 = 0x081C,
+
          EDDSA_25519 = 0x0807,
          EDDSA_448 = 0x0808,
       };

--- a/src/tests/test_tls_signature_scheme.cpp
+++ b/src/tests/test_tls_signature_scheme.cpp
@@ -70,6 +70,15 @@ std::vector<Test::Result> test_signature_scheme() {
       result.test_u16_eq("RSA_PSS_SHA256", Sig::from_string("RSA_PSS_SHA256").wire_code(), Sig::RSA_PSS_SHA256);
       result.test_u16_eq("RSA_PSS_SHA384", Sig::from_string("RSA_PSS_SHA384").wire_code(), Sig::RSA_PSS_SHA384);
       result.test_u16_eq("RSA_PSS_SHA512", Sig::from_string("RSA_PSS_SHA512").wire_code(), Sig::RSA_PSS_SHA512);
+      result.test_u16_eq("ECDSA_BRAINPOOL256R1_TLS13_SHA256",
+                         Sig::from_string("ECDSA_BRAINPOOL256R1_TLS13_SHA256").wire_code(),
+                         Sig::ECDSA_BRAINPOOL256R1_TLS13_SHA256);
+      result.test_u16_eq("ECDSA_BRAINPOOL384R1_TLS13_SHA384",
+                         Sig::from_string("ECDSA_BRAINPOOL384R1_TLS13_SHA384").wire_code(),
+                         Sig::ECDSA_BRAINPOOL384R1_TLS13_SHA384);
+      result.test_u16_eq("ECDSA_BRAINPOOL512R1_TLS13_SHA512",
+                         Sig::from_string("ECDSA_BRAINPOOL512R1_TLS13_SHA512").wire_code(),
+                         Sig::ECDSA_BRAINPOOL512R1_TLS13_SHA512);
 
       result.test_u16_eq("custom code point", Sig::from_string("0xFE42").wire_code(), Sig(0xFE42).wire_code());
 


### PR DESCRIPTION
This is described in [RFC 8734](https://www.rfc-editor.org/rfc/rfc8734.html) and is essentially straight-forward: Adding explicit code points for ECDSA with Brainpool, similar to the additions in #5691. As before I wouldn't restrict those code points for usage in TLS 1.3 explicitly. Perhaps we shouldn't enable them by default, though.

_Currently, that's really just a prove of concept (which succeeds in performing a handshake against a Bouncycastle server that is configured with a brainpool-based certificate)._ I need to go through this RFC and RFC 8446 once more to see if anything else has to be done (such as restricting the standard ECDSA code points to the NIST curves).

It would be nice to land that before Botan 3.13, if possible.

Closes #3811