### PR TITLE
FIX: `./botan tls_client` can drop outgoing alert records on error

### DIFF
--- a/src/cli/tls_client.cpp
+++ b/src/cli/tls_client.cpp
@@ -4,6 +4,7 @@
 *     2017 René Korthaus, Rohde & Schwarz Cybersecurity
 *     2022 René Meusel, Hannes Rantzsch - neXenio GmbH
 *     2023 René Meusel, Rohde & Schwarz Cybersecurity
+*     2026 René Meusel, Rohde & Schwarz Networks and Cybersecurity
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -184,7 +185,10 @@ class TLS_Client final : public Command {
          init_sockets();
       }
 
-      ~TLS_Client() override { stop_sockets(); }
+      ~TLS_Client() override {
+         shutdown_socket();
+         stop_sockets();
+      }
 
       TLS_Client(const TLS_Client& other) = delete;
       TLS_Client(TLS_Client&& other) = delete;
@@ -361,7 +365,7 @@ class TLS_Client final : public Command {
 
          set_return_code((we_closed || callbacks->peer_closed()) ? 0 : 1);
 
-         ::close(m_sockfd);
+         shutdown_socket();
       }
 
    public:
@@ -435,6 +439,25 @@ class TLS_Client final : public Command {
          if(r == -1) {
             throw CLI_Error("Socket write failed errno=" + std::to_string(errno));
          }
+      }
+
+      void shutdown_socket() {
+         if(m_sockfd == invalid_socket()) {
+            return;
+         }
+
+         // Signal that we are done writing so pending alert records are
+         // delivered with a FIN rather than lost to a RST.
+         ::shutdown(m_sockfd, SHUT_WR);
+
+         // Drain unread incoming data; if the receive buffer is non-empty when
+         // we close(), the kernel sends RST which discards our outgoing data
+         // (including any alert we sent).
+         char buf[256];
+         while(::read(m_sockfd, buf, sizeof(buf)) > 0) {}
+         ::close(m_sockfd);
+
+         m_sockfd = invalid_socket();
       }
 
       socket_type m_sockfd = invalid_socket();


### PR DESCRIPTION
This is an attempt to fix the currently failing nightly CI run (TLS Anvil Client), in response to [this post](https://github.com/randombit/botan/pull/5767#issuecomment-5116600143). To the best of my understanding the protocol implementation is correct, but we're tripping over some POSIX and/or TCP shenanigans in `./botan tls_client`.

TL;DR: The TLS client CLI command (used by the Anvil tests) doesn't gracefully shutdown the TCP socket resulting in sporadic data loss. This shows up after #5767 stopped coalescing the dummy CCS and the alert record into a single call to `TLS::Callbacks::tls_emit_data()`.

That likely addresses a very similar error mode as [this recent commit](https://github.com/randombit/botan/commit/579f1703cfff97a4c12357482295f40e592b1948) in the BoGo shim.

---

When the TLS client detects an error (e.g., the certificate cannot be parsed) it will emit a TLS alert record (likely something like "handshake failure") and then rethrow whatever exception caused the failure. The CLI command 'tls_client' does not catch this exception and aborts fairly violently. In the process, its POSIX socket wasn't closed gracefully and hence might drop some outgoing data, despite the fact that all socket calls are synchronous!

As it turns out, one single call to `::send()` on the socket will likely make it out onto the wire before the described ungraceful shutdown hits. But any additional call to `::send()` might not, despite the synchronous calls. [Disclaimer: That's a summary of what Claude Opus said.]

This started happening on TLS 1.3 after GH #5767 was merged. In compatibility mode, a dummy ChangeCipherSpec record must be emitted before the first encrypted record coming from the Client. Before #5767 those two records were coalesced into a single call to `TLS::Callbacks::tls_emit_data()`:

https://github.com/randombit/botan/blob/ab9d4657f9f23b19525724a55d9c840a17bab81c/src/lib/tls/tls13/tls_channel_impl_13.cpp#L370-L376

After #5767 they're two consecutive calls to `TLS::Callbacks::tls_emit_data()`. In conclusion, sometimes the TLS alert record is dropped due to the ungraceful shutdown of the 'tls_client` CLI command. TLS Anvil detected this in the recently failed nightly tests.