### PR TITLE
Align documented and annotated deprecation markers

### DIFF
--- a/doc/deprecated.rst
+++ b/doc/deprecated.rst
@@ -59,6 +59,8 @@ in a future major release:
 
 - All ciphersuites using static RSA key exchange
 
+- Support for CCM-8 ciphersuites
+
 - ``Credentials_Manager::psk()`` to provide various TLS-specific keys and
   secrets, most notably "session-ticket", "dtls-cookie-secret" and the actual
   TLS PSKs for given identities and hosts. Instead, use the dedicated methods in
@@ -145,6 +147,8 @@ Deprecated modules include
 - Kyber R3 support: prefer ML-KEM
 
 - Dilithium R3 support: prefer ML-DSA
+
+- SPHINCS+: prefer SLH-DSA
 
 - Block cipher ``gost_28147``: This cipher was obsolete 20 years ago.
 

--- a/src/build-data/policy/bsi.txt
+++ b/src/build-data/policy/bsi.txt
@@ -56,7 +56,8 @@ gmac
 
 # Table 5.3/5.5: Recommended signature algorithms.
 # rsa (already enabled above)
-dsa
+# (DSA support is deprecated)
+# dsa
 ecdsa
 ecgdsa
 eckcdsa

--- a/src/lib/hash/gost_3411/info.txt
+++ b/src/lib/hash/gost_3411/info.txt
@@ -4,6 +4,7 @@ GOST_34_11 -> 20131128
 
 <module_info>
 name -> "GOST 34.11"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/pubkey/dilithium/dilithium_round3/info.txt
+++ b/src/lib/pubkey/dilithium/dilithium_round3/info.txt
@@ -5,6 +5,7 @@ DILITHIUM_ROUND3 -> 20240916
 <module_info>
 name -> "Dilithium Round 3"
 type -> "Internal"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/pubkey/dsa/info.txt
+++ b/src/lib/pubkey/dsa/info.txt
@@ -4,6 +4,7 @@ DSA -> 20131128
 
 <module_info>
 name -> "DSA"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/pubkey/kyber/kyber_round3/info.txt
+++ b/src/lib/pubkey/kyber/kyber_round3/info.txt
@@ -6,6 +6,7 @@ KYBER_ROUND3 -> 20240117
 name -> "Kyber Round 3 Encapsulation"
 brief -> "Kyber key encapsulation as specified in the Round 3 spec"
 type -> "Internal"
+lifecycle -> "Deprecated"
 </module_info>
 
 <requires>

--- a/src/lib/xof/aes_crystals_xof/info.txt
+++ b/src/lib/xof/aes_crystals_xof/info.txt
@@ -2,6 +2,8 @@
 AES_CRYSTALS_XOF -> 20230816
 </internal_defines>
 
+# TODO(Botan4) only needed for 90s mode, remove
+
 <module_info>
 name -> "CRYSTALS XOF"
 brief -> "XOF used in Kyber 90s and Dilithium AES"


### PR DESCRIPTION
Some modules were listed as deprecated but not given the correct annotation in the module file.