### PR TITLE
Optimize SRP6's server step2

### DIFF
--- a/src/lib/misc/srp6/srp6.cpp
+++ b/src/lib/misc/srp6/srp6.cpp
@@ -167,16 +167,17 @@ BigInt SRP6_Server_Session::step1(
       throw Invalid_Argument("SRP6_Server_Session: invalid verifier");
    }
 
-   BOTAN_ARG_CHECK(b_bits <= group.p_bits(), "Invalid b_bits");
+   BOTAN_ARG_CHECK(b_bits >= 160 && b_bits <= group.p_bits(), "Invalid b_bits");
 
    BOTAN_STATE_CHECK(!m_group);
    m_group = std::make_unique<DL_Group>(group);
+   m_b_bits = b_bits;
 
    const BigInt& g = m_group->get_g();
    const BigInt& p = m_group->get_p();
 
    m_v = v;
-   m_b = BigInt(rng, b_bits);
+   m_b = BigInt(rng, m_b_bits);
    m_hash_id = hash_id;
 
    auto hash_fn = HashFunction::create_or_throw(hash_id);
@@ -205,8 +206,12 @@ SymmetricKey SRP6_Server_Session::step2(const BigInt& A) {
    const BigInt u = hash_seq(*hash_fn, m_group->p_bytes(), A, m_B);
    BOTAN_ASSERT_NOMSG(!u.is_zero());
 
-   const BigInt vup = m_group->power_b_p(m_v, u, m_group->p_bits());
-   const BigInt S = m_group->power_b_p(m_group->multiply_mod_p(A, vup), m_b, m_group->p_bits());
+   // The maximum length of u is fixed based on the chosen hash function
+   const size_t u_bits = hash_fn->output_length() * 8;
+   const BigInt vup = m_group->power_b_p(m_v, u, u_bits);
+
+   // The size of b is chosen by either a formula or the application; either way it is public
+   const BigInt S = m_group->power_b_p(m_group->multiply_mod_p(A, vup), m_b, m_b_bits);
 
    return SymmetricKey(S.serialize<secure_vector<uint8_t>>(m_group->p_bytes()));
 }

--- a/src/lib/misc/srp6/srp6.h
+++ b/src/lib/misc/srp6/srp6.h
@@ -136,6 +136,7 @@ class BOTAN_PUBLIC_API(2, 0) SRP6_Server_Session final {
       std::unique_ptr<DL_Group> m_group;
       std::string m_hash_id;
       BigInt m_B, m_b, m_v, m_S;
+      size_t m_b_bits = 0;
 };
 
 }  // namespace Botan


### PR DESCRIPTION
These used the full width of the group as the advertised exponent size, but that isn't necessary for either `u` or `b`; `u` is a hash so the maximum length is small and public, and the length of `b` is chosen by either a public formula or from an application provided setting. Improves step2 by 10x to 25x depending on group size.