### PR TITLE
DTLS bug fixes and hardenings

### DIFF
--- a/src/bogo_shim/config.json
+++ b/src/bogo_shim/config.json
@@ -203,7 +203,6 @@
         "CipherNegotiation-5": "No support for cipher equivalence classes",
         "CipherNegotiation-8": "No support for cipher equivalence classes",
         "ALPNServer-SelectEmpty-*": "Botan treats empty ALPN from callback as a decline",
-        "AppDataAfterChangeCipherSpec-DTLS*": "BoringSSL DTLS drops out of order AppData, we reject",
         "Resume-Client-NoResume-TLS1-TLS11-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS1-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS11-TLS12-TLS": "BoGo expects resumption attempt sends latest version",

--- a/src/bogo_shim/config_no_tls12.json
+++ b/src/bogo_shim/config_no_tls12.json
@@ -204,7 +204,6 @@
         "CipherNegotiation-5": "No support for cipher equivalence classes",
         "CipherNegotiation-8": "No support for cipher equivalence classes",
         "ALPNServer-SelectEmpty-*": "Botan treats empty ALPN from callback as a decline",
-        "AppDataAfterChangeCipherSpec-DTLS*": "BoringSSL DTLS drops out of order AppData, we reject",
         "Resume-Client-NoResume-TLS1-TLS11-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS1-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS11-TLS12-TLS": "BoGo expects resumption attempt sends latest version",

--- a/src/bogo_shim/config_no_tls13.json
+++ b/src/bogo_shim/config_no_tls13.json
@@ -203,7 +203,6 @@
         "CipherNegotiation-5": "No support for cipher equivalence classes",
         "CipherNegotiation-8": "No support for cipher equivalence classes",
         "ALPNServer-SelectEmpty-*": "Botan treats empty ALPN from callback as a decline",
-        "AppDataAfterChangeCipherSpec-DTLS*": "BoringSSL DTLS drops out of order AppData, we reject",
         "Resume-Client-NoResume-TLS1-TLS11-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS1-TLS12-TLS": "BoGo expects resumption attempt sends latest version",
         "Resume-Client-NoResume-TLS11-TLS12-TLS": "BoGo expects resumption attempt sends latest version",

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -63,6 +63,27 @@ void prune_old_cipher_states(std::map<uint16_t, T>& states) {
    }
 }
 
+// Run fn, absorbing the exceptions that report malformed input when `absorb`
+// is set. Used where the input is unauthenticated epoch-zero data that must
+// not be able to tear down an established association. Only TLS_Exception and
+// Decoding_Error are absorbed: an Internal_Error from one of the reassembly
+// accounting assertions, or a failed allocation, still propagates rather than
+// leaving the association running on state those assertions exist to protect.
+template <typename F>
+void absorb_malformed_input_errors(bool absorb, F fn) {
+   try {
+      fn();
+   } catch(const TLS_Exception&) {
+      if(!absorb) {
+         throw;
+      }
+   } catch(const Decoding_Error&) {
+      if(!absorb) {
+         throw;
+      }
+   }
+}
+
 }  // namespace
 
 Channel_Impl_12::Channel_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
@@ -636,16 +657,14 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
    const auto process_retransmitted_record = [&] {
       BOTAN_ASSERT(m_active_state.has_value(), "Have active DTLS association for retransmission");
       BOTAN_ASSERT_NONNULL(m_active_state->dtls_handshake_io());
-      try {
+      // Epoch-zero records are unauthenticated and may be spoofed, so a
+      // malformed one must not tear down an established association.
+      const bool unauthenticated = (record_sequence >> 48) == 0;
+
+      absorb_malformed_input_errors(unauthenticated, [&] {
          m_active_state->dtls_handshake_io()->add_retransmitted_record(
             record.data(), record.size(), record_type, record_sequence);
-      } catch(...) {
-         // Epoch-zero records are unauthenticated and may be spoofed. Invalid
-         // retransmissions must not tear down an established association.
-         if((record_sequence >> 48) > 0) {
-            throw;
-         }
-      }
+      });
    };
 
    if(!m_pending_state) {
@@ -664,7 +683,6 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
       if(m_is_datagram && !epoch0_restart) {
          if(m_sequence_numbers) {
             const uint16_t epoch = record_sequence >> 48;
-
             const uint16_t current_epoch = sequence_numbers().current_read_epoch();
             if(epoch == current_epoch) {
                // Either endpoint can initiate renegotiation from FINISHED:
@@ -692,21 +710,36 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
 
    // May have been created in above conditional
    if(m_pending_state) {
-      m_pending_state->handshake_io().add_record(record.data(), record.size(), record_type, record_sequence);
+      // An epoch-zero record is unauthenticated. Once an association is
+      // established, one arriving during a pending renegotiation must not be
+      // able to destroy it, exactly as for the no-pending-handshake path above.
+      // Without this a single forged CCS or handshake fragment tore down the
+      // active association and the renegotiation along with it.
+      //
+      // Delivery is inside the guard as well as reassembly. A bare 12-byte
+      // header declaring a zero-length message reassembles cleanly and only
+      // fails when the message itself is parsed or dispatched, which reaches
+      // the same teardown by a later route.
+      const bool unauthenticated_against_active_association =
+         m_is_datagram && (record_sequence >> 48) == 0 && m_active_state.has_value();
 
-      while(auto* pending = m_pending_state.get()) {
-         auto msg = pending->get_next_handshake_msg(policy().maximum_handshake_message_size());
+      absorb_malformed_input_errors(unauthenticated_against_active_association, [&] {
+         m_pending_state->handshake_io().add_record(record.data(), record.size(), record_type, record_sequence);
 
-         if(msg.first == Handshake_Type::None) {  // no full handshake yet
-            break;
+         while(auto* pending = m_pending_state.get()) {
+            auto msg = pending->get_next_handshake_msg(policy().maximum_handshake_message_size());
+
+            if(msg.first == Handshake_Type::None) {  // no full handshake yet
+               break;
+            }
+
+            process_handshake_msg(*pending, msg.first, msg.second, epoch0_restart);
+
+            if(!m_pending_state) {
+               break;
+            }
          }
-
-         process_handshake_msg(*pending, msg.first, msg.second, epoch0_restart);
-
-         if(!m_pending_state) {
-            break;
-         }
-      }
+      });
    }
 }
 

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -448,9 +448,11 @@ void Channel_Impl_12::activate_session() {
       map_remove_if(not_current_epoch, m_read_cipher_states);
    }
 
-   // In a full handshake the server sends the terminal flight; in an
-   // abbreviated handshake the client does. Both endpoints retain handshake
-   // sequence state, but only the terminal sender replays its outgoing flight.
+   // RFC 6347 4.2.4: "the node that transmits the last flight (the server in an
+   // ordinary handshake or the client in a resumed handshake) MUST respond to a
+   // retransmit of the peer's last flight with a retransmit of the last
+   // flight." Both endpoints retain handshake sequence state, but only that
+   // node replays its outgoing flight.
    const bool sent_terminal_dtls_flight = m_is_datagram && (m_is_server == (state.server_hello_done() != nullptr));
 
    if(m_is_datagram) {

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -259,6 +259,10 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
       }
    }
 
+   // Read epochs at or below this one belong to the association already in place,
+   // so application data under them stays deliverable while this handshake runs.
+   // Anything above it is this handshake's own, unauthenticated until its
+   // Finished. See the application-data gate in from_peer.
    m_epochs_before_latest_renegotiation = Epochs_Before_Latest_Renegotiation{sequence_numbers().current_read_epoch(),
                                                                              sequence_numbers().current_write_epoch()};
 
@@ -639,7 +643,34 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
                throw TLS_Exception(Alert::UnexpectedMessage, "Received application data after connection closure");
             }
             if(pending_state() != nullptr) {
-               throw TLS_Exception(Alert::UnexpectedMessage, "Can't interleave application and handshake data");
+               /*
+               What matters is which epoch the record belongs to, not which role we
+               are playing.
+
+               RFC 6347 4.2.4: "Implementations MUST either discard or buffer all
+               application data packets for the new epoch until they have received
+               the Finished message for that epoch." Data under the epoch this
+               handshake installed is not authenticated until its Finished, so it
+               must not reach the application; equally it is not an error, because
+               ordinary reordering produces it whenever a peer writes immediately
+               after activating.
+
+               Data under an epoch the established association owns stays valid
+               while a renegotiation is in flight, per 4.1.
+
+               Epoch zero is neither: application data there is plaintext, so it is
+               never legitimate and no association is at stake.
+               */
+               if(m_is_datagram && record.epoch() > 0) {
+                  const uint16_t active_epoch =
+                     m_epochs_before_latest_renegotiation ? m_epochs_before_latest_renegotiation->read_epoch : 0;
+
+                  if(!m_active_state.has_value() || record.epoch() > active_epoch) {
+                     continue;  // this handshake's epoch, still unauthenticated
+                  }
+               } else {
+                  throw TLS_Exception(Alert::UnexpectedMessage, "Can't interleave application and handshake data");
+               }
             }
             process_application_data(record.sequence(), m_record_buf);
          } else if(record.type() == Record_Type::Alert) {

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -117,9 +117,52 @@ void Channel_Impl_12::reset_state() {
    m_active_state.reset();
    m_pending_state.reset();
    m_epochs_before_latest_renegotiation.reset();
+   m_resumption_handle.reset();
    m_readbuf.clear();
    m_write_cipher_states.clear();
    m_read_cipher_states.clear();
+}
+
+void Channel_Impl_12::note_resumption_handle(std::optional<Session_Handle> handle) {
+   m_resumption_handle = std::move(handle);
+}
+
+std::vector<Session_Handle> Channel_Impl_12::take_sessions_to_invalidate() {
+   // A ticket-backed session is not cached under the ServerHello session ID, so
+   // both handles have to be collected.
+   std::vector<Session_Handle> handles;
+
+   if(m_resumption_handle.has_value()) {
+      handles.push_back(m_resumption_handle.value());
+      m_resumption_handle.reset();
+   }
+
+   if(m_active_state.has_value()) {
+      const auto& sid = m_active_state->session_id();
+      if(!sid.empty()) {
+         handles.emplace_back(sid);
+      }
+   }
+
+   return handles;
+}
+
+void Channel_Impl_12::invalidate_sessions(const std::vector<Session_Handle>& handles) {
+   // RFC 5246 7.2.2: "Servers and clients MUST forget any session-identifiers,
+   // keys, and secrets associated with a failed connection.  Thus, any
+   // connection terminated with a fatal alert MUST NOT be resumed."
+   //
+   // Best effort, and deliberately last: remove() reaches application-supplied
+   // storage and can throw, and by then the keys are already gone. Letting a
+   // failed cache eviction abort the teardown would leave the channel usable
+   // after a security-fatal event, which is the worse of the two outcomes. A
+   // stateless ticket issuer has nothing to remove and cannot revoke what it
+   // already handed out.
+   for(const auto& handle : handles) {
+      try {
+         session_manager().remove(handle);
+      } catch(...) {}
+   }
 }
 
 void Channel_Impl_12::reset_active_association_state() {
@@ -480,6 +523,14 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
 
    try {
       while(input_size > 0) {
+         // A fatal alert destroys the cipher states, so nothing further can even
+         // be decrypted. Closure by close_notify is different: the responding
+         // close_notify still has to be read, so those records keep flowing
+         // through the loop and are filtered per record type below.
+         if(m_had_fatal_alert) {
+            return 0;
+         }
+
          size_t consumed = 0;
 
          auto get_epoch = [this](uint16_t epoch) { return read_cipher_state_epoch(epoch); };
@@ -559,6 +610,14 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
                   throw TLS_Exception(Alert::ProtocolVersion, "Received unexpected record version");
                }
             }
+         }
+
+         // RFC 5246 7.2.1: "Any data received after a closure alert is ignored."
+         // This is about a closure alert the peer sent us. A peer that keeps
+         // talking after *our* close_notify is a different case, kept as an
+         // error below; BoGo's Shutdown-Shim-ApplicationData requires it.
+         if(m_peer_closed_connection && record.type() != Record_Type::Alert) {
+            continue;
          }
 
          if(record.type() == Record_Type::Handshake || record.type() == Record_Type::ChangeCipherSpec) {
@@ -781,17 +840,41 @@ void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record) {
       m_pending_state.reset();
    }
 
-   callbacks().tls_alert(alert_msg);
+   std::vector<Session_Handle> invalidated;
 
-   // If the alert is fatal on an active session, prevent later resumptions
-   if(alert_msg.is_fatal() && m_active_state.has_value()) {
-      const auto& sid = m_active_state->session_id();
-      if(!sid.empty()) {
-         session_manager().remove(Session_Handle(sid));
+   if(alert_msg.is_fatal()) {
+      // RFC 5246 7.2.2: "Upon transmission or receipt of a fatal alert message,
+      // both parties immediately close the connection."
+      //
+      // Closing before the callback means application code called from there
+      // cannot keep using the connection or its exporter. The active state
+      // itself survives until the callback returns, so a handler can still
+      // report the peer identity that failed.
+      m_has_been_closed = true;
+      m_had_fatal_alert = true;
+      invalidated = take_sessions_to_invalidate();
+   }
+
+   // The callback is application code and may throw. It must not be able to
+   // leave the connection secrets alive after a fatal alert.
+   try {
+      callbacks().tls_alert(alert_msg);
+   } catch(...) {
+      if(alert_msg.is_fatal()) {
+         reset_state();
+         invalidate_sessions(invalidated);
       }
+      throw;
+   }
+
+   if(alert_msg.is_fatal()) {
+      reset_state();
+      invalidate_sessions(invalidated);
    }
 
    if(alert_msg.type() == Alert::CloseNotify) {
+      m_peer_closed_connection = true;
+
       // TLS 1.2 requires us to immediately react with our "close_notify",
       // the return value of the application's callback has no effect on that.
       callbacks().tls_peer_closed_connection();
@@ -871,13 +954,22 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
    }
 
    if(alert.is_fatal()) {
-      if(m_active_state.has_value()) {
-         const auto& sid = m_active_state->session_id();
-         if(!sid.empty()) {
-            session_manager().remove(Session_Handle(sid));
-         }
-      }
+      // Order matters: the channel is made unusable and its secrets destroyed
+      // before any application-supplied storage is touched, so a throwing
+      // session manager cannot leave is_active() true with live keys.
+      m_had_fatal_alert = true;
+      m_has_been_closed = true;
+
+      // Alert::None is the local teardown that is never sent to the peer, used
+      // where the trigger was unauthenticated input or a local timeout. Evicting
+      // the resumption state on that basis would hand anyone able to reach the
+      // address the ability to destroy it, which is what keeping the teardown
+      // local exists to prevent.
+      const auto invalidated =
+         (alert.type() == Alert::None) ? std::vector<Session_Handle>() : take_sessions_to_invalidate();
+
       reset_state();
+      invalidate_sessions(invalidated);
    }
 
    if(alert.type() == Alert::CloseNotify || alert.is_fatal()) {
@@ -957,6 +1049,15 @@ SymmetricKey Channel_Impl_12::key_material_export(std::string_view label,
                                                   size_t length) const {
    if(!m_active_state.has_value()) {
       throw Invalid_State("Channel_Impl_12::key_material_export connection not active");
+   }
+
+   // Keyed on the fatal alert rather than on is_closed(): RFC 5246 7.2.2 makes
+   // a fatally terminated connection's secrets unusable, but a clean
+   // close_notify does not, and TLS 1.3 keeps its exporter working across one.
+   // Reachable only from a tls_alert callback, since the teardown that follows
+   // clears m_active_state and the check above then fires instead.
+   if(m_had_fatal_alert) {
+      throw Invalid_State("Channel_Impl_12::key_material_export connection had a fatal alert");
    }
 
    if(pending_state() != nullptr) {

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -28,12 +28,11 @@ namespace Botan::TLS {
 namespace {
 
 bool is_new_dtls_association_client_hello(std::span<const uint8_t> msg_and_header, Record_Type record_type) {
-   constexpr size_t DTLS_HANDSHAKE_HEADER_SIZE = 12;
-
    // Every new DTLS handshake starts at message_seq 0. A cookie-bearing
    // ClientHello uses message_seq 1, so one arriving late belongs to the
    // previous handshake and must not replace the active association's state.
-   return record_type == Record_Type::Handshake && msg_and_header.size() >= DTLS_HANDSHAKE_HEADER_SIZE &&
+   return record_type == Record_Type::Handshake &&
+          msg_and_header.size() >= Datagram_Handshake_IO::DTLS_HANDSHAKE_HEADER_SIZE &&
           static_cast<Handshake_Type>(msg_and_header[0]) == Handshake_Type::ClientHello &&
           load_be(msg_and_header.subspan<4, 2>()) == 0;
 }
@@ -219,7 +218,8 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
                                                    initial_timeout_ms,
                                                    max_timeout_ms,
                                                    max_retransmissions,
-                                                   policy().maximum_handshake_message_size());
+                                                   policy().maximum_handshake_message_size(),
+                                                   m_is_server);
    } else {
       auto send_record_f = [this](Record_Type rec_type, const std::vector<uint8_t>& record) {
          send_record(rec_type, record);
@@ -440,7 +440,7 @@ void Channel_Impl_12::activate_session() {
 }
 
 size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
-   const bool allow_epoch0_restart = m_is_datagram && m_is_server && policy().allow_dtls_epoch0_restart();
+   const bool allow_epoch0_restart = m_is_datagram && dtls_epoch0_restart_enabled();
 
    const auto* input = data.data();
    auto input_size = data.size();
@@ -532,7 +532,16 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
             if(m_has_been_closed) {
                throw TLS_Exception(Alert::UnexpectedMessage, "Received handshake data after connection closure");
             }
-            process_handshake_ccs(m_record_buf, record.sequence(), record.type(), record.version(), epoch0_restart);
+            try {
+               process_handshake_ccs(m_record_buf, record.sequence(), record.type(), record.version(), epoch0_restart);
+            } catch(Exception&) {
+               // The restart ClientHello is unauthenticated until its cookie
+               // validates; if it fails, roll back the state.
+               if(!epoch0_restart) {
+                  throw;
+               }
+               clear_pending_handshake_state();
+            }
          } else if(record.type() == Record_Type::ApplicationData) {
             if(m_has_been_closed) {
                throw TLS_Exception(Alert::UnexpectedMessage, "Received application data after connection closure");
@@ -565,11 +574,65 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
    }
 }
 
+void Channel_Impl_12::discard_stale_cookie_exchange_state(const secure_vector<uint8_t>& record,
+                                                          Record_Type record_type) {
+   if(!m_is_datagram || !m_pending_state || record_type != Record_Type::Handshake ||
+      record.size() < Datagram_Handshake_IO::DTLS_HANDSHAKE_HEADER_SIZE) {
+      return;
+   }
+
+   if(static_cast<Handshake_Type>(record[0]) != Handshake_Type::ClientHello) {
+      return;
+   }
+
+   // Only the start of a ClientHello, at the message_seq every handshake begins
+   // with (RFC 6347 4.2.2).
+   const uint16_t message_seq = load_be<uint16_t>(&record[4], 0);
+   const size_t fragment_offset = make_uint32(0, record[6], record[7], record[8]);
+   const size_t msg_length = make_uint32(0, record[1], record[2], record[3]);
+
+   if(message_seq != 0 || fragment_offset != 0) {
+      return;
+   }
+
+   // A declared length this short cannot be a real ClientHello, so it cannot be
+   // the start of one. The same reasoning as the reassembly path's guard: a bare
+   // 12-byte header should not be able to discard a pending cookie exchange.
+   if(msg_length < Datagram_Handshake_IO::MIN_CLIENT_HELLO_SIZE) {
+      return;
+   }
+
+   auto* dtls_io = dynamic_cast<Datagram_Handshake_IO*>(&m_pending_state->handshake_io());
+   if(dtls_io == nullptr) {
+      return;
+   }
+
+   /*
+   The cookie exchange is meant to be stateless, but the pending state carrying
+   it survives across the HelloVerifyRequest. Anyone able to reach this address
+   can therefore advance its handshake sequence numbers with ClientHellos that
+   never validate, and every later handshake starting at message_seq 0 then
+   looks like a stale duplicate of that one. Two forged datagrams were enough to
+   lock a channel out permanently.
+
+   Discard the state instead, so a new cookie exchange begins. Restricted to a
+   pending state that has consumed a message but holds no accepted ClientHello,
+   ie one that has answered with a HelloVerifyRequest and is still waiting for
+   the cookie to come back. A handshake that got past the cookie check keeps its
+   state, so this cannot be used to reset one in progress.
+   */
+   if(dtls_io->in_message_seq() > 0 && m_pending_state->client_hello() == nullptr) {
+      clear_pending_handshake_state();
+   }
+}
+
 void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record,
                                             uint64_t record_sequence,
                                             Record_Type record_type,
                                             Protocol_Version record_version,
                                             bool epoch0_restart) {
+   discard_stale_cookie_exchange_state(record, record_type);
+
    const auto process_retransmitted_record = [&] {
       BOTAN_ASSERT(m_active_state.has_value(), "Have active DTLS association for retransmission");
       BOTAN_ASSERT_NONNULL(m_active_state->dtls_handshake_io());
@@ -777,18 +840,20 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
    }
 }
 
-void Channel_Impl_12::secure_renegotiation_check(const Client_Hello_12* client_hello) {
+void Channel_Impl_12::secure_renegotiation_check(const Client_Hello_12* client_hello, bool fresh_handshake_mode) {
    BOTAN_ASSERT_NONNULL(client_hello);
    const bool secure_renegotiation = client_hello->secure_renegotiation();
 
-   if(m_active_state && m_active_state->client_supports_secure_renegotiation() != secure_renegotiation) {
+   if(!fresh_handshake_mode && m_active_state &&
+      m_active_state->client_supports_secure_renegotiation() != secure_renegotiation) {
       throw TLS_Exception(Alert::HandshakeFailure, "Client changed its mind about secure renegotiation");
    }
 
    if(secure_renegotiation) {
       const std::vector<uint8_t>& data = client_hello->renegotiation_info();
 
-      const auto expected = secure_renegotiation_data_for_client_hello();
+      const auto expected =
+         fresh_handshake_mode ? std::vector<uint8_t>() : secure_renegotiation_data_for_client_hello();
       if(!CT::is_equal<uint8_t>(data, expected).as_bool()) {
          throw TLS_Exception(Alert::HandshakeFailure, "Client sent bad values for secure renegotiation");
       }

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -867,8 +867,20 @@ void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record) {
    //    no_renegotiation
    //       Sent by the client in response to a hello request or by the
    //       server in response to a client hello after initial handshaking.
+   //
+   // Both of those precede any ChangeCipherSpec from the refusing side, so a
+   // refusal arriving after one means the peer both refused the handshake and
+   // proceeded with it. Discarding the pending state is what implements the
+   // refusal, but past a CCS that state is the only thing keeping application
+   // data under the new, un-Finished keys from being delivered, and there is no
+   // rollback that would leave keys, identity and exporter describing the same
+   // handshake. End the association rather than open that gate.
    if(alert_msg.type() == Alert::NoRenegotiation && m_active_state.has_value()) {
-      m_pending_state.reset();
+      if(!pending_handshake_epochs_unmoved()) {
+         throw TLS_Exception(Alert::UnexpectedMessage, "Received no_renegotiation after ChangeCipherSpec");
+      }
+
+      clear_pending_handshake_state();
    }
 
    std::vector<Session_Handle> invalidated;
@@ -980,8 +992,14 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
       }
    }
 
+   // We are the refusing side here, so our own epochs cannot have moved for
+   // this handshake and the check is defensive. send_alert is called from
+   // from_peer's catch handlers and must not throw, so an unexpected case
+   // leaves the pending state in place rather than ending the association.
    if(alert.type() == Alert::NoRenegotiation && m_active_state.has_value()) {
-      m_pending_state.reset();
+      if(pending_handshake_epochs_unmoved()) {
+         clear_pending_handshake_state();
+      }
    }
 
    if(alert.is_fatal()) {

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -219,6 +219,15 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
    m_epochs_before_latest_renegotiation = Epochs_Before_Latest_Renegotiation{sequence_numbers().current_read_epoch(),
                                                                              sequence_numbers().current_write_epoch()};
 
+   // Floor for the pending handshake's reassembly: a delayed record from the
+   // handshake before it arrives under a lower epoch and would otherwise take
+   // the sequence slot the real message needs.
+   //
+   // Zero when epoch-zero restart is enabled, because there the peer
+   // legitimately begins again at epoch zero and the floor would reject it.
+   // That policy defaults to off, so a server ordinarily keeps the protection.
+   const uint16_t initial_epoch = dtls_epoch0_restart_enabled() ? 0 : m_epochs_before_latest_renegotiation->read_epoch;
+
    using namespace std::placeholders;
 
    std::unique_ptr<Handshake_IO> io;
@@ -240,7 +249,8 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
                                                    max_timeout_ms,
                                                    max_retransmissions,
                                                    policy().maximum_handshake_message_size(),
-                                                   m_is_server);
+                                                   m_is_server,
+                                                   initial_epoch);
    } else {
       auto send_record_f = [this](Record_Type rec_type, const std::vector<uint8_t>& record) {
          send_record(rec_type, record);

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -171,7 +171,10 @@ class Channel_Impl_12 : public Channel_Impl {
 
       /* secure renegotiation handling */
 
-      void secure_renegotiation_check(const Client_Hello_12* client_hello);
+      // `fresh_handshake_mode` makes the check ignore m_active_state and treat
+      // the new ClientHello as starting a fresh handshake. Used for DTLS
+      // epoch-0 restart, where the peer has lost association state.
+      void secure_renegotiation_check(const Client_Hello_12* client_hello, bool fresh_handshake_mode = false);
       void secure_renegotiation_check(const Server_Hello_12* server_hello);
 
       std::vector<uint8_t> secure_renegotiation_data_for_client_hello() const;
@@ -186,6 +189,14 @@ class Channel_Impl_12 : public Channel_Impl {
       Callbacks& callbacks() const { return *m_callbacks; }
 
       void reset_active_association_state();
+
+      // Drop a pending DTLS cookie exchange that a fresh ClientHello supersedes,
+      // so unvalidated ClientHellos cannot wedge the handshake sequence numbers.
+      void discard_stale_cookie_exchange_state(const secure_vector<uint8_t>& record, Record_Type record_type);
+
+      // Whether epoch-0 restart of an active DTLS association is permitted
+      // (only true for Server_Impl with a valid DTLS cookie secret)
+      virtual bool dtls_epoch0_restart_enabled() const { return false; }
 
       virtual void initiate_handshake(Handshake_State& state, bool force_full_renegotiation) = 0;
 

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -265,8 +265,10 @@ class Channel_Impl_12 : public Channel_Impl {
       /* handle under which this connection's session is cached, if any */
       std::optional<Session_Handle> m_resumption_handle;
 
-      // Epochs in force when the pending handshake began. Whether either has
-      // moved decides if an abandoned handshake can be discarded or has to
+      // Epochs in force when the pending handshake began. The read epoch says
+      // whether application data belongs to the old association or to the new,
+      // still-unauthenticated epoch; whether either epoch has moved decides
+      // whether an abandoned handshake can be discarded or has to
       // take the association with it.
       struct Epochs_Before_Latest_Renegotiation final {
             uint16_t read_epoch;

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -268,7 +268,7 @@ class Channel_Impl_12 : public Channel_Impl {
       // Epochs in force when the pending handshake began. The read epoch says
       // whether application data belongs to the old association or to the new,
       // still-unauthenticated epoch; whether either epoch has moved decides
-      // whether an abandoned handshake can be discarded or has to
+      // whether an abandoned or refused handshake can be discarded or has to
       // take the association with it.
       struct Epochs_Before_Latest_Renegotiation final {
             uint16_t read_epoch;
@@ -277,8 +277,11 @@ class Channel_Impl_12 : public Channel_Impl {
 
       void abandon_timed_out_handshake();
 
+      // Whether neither epoch has moved since the pending handshake began, so
+      // dropping it cannot leave the channel describing two handshakes at once.
       bool pending_handshake_epochs_unmoved() const;
 
+      // Drop the pending handshake and the epoch markers that describe it.
       void clear_pending_handshake_state();
 
       /*

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -190,6 +190,13 @@ class Channel_Impl_12 : public Channel_Impl {
 
       void reset_active_association_state();
 
+      /**
+      * Record the resumption handle this connection was established or resumed
+      * under, so that a fatal alert can invalidate it. The ServerHello session
+      * ID does not identify a ticket-backed session.
+      */
+      void note_resumption_handle(std::optional<Session_Handle> handle);
+
       // Drop a pending DTLS cookie exchange that a fresh ClientHello supersedes,
       // so unvalidated ClientHellos cannot wedge the handshake sequence numbers.
       void discard_stale_cookie_exchange_state(const secure_vector<uint8_t>& record, Record_Type record_type);
@@ -211,6 +218,13 @@ class Channel_Impl_12 : public Channel_Impl {
          Connection_Cipher_State* cipher_state, uint16_t epoch, Record_Type type, const uint8_t input[], size_t length);
 
       void reset_state();
+
+      // Collect the handles this connection's session is cached under, clearing
+      // the tracked one. Separate from the removal so that the caller can
+      // destroy the connection state first; see invalidate_sessions.
+      std::vector<Session_Handle> take_sessions_to_invalidate();
+
+      void invalidate_sessions(const std::vector<Session_Handle>& handles);
 
       Connection_Sequence_Numbers& sequence_numbers() const;
 
@@ -247,6 +261,9 @@ class Channel_Impl_12 : public Channel_Impl {
 
       /* pending handshake state (null when no handshake is in progress) */
       std::unique_ptr<Handshake_State> m_pending_state;
+
+      /* handle under which this connection's session is cached, if any */
+      std::optional<Session_Handle> m_resumption_handle;
 
       // Epochs in force when the pending handshake began. Whether either has
       // moved decides if an abandoned handshake can be discarded or has to
@@ -287,6 +304,14 @@ class Channel_Impl_12 : public Channel_Impl {
       secure_vector<uint8_t> m_record_buf;
 
       bool m_has_been_closed;
+
+      // Set when a fatal alert was sent or received, which unlike close_notify
+      // destroys the connection state outright.
+      bool m_had_fatal_alert = false;
+
+      // Set when the peer sent close_notify, as opposed to us closing. Only
+      // then is later data from the peer something to ignore rather than reject.
+      bool m_peer_closed_connection = false;
 
       std::optional<Active_Connection_State_12> m_active_state;
       // TODO(Botan4) remember to remove this when renegotiation support is dropped

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -798,6 +798,8 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
          }
       }
 
+      note_resumption_handle(handle);
+
       activate_session();
    } else {
       throw Unexpected_Message("Unknown handshake message received");

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -54,6 +54,8 @@ class Client_Handshake_State_12 final : public Handshake_State {
 
       void mark_as_renegotiation() { m_is_reneg = true; }
 
+      size_t note_hello_verify_request() { return ++m_hello_verify_requests; }
+
       const secure_vector<uint8_t>& resume_master_secret() const {
          BOTAN_STATE_CHECK(is_a_resumption());
          return m_resumed_session->master_secret();
@@ -90,6 +92,7 @@ class Client_Handshake_State_12 final : public Handshake_State {
       // Used during session resumption
       std::optional<Session> m_resumed_session;
       bool m_is_reneg = false;
+      size_t m_hello_verify_requests = 0;
 };
 
 }  // namespace
@@ -292,6 +295,22 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
    }
 
    if(type == Handshake_Type::HelloVerifyRequest) {
+      // RFC 6347 4.2.1 requires tolerating more than one: "This may result in
+      // clients receiving multiple HelloVerifyRequest messages with different
+      // cookies. Clients SHOULD handle this by sending a new ClientHello with a
+      // cookie in response to the new HelloVerifyRequest."
+      //
+      // Each one makes us re-send the ClientHello, and a HelloVerifyRequest is
+      // unauthenticated epoch-zero data that resets the retransmission counter,
+      // so an unbounded stream of forged ones would have us flood the server
+      // indefinitely. Bound how many we will act on.
+      const size_t hello_verify_requests = state.note_hello_verify_request();
+      const size_t max_hello_verify_requests = policy().dtls_maximum_hello_verify_requests();
+
+      if(max_hello_verify_requests > 0 && hello_verify_requests > max_hello_verify_requests) {
+         throw TLS_Exception(Alert::UnexpectedMessage, "Too many DTLS HelloVerifyRequest messages");
+      }
+
       state.set_expected_next(Handshake_Type::ServerHello);
       state.set_expected_next(Handshake_Type::HelloVerifyRequest);  // might get it again
 

--- a/src/lib/tls/tls12/tls_connection_state_12.h
+++ b/src/lib/tls/tls12/tls_connection_state_12.h
@@ -82,8 +82,6 @@ class Active_Connection_State_12 final {
        */
       Datagram_Handshake_IO* dtls_handshake_io() { return m_dtls_handshake_io.get(); }
 
-      const Datagram_Handshake_IO* dtls_handshake_io() const { return m_dtls_handshake_io.get(); }
-
    private:
       Protocol_Version m_version;
       uint16_t m_ciphersuite_code = 0;

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -19,8 +19,6 @@ namespace Botan::TLS {
 
 namespace {
 
-constexpr size_t DTLS_HANDSHAKE_HEADER_SIZE = 12;
-
 inline size_t load_be24(const uint8_t q[3]) {
    return make_uint32(0, q[0], q[1], q[2]);
 }
@@ -142,6 +140,20 @@ std::vector<uint8_t> Stream_Handshake_IO::send(const Handshake_Message& msg) {
    return buf;
 }
 
+namespace {
+
+size_t max_pending_reassembly(size_t policy_hs_max) {
+   constexpr size_t overall_cap = 1024 * 1024;  // arbitrary
+
+   if(policy_hs_max == 0) {
+      return overall_cap;
+   } else {
+      return std::min<size_t>(policy_hs_max * 4, overall_cap);
+   }
+}
+
+}  // namespace
+
 Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              steady_clock_fn steady_clock_ms,
                                              class Connection_Sequence_Numbers& seq,
@@ -159,7 +171,8 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
       m_send_hs(std::move(writer)),
       m_steady_clock_ms(std::move(steady_clock_ms)),
       m_mtu(mtu),
-      m_max_handshake_msg_size(max_handshake_msg_size) {}
+      m_max_handshake_msg_size(max_handshake_msg_size),
+      m_max_pending_reassembly(max_pending_reassembly(m_max_handshake_msg_size)) {}
 
 Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
    return Protocol_Version::DTLS_V12;
@@ -300,18 +313,77 @@ bool Datagram_Handshake_IO::reassemble_retransmitted_fragment(const uint8_t frag
    auto [i, inserted] = m_retransmitted_messages.try_emplace(msg_type, message_seq, Handshake_Reassembly{});
 
    if(!inserted && i->second.first != message_seq) {
+      release_reassembly_bytes(i->second.second);
       i->second = std::make_pair(message_seq, Handshake_Reassembly());
    }
 
    auto& reassembly = i->second.second;
-   reassembly.add_fragment(fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+
+   // These buffers hold unauthenticated input, so they are charged against the
+   // same budget as the main reassembly path rather than growing on their own.
+   if(!charged_add_fragment(reassembly,
+                            m_max_pending_reassembly,
+                            fragment,
+                            fragment_length,
+                            fragment_offset,
+                            epoch,
+                            msg_type,
+                            msg_length)) {
+      return false;
+   }
 
    if(!reassembly.complete()) {
       return false;
    }
 
+   release_reassembly_bytes(reassembly);
    m_retransmitted_messages.erase(i);
    return true;
+}
+
+bool Datagram_Handshake_IO::charged_add_fragment(Handshake_Reassembly& reassembly,
+                                                 size_t ceiling,
+                                                 const uint8_t fragment[],
+                                                 size_t fragment_length,
+                                                 size_t fragment_offset,
+                                                 uint16_t epoch,
+                                                 Handshake_Type msg_type,
+                                                 size_t msg_length) {
+   // Preflight the merge so overlap with already-buffered segments is not
+   // charged twice: near the ceiling, a whole-message retransmission landing
+   // on top of a partially received copy must stay admissible.
+   const size_t charged_before = reassembly.charged_bytes();
+   const size_t charged_after = reassembly.charged_bytes_after_add(fragment_length, fragment_offset);
+   BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= charged_before);
+   if(m_pending_reassembly_bytes - charged_before + charged_after > ceiling) {
+      return false;
+   }
+
+   try {
+      reassembly.add_fragment(fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+   } catch(...) {
+      recharge_reassembly_bytes(charged_before, reassembly);
+      throw;
+   }
+   recharge_reassembly_bytes(charged_before, reassembly);
+   return true;
+}
+
+void Datagram_Handshake_IO::release_reassembly_bytes(const Handshake_Reassembly& reassembly) {
+   BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= reassembly.charged_bytes());
+   m_pending_reassembly_bytes -= reassembly.charged_bytes();
+}
+
+void Datagram_Handshake_IO::recharge_reassembly_bytes(size_t charged_before, const Handshake_Reassembly& reassembly) {
+   const size_t charged_after = reassembly.charged_bytes();
+
+   if(charged_after >= charged_before) {
+      m_pending_reassembly_bytes += charged_after - charged_before;
+   } else {
+      const size_t refund = charged_before - charged_after;
+      BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= refund);
+      m_pending_reassembly_bytes -= refund;
+   }
 }
 
 bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fragment[],
@@ -335,11 +407,20 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
    if(msg_type == Handshake_Type::ClientHello) {
       if(!retransmitted_flight && m_awaiting_cookie_client_hello) {
          if(!m_retransmitted_client_hello.has_value() || m_retransmitted_client_hello->first != message_seq) {
+            if(m_retransmitted_client_hello.has_value()) {
+               release_reassembly_bytes(m_retransmitted_client_hello->second);
+            }
             m_retransmitted_client_hello = std::make_pair(message_seq, Handshake_Reassembly());
          }
 
-         m_retransmitted_client_hello->second.add_fragment(
-            fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+         charged_add_fragment(m_retransmitted_client_hello->second,
+                              m_max_pending_reassembly,
+                              fragment,
+                              fragment_length,
+                              fragment_offset,
+                              epoch,
+                              msg_type,
+                              msg_length);
          return false;
       }
 
@@ -449,45 +530,14 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
          throw Decoding_Error("Bad lengths in DTLS header");
       }
 
-      // Bound the out-of-order reassembly window.
-      constexpr uint16_t reassembly_window = 16;
-
-      // Independently cap total bytes committed to in-flight reassembly slots
-      const size_t max_pending = 4 * m_max_handshake_msg_size;
-
-      if(message_seq >= m_in_message_seq && (message_seq - m_in_message_seq) < reassembly_window) {
-         if(retransmitted_flight) {
-            if(fragment_length == 0) {
-               record += total_size;
-               record_len -= total_size;
-               continue;
-            }
-
-            throw TLS_Exception(Alert::UnexpectedMessage, "Unexpected new DTLS handshake message");
-         }
-
-         auto [it, inserted] = m_messages.try_emplace(message_seq);
-         if(inserted) {
-            if(m_max_handshake_msg_size > 0 && m_pending_reassembly_bytes + msg_len > max_pending) {
-               m_messages.erase(it);
-               record += total_size;
-               record_len -= total_size;
-               continue;
-            }
-            m_pending_reassembly_bytes += msg_len;
-         }
-         it->second.add_fragment(
-            &record[DTLS_HANDSHAKE_HEADER_SIZE], fragment_length, fragment_offset, epoch, msg_type, msg_len);
-      } else {
-         retransmit_response |= process_previous_handshake_fragment(&record[DTLS_HANDSHAKE_HEADER_SIZE],
-                                                                    fragment_length,
-                                                                    fragment_offset,
-                                                                    epoch,
-                                                                    msg_type,
-                                                                    msg_len,
-                                                                    message_seq,
-                                                                    retransmitted_flight);
-      }
+      retransmit_response |= process_handshake_fragment(&record[DTLS_HANDSHAKE_HEADER_SIZE],
+                                                        fragment_length,
+                                                        fragment_offset,
+                                                        epoch,
+                                                        msg_type,
+                                                        msg_len,
+                                                        message_seq,
+                                                        retransmitted_flight);
 
       record += total_size;
       record_len -= total_size;
@@ -496,6 +546,73 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
    if(retransmit_response && (!m_finished || m_retransmit_terminal_flight)) {
       retransmit_last_flight();
    }
+}
+
+bool Datagram_Handshake_IO::process_handshake_fragment(const uint8_t fragment[],
+                                                       size_t fragment_length,
+                                                       size_t fragment_offset,
+                                                       uint16_t epoch,
+                                                       Handshake_Type msg_type,
+                                                       size_t msg_length,
+                                                       uint16_t message_seq,
+                                                       bool retransmitted_flight) {
+   // Bound the out-of-order reassembly window.
+   constexpr uint16_t reassembly_window = 16;
+
+   // An empty fragment for a non-empty message is garbage, just drop it.
+   if(fragment_length == 0 && msg_length > 0) {
+      return false;
+   }
+
+   if(message_seq < m_in_message_seq) {
+      return process_previous_handshake_fragment(
+         fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq, retransmitted_flight);
+   }
+
+   // Beyond the reassembly window is not a retransmission of anything we
+   // have seen, so it must not be able to pull a flight replay out of us.
+   // Drop it silently: the sender has proven nothing at this point.
+   if((message_seq - m_in_message_seq) >= reassembly_window) {
+      return false;
+   }
+
+   if(retransmitted_flight) {
+      if(fragment_length == 0) {
+         return false;
+      }
+
+      throw TLS_Exception(Alert::UnexpectedMessage, "Unexpected new DTLS handshake message");
+   }
+
+   // Charge the reassembly budget by bytes actually committed, not by
+   // the claimed msg_length. Otherwise an attacker can lock the full
+   // budget by sending small (e.g. fragment_length=1) fragments with
+   // a large claimed msg_length, displacing legitimate handshake
+   // messages.
+   // Reserve headroom for the message actually being waited on. Otherwise
+   // fragments for the fifteen slots beyond it can consume the whole
+   // budget, after which every fragment of the expected message is
+   // silently dropped and the handshake cannot proceed.
+   const size_t ceiling = (message_seq == m_in_message_seq) ? m_max_pending_reassembly : m_max_pending_reassembly / 2;
+
+   auto [it, inserted] = m_messages.try_emplace(message_seq);
+
+   bool accepted = false;
+   try {
+      accepted = charged_add_fragment(
+         it->second, ceiling, fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+   } catch(...) {
+      if(inserted) {
+         m_messages.erase(it);
+      }
+      throw;
+   }
+
+   if(!accepted && inserted) {
+      m_messages.erase(it);
+   }
+
+   return false;
 }
 
 std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_record(bool expecting_ccs,
@@ -519,6 +636,7 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
 
    if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
       auto result = m_retransmitted_client_hello->second.message();
+      release_reassembly_bytes(m_retransmitted_client_hello->second);
       m_retransmitted_client_hello.reset();
       m_recreating_hello_verify_request = true;
       return result;
@@ -531,6 +649,7 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
    }
 
    m_in_message_seq += 1;
+   m_any_message_delivered = true;
 
    auto result = i->second.message();
 
@@ -542,18 +661,36 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
    // bytes against the cap. The entry itself stays in m_messages because
    // the expecting_ccs branch above uses m_messages.begin()->second.epoch()
    // as an epoch-0 sentinel; it only needs the metadata, not the buffers.
-   BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= i->second.msg_length());
-   m_pending_reassembly_bytes -= i->second.msg_length();
+   release_reassembly_bytes(i->second);
    i->second.release_buffers();
+
+   // May erase the entry i refers to, so nothing below may use it.
+   prune_delivered_messages();
 
    return result;
 }
 
+void Datagram_Handshake_IO::prune_delivered_messages() {
+   // Delivered slots are retained only so that the expecting_ccs branch above
+   // can read an epoch from m_messages.begin(). Keeping one per delivered
+   // message let unauthenticated input retain a map node apiece, none of it
+   // charged against the reassembly budget, so all but the lowest are dropped.
+   auto i = m_messages.begin();
+
+   if(i == m_messages.end()) {
+      return;
+   }
+
+   ++i;
+
+   while(i != m_messages.end() && i->second.delivered()) {
+      i = m_messages.erase(i);
+   }
+}
+
 void Datagram_Handshake_IO::Handshake_Reassembly::release_buffers() {
-   m_received_mask.clear();
-   m_received_mask.shrink_to_fit();
-   m_message.clear();
-   m_message.shrink_to_fit();
+   m_segments.clear();
+   m_delivered = true;
 }
 
 void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fragment[],
@@ -567,15 +704,20 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
       m_epoch = epoch;
       m_msg_type = msg_type;
       m_msg_length = msg_length;
-      m_message.resize(msg_length);
-      m_received_mask.assign(msg_length, 0);
    } else {
-      if(msg_type != m_msg_type || msg_length != m_msg_length || epoch != m_epoch) {
-         throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
+      // A delivered slot is a post-delivery sentinel kept for the expecting_ccs
+      // branch; drop the fragment cheaply before running the per-fragment-header
+      // consistency check. Otherwise a stray retransmission whose msg_length
+      // field was rewritten in transit (or spoofed by an attacker for any
+      // message_seq < m_in_message_seq) would throw Decoding_Error and tear down
+      // the connection -- but post-delivery, no header check is meaningful since
+      // the storage buffers are already released.
+      if(m_delivered || complete()) {
+         return;  // already have entire message, ignore this
       }
 
-      if(complete()) {
-         return;  // already have entire message, ignore this
+      if(msg_type != m_msg_type || msg_length != m_msg_length || epoch != m_epoch) {
+         throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
       }
    }
 
@@ -587,26 +729,101 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
       throw Decoding_Error("Fragment overlaps past end of message");
    }
 
-   BOTAN_ASSERT_NOMSG(m_received_mask.size() == m_msg_length);
+   if(fragment_length == 0) {
+      return;
+   }
 
-   for(size_t i = 0; i != fragment_length; ++i) {
-      const size_t off = fragment_offset + i;
-      if(m_received_mask[off] != 0) {
-         // RFC 6347 4.2.3 permits overlapping retransmissions, but the
-         // overlapping bytes must agree.
-         if(m_message[off] != fragment[i]) {
-            throw Decoding_Error("Inconsistent overlapping DTLS handshake fragment");
-         }
-      } else {
-         m_message[off] = fragment[i];
-         m_received_mask[off] = 1;
-         ++m_bytes_received;
+   const size_t new_start = fragment_offset;
+   const size_t new_end = fragment_offset + fragment_length;
+
+   // Find the first existing segment that touches or overlaps [new_start,...].
+   auto it = m_segments.lower_bound(new_start);
+   if(it != m_segments.begin()) {
+      auto prev = std::prev(it);
+      if(prev->first + prev->second.size() >= new_start) {
+         it = prev;
       }
    }
+
+   // Walk forward through every segment that overlaps or is adjacent to the
+   // (potentially-growing) merged span. RFC 6347 4.2.3: "DTLS implementations
+   // MUST be able to handle overlapping fragment ranges." Requiring the
+   // overlapping bytes to agree is ours, not the RFC's: disagreement means one
+   // of the two copies is corrupt or forged.
+   size_t merged_start = new_start;
+   size_t merged_end = new_end;
+   size_t existing_bytes = 0;
+   const auto first_to_merge = it;
+   while(it != m_segments.end() && it->first <= merged_end) {
+      const size_t seg_start = it->first;
+      const size_t seg_end = seg_start + it->second.size();
+
+      const size_t ov_start = std::max(seg_start, new_start);
+      const size_t ov_end = std::min(seg_end, new_end);
+      for(size_t i = ov_start; i < ov_end; ++i) {
+         if(it->second[i - seg_start] != fragment[i - new_start]) {
+            throw Decoding_Error("Inconsistent overlapping DTLS handshake fragment");
+         }
+      }
+
+      merged_start = std::min(merged_start, seg_start);
+      merged_end = std::max(merged_end, seg_end);
+      existing_bytes += it->second.size();
+      ++it;
+   }
+
+   std::vector<uint8_t> merged(merged_end - merged_start);
+   for(auto i = first_to_merge; i != it; ++i) {
+      std::copy(i->second.begin(), i->second.end(), merged.begin() + (i->first - merged_start));
+   }
+   std::copy(fragment, fragment + fragment_length, merged.begin() + (new_start - merged_start));
+   m_segments.erase(first_to_merge, it);
+   m_segments.emplace(merged_start, std::move(merged));
+
+   m_bytes_received += (merged_end - merged_start) - existing_bytes;
+}
+
+size_t Datagram_Handshake_IO::Handshake_Reassembly::charged_bytes_after_add(size_t fragment_length,
+                                                                            size_t fragment_offset) const {
+   // The early-out and merge-walk structure must match add_fragment above.
+   if(m_delivered || complete() || fragment_length == 0) {
+      return charged_bytes();
+   }
+
+   const size_t new_start = fragment_offset;
+   const size_t new_end = fragment_offset + fragment_length;
+
+   auto it = m_segments.lower_bound(new_start);
+   if(it != m_segments.begin()) {
+      auto prev = std::prev(it);
+      if(prev->first + prev->second.size() >= new_start) {
+         it = prev;
+      }
+   }
+
+   size_t merged_start = new_start;
+   size_t merged_end = new_end;
+   size_t existing_bytes = 0;
+   size_t merged_segments = 0;
+   while(it != m_segments.end() && it->first <= merged_end) {
+      merged_start = std::min(merged_start, it->first);
+      merged_end = std::max(merged_end, it->first + it->second.size());
+      existing_bytes += it->second.size();
+      ++merged_segments;
+      ++it;
+   }
+
+   const size_t merged_payload = m_bytes_received + (merged_end - merged_start) - existing_bytes;
+   const size_t segments_after = m_segments.size() - merged_segments + 1;
+   return merged_payload + SEGMENT_OVERHEAD * segments_after;
 }
 
 bool Datagram_Handshake_IO::Handshake_Reassembly::complete() const {
-   return (m_msg_type != Handshake_Type::None && m_bytes_received == m_msg_length);
+   // A delivered slot keeps its metadata but no longer has the bytes, so it
+   // must not claim to be complete: message() would fail its own invariant and
+   // have_more_data() would report trailing data that is not there. Reachable
+   // once message_seq wraps back onto a slot already delivered.
+   return (!m_delivered && m_msg_type != Handshake_Type::None && m_bytes_received == m_msg_length);
 }
 
 std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::Handshake_Reassembly::message() const {
@@ -614,7 +831,16 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::Handshake
       throw Internal_Error("Datagram_Handshake_IO - message not complete");
    }
 
-   return std::make_pair(m_msg_type, m_message);
+   if(m_msg_length == 0) {
+      return std::make_pair(m_msg_type, std::vector<uint8_t>());
+   }
+
+   // Eager merging guarantees a single segment spanning [0, m_msg_length)
+   // once bytes_received == m_msg_length.
+   BOTAN_ASSERT_NOMSG(m_segments.size() == 1);
+   const auto& only = *m_segments.begin();
+   BOTAN_ASSERT_NOMSG(only.first == 0 && only.second.size() == m_msg_length);
+   return std::make_pair(m_msg_type, only.second);
 }
 
 std::vector<uint8_t> Datagram_Handshake_IO::format_fragment(const uint8_t fragment[],
@@ -648,8 +874,14 @@ std::vector<uint8_t> Datagram_Handshake_IO::format_w_seq(const std::vector<uint8
 }
 
 std::vector<uint8_t> Datagram_Handshake_IO::format(const std::vector<uint8_t>& msg, Handshake_Type type) const {
-   BOTAN_ASSERT_NOMSG(m_in_message_seq > 0);
-   return format_w_seq(msg, type, m_in_message_seq - 1);
+   // Formats the message just delivered, so the guard is that one exists, not
+   // that the counter is non-zero. Those differ once m_in_message_seq wraps,
+   // which unauthenticated ClientHellos can drive: the cookie exchange is
+   // supposed to be stateless but its pending state survives, and each attempt
+   // advances the counter. The subtraction then wraps to 65535 of its own
+   // accord, which is the right sequence number for that message.
+   BOTAN_ASSERT_NOMSG(m_any_message_delivered);
+   return format_w_seq(msg, type, static_cast<uint16_t>(m_in_message_seq - 1));
 }
 
 std::vector<uint8_t> Datagram_Handshake_IO::send(const Handshake_Message& msg) {

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -19,6 +19,11 @@ namespace Botan::TLS {
 
 namespace {
 
+// Bound on peer-cued flight replays when the policy leaves the timer's own
+// retransmission count unlimited. Matches the default of
+// Policy::dtls_maximum_retransmissions.
+constexpr size_t DEFAULT_PEER_REPLAY_BUDGET = 12;
+
 // How many ClientHellos a server will take before it commits to a handshake by
 // sending a flight. The exchange RFC 6347 4.2.1 describes needs two; the rest
 // absorb a cookie secret rotation. Each one advances the expected sequence, so
@@ -190,12 +195,58 @@ Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
    return Protocol_Version::DTLS_V12;
 }
 
-void Datagram_Handshake_IO::retransmit_last_flight() {
+std::optional<size_t> Datagram_Handshake_IO::last_completed_flight_index() const {
    // m_flights keeps an empty trailing slot while waiting for the peer, so the
    // last completed flight is normally the one before it.
    const size_t flight_idx = (m_flights.size() == 1) ? 0 : (m_flights.size() - 2);
-   retransmit_flight(flight_idx);
-   m_last_write = m_steady_clock_ms();
+
+   // A peer can ask us to replay a flight before we have sent one, eg with a
+   // ClientHello whose message_seq is past the reassembly window. There is
+   // nothing to retransmit and retransmit_flight would assert.
+   if(m_flights[flight_idx].empty()) {
+      return std::nullopt;
+   }
+
+   return flight_idx;
+}
+
+void Datagram_Handshake_IO::retransmit_last_flight() {
+   if(const auto flight_idx = last_completed_flight_index()) {
+      retransmit_flight(*flight_idx);
+      m_last_write = m_steady_clock_ms();
+   }
+}
+
+/*
+* RFC 6347 4.2.4 gives the WAITING state a "read retransmit" transition that
+* replays our flight when the peer retransmits theirs.
+*
+* The cue for it is unauthenticated epoch-zero data, so this deliberately is not
+* retransmit_last_flight(). Re-anchoring m_last_write the way that does means a
+* peer cueing faster than the timeout keeps next_retransmission_timeout() from
+* ever expiring, so m_retransmit_count never advances and the handshake never
+* gives up; and unbounded, each cue draws a whole flight toward whatever address
+* the cue claims to come from.
+*
+* Spending the timer's own budget, reset by the same forward progress, caps a
+* continuously cueing peer at doubling the flight traffic the handshake would
+* emit anyway. Counting rather than rate limiting answers a legitimate peer's
+* retransmit promptly, which BoGo's DTLS-Retransmit-Client-Basic requires.
+*/
+void Datagram_Handshake_IO::replay_last_flight_for_peer() {
+   // An unset m_max_retransmissions means "retransmit on my own timer forever",
+   // which is a different proposition from "replay whenever an unauthenticated
+   // packet asks me to". This path is never unbounded, whatever the policy.
+   const size_t bound = m_max_retransmissions.value_or(DEFAULT_PEER_REPLAY_BUDGET);
+
+   if(m_peer_replay_count >= bound) {
+      return;
+   }
+
+   if(const auto flight_idx = last_completed_flight_index()) {
+      m_peer_replay_count += 1;
+      retransmit_flight(*flight_idx);
+   }
 }
 
 void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx) {
@@ -224,10 +275,6 @@ void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx) {
 }
 
 bool Datagram_Handshake_IO::have_more_data() const {
-   if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
-      return true;
-   }
-
    // Future or incomplete fragments remain buffered, but only a complete
    // next-in-sequence message is trailing handshake data. A buffered duplicate
    // ClientHello is not: it carries nothing the peer has not already sent, and
@@ -245,8 +292,9 @@ void Datagram_Handshake_IO::finalize_handshake(bool retransmit_terminal_flight) 
       m_flight_ccs.emplace_back();
    }
 
-   // RFC 6347 4.2.4 transitions directly to FINISHED after sending the
-   // terminal flight. Keep the flight for reactive replay when the peer
+   // RFC 6347 4.2.4: "Once the messages have been sent, the implementation
+   // then enters the FINISHED state if this is the last flight in the
+   // handshake." Keep the flight for reactive replay when the peer
    // retransmits, but do not arm a proactive retransmission timer.
    m_finished = true;
    m_retransmit_terminal_flight = retransmit_terminal_flight;
@@ -446,39 +494,41 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
          return false;
       }
 
+      // RFC 6347 4.2.4 makes the terminal-flight sender "respond to a retransmit
+      // of the peer's last flight with a retransmit of the last flight". Once our
+      // handshake has completed, the peer's last flight is the one ending in its
+      // Finished, never a ClientHello: a peer still retransmitting its
+      // ClientHello cannot have sent the flight that completed us. So a
+      // ClientHello arriving now is spurious, and answering it would let
+      // unauthenticated epoch-zero input draw a flight out of us without limit.
+      // The Finished-based cue below still covers the case this protects.
+      if(m_finished) {
+         return false;
+      }
+
       return reassemble_retransmitted_fragment(
          fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq);
    }
 
-   // Other previous-flight messages request an immediate response only after
-   // the handshake IO was retained by an active association. While pending,
-   // the normal retransmission timer handles recovery.
+   // Only an association that has already completed its handshake answers a
+   // retransmitted peer flight here.
+   //
+   // RFC 6347 4.2.4 also gives the WAITING state a "read retransmit" exit that
+   // replays the outgoing flight immediately. Applying that while the handshake
+   // is still pending misfires under fragment reordering: a late duplicate
+   // fragment of an already-consumed message is indistinguishable from a
+   // genuine retransmission, so the peer sees a flight replay it never asked
+   // for (BoGo ReorderHandshakeFragments-Large). Recovery is left to the local
+   // retransmission timer, which costs latency but cannot desynchronise a peer
+   // that was not retransmitting. A retransmitted ClientHello is handled above,
+   // because the stateless cookie response has no timer of its own.
    if(!retransmitted_flight) {
       return false;
    }
 
-   if(msg_type == Handshake_Type::ServerHello) {
-      m_retransmitted_server_hello_complete = reassemble_retransmitted_fragment(
-         fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq);
-
-      if(m_retransmitted_server_hello_complete && m_retransmitted_server_hello_done_complete) {
-         m_retransmitted_server_hello_complete = false;
-         m_retransmitted_server_hello_done_complete = false;
-         return true;
-      }
-   } else if(msg_type == Handshake_Type::ServerHelloDone && msg_length == 0) {
-      if(reassemble_retransmitted_fragment(
-            fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
-         m_retransmitted_server_hello_done_complete = true;
-         if(m_retransmitted_server_hello_complete) {
-            m_retransmitted_server_hello_complete = false;
-            m_retransmitted_server_hello_done_complete = false;
-            return true;
-         }
-      }
-   } else if(msg_type == Handshake_Type::Finished &&
-             reassemble_retransmitted_fragment(
-                fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
+   if(msg_type == Handshake_Type::Finished &&
+      reassemble_retransmitted_fragment(
+         fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
       // A final-flight retransmission includes CCS, but UDP may deliver its
       // records in either order. Wait until both have been observed.
       if(m_retransmitted_ccs_epoch == epoch) {
@@ -486,6 +536,10 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
          return true;
       }
 
+      // Only the matching pair means anything, so a half seen for some other
+      // epoch is stale. Leaving it set would keep this armed indefinitely for an
+      // epoch an attacker chose, since epoch-zero CCS records are unauthenticated.
+      m_retransmitted_ccs_epoch.reset();
       m_retransmitted_finished_epoch = epoch;
    }
 
@@ -498,6 +552,15 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
                                        uint64_t record_sequence,
                                        bool retransmitted_flight) {
    const uint16_t epoch = static_cast<uint16_t>(record_sequence >> 48);
+
+   // A record under a non-zero epoch authenticated at the record layer, so the
+   // peer is live and is who it claims to be. Restore the peer-cued replay
+   // budget: RFC 6347 4.2.4 requires the terminal-flight sender to answer a
+   // retransmit of the peer's last flight for as long as the association lasts,
+   // and the retained IO never sends a new flight to reset the count otherwise.
+   if(epoch > 0) {
+      m_peer_replay_count = 0;
+   }
 
    if(record_type == Record_Type::ChangeCipherSpec) {
       if(record_len != 1 || record[0] != 1) {
@@ -514,9 +577,10 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
          if(m_retransmitted_finished_epoch == finished_epoch) {
             m_retransmitted_finished_epoch.reset();
             if(m_retransmit_terminal_flight) {
-               retransmit_last_flight();
+               replay_last_flight_for_peer();
             }
          } else {
+            m_retransmitted_finished_epoch.reset();
             m_retransmitted_ccs_epoch = finished_epoch;
          }
       }
@@ -566,7 +630,7 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
    }
 
    if(retransmit_response && (!m_finished || m_retransmit_terminal_flight)) {
-      retransmit_last_flight();
+      replay_last_flight_for_peer();
    }
 }
 
@@ -1051,7 +1115,7 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
    }
 
    m_flights.rbegin()->push_back(m_out_message_seq);
-   m_flight_data.emplace(m_out_message_seq, Message_Info(epoch, msg_type, msg_bits));
+   m_flight_data.insert_or_assign(m_out_message_seq, Message_Info(epoch, msg_type, msg_bits));
 
    m_out_message_seq += 1;
    m_last_write = m_steady_clock_ms();
@@ -1059,6 +1123,7 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
    // Sending a new flight is forward progress: reset the give-up counter so the
    // retransmission budget applies per flight, not across the whole handshake.
    m_retransmit_count = 0;
+   m_peer_replay_count = 0;
 
    return send_message(m_out_message_seq - 1, epoch, msg_type, msg_bits);
 }

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -19,6 +19,13 @@ namespace Botan::TLS {
 
 namespace {
 
+// How many ClientHellos a server will take before it commits to a handshake by
+// sending a flight. The exchange RFC 6347 4.2.1 describes needs two; the rest
+// absorb a cookie secret rotation. Each one advances the expected sequence, so
+// this is also what keeps that counter from being driven around by
+// unauthenticated input.
+constexpr uint16_t MAX_PRE_COMMIT_CLIENT_HELLOS = 8;
+
 inline size_t load_be24(const uint8_t q[3]) {
    return make_uint32(0, q[0], q[1], q[2]);
 }
@@ -161,7 +168,8 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              uint64_t initial_timeout_ms,
                                              uint64_t max_timeout_ms,
                                              std::optional<size_t> max_retransmissions,
-                                             size_t max_handshake_msg_size) :
+                                             size_t max_handshake_msg_size,
+                                             bool is_server) :
       m_seqs(seq),
       m_flights(1),
       m_flight_ccs(1),
@@ -172,7 +180,8 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
       m_steady_clock_ms(std::move(steady_clock_ms)),
       m_mtu(mtu),
       m_max_handshake_msg_size(max_handshake_msg_size),
-      m_max_pending_reassembly(max_pending_reassembly(m_max_handshake_msg_size)) {}
+      m_max_pending_reassembly(max_pending_reassembly(m_max_handshake_msg_size)),
+      m_is_server(is_server) {}
 
 Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
    return Protocol_Version::DTLS_V12;
@@ -217,7 +226,9 @@ bool Datagram_Handshake_IO::have_more_data() const {
    }
 
    // Future or incomplete fragments remain buffered, but only a complete
-   // next-in-sequence message is trailing handshake data.
+   // next-in-sequence message is trailing handshake data. A buffered duplicate
+   // ClientHello is not: it carries nothing the peer has not already sent, and
+   // get_next_record only reaches for it when there is no in-sequence message.
    const auto next = m_messages.find(m_in_message_seq);
    return next != m_messages.end() && next->second.complete();
 }
@@ -405,6 +416,14 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
    // retransmitted initial ClientHello back to the server handshake logic so
    // it can recreate the stateless cookie response instead.
    if(msg_type == Handshake_Type::ClientHello) {
+      // A declared length this short cannot be a real ClientHello, so it cannot
+      // be a retransmission of one. Without this a bare 12-byte handshake
+      // header claiming msg_length 0 counts as a fully reassembled message and
+      // buys a whole flight replay.
+      if(msg_length < Datagram_Handshake_IO::MIN_CLIENT_HELLO_SIZE) {
+         return false;
+      }
+
       if(!retransmitted_flight && m_awaiting_cookie_client_hello) {
          if(!m_retransmitted_client_hello.has_value() || m_retransmitted_client_hello->first != message_seq) {
             if(m_retransmitted_client_hello.has_value()) {
@@ -576,6 +595,31 @@ bool Datagram_Handshake_IO::process_handshake_fragment(const uint8_t fragment[],
       return false;
    }
 
+   /*
+   RFC 6347 4.2.1 has the cookie exchange exist so that a server need not
+   allocate state before the peer's reachability is proved. Until this
+   endpoint commits to the handshake by sending a flight, the only message
+   worth keeping is the ClientHello it is waiting for.
+
+   Queueing anything else lets one spoofed datagram decide the handshake.
+   A complete zero-length message parked in a future slot survives into the
+   real handshake, where have_more_data() reads it as trailing handshake
+   data and the server answers the legitimate client with a fatal alert.
+   RFC 6347 4.2.2 permits queueing a future message but equally permits
+   discarding it, and before a cookie there is nothing to weigh against
+   the cost. Only future slots are dropped: a wrong message type at the
+   sequence actually expected is a protocol error and has to be reported
+   as one, which BoGo's WrongMessageType-ClientHello-DTLS checks.
+
+   The count bounds it in the other direction: each accepted ClientHello
+   advances the expected sequence and draws another HelloVerifyRequest, so
+   without a limit that counter can be walked all the way around.
+   */
+   if(server_awaiting_first_flight() && ((msg_type != Handshake_Type::ClientHello && message_seq != m_in_message_seq) ||
+                                         m_in_message_seq >= MAX_PRE_COMMIT_CLIENT_HELLOS)) {
+      return false;
+   }
+
    if(retransmitted_flight) {
       if(fragment_length == 0) {
          return false;
@@ -634,17 +678,23 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
       return std::make_pair(Handshake_Type::None, std::vector<uint8_t>());
    }
 
-   if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
-      auto result = m_retransmitted_client_hello->second.message();
-      release_reassembly_bytes(m_retransmitted_client_hello->second);
-      m_retransmitted_client_hello.reset();
-      m_recreating_hello_verify_request = true;
-      return result;
-   }
-
    auto i = m_messages.find(m_in_message_seq);
 
    if(i == m_messages.end() || !i->second.complete()) {
+      // Nothing in sequence to make progress with. A buffered duplicate of an
+      // earlier ClientHello is useful only here, to regenerate the stateless
+      // cookie response. It deliberately does not take priority: delivering it
+      // ahead of an in-sequence message makes that message look like trailing
+      // data to the caller's have_more_data() check, which then aborts a
+      // perfectly good handshake.
+      if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
+         auto duplicate = m_retransmitted_client_hello->second.message();
+         m_last_client_hello_msg_seq = m_retransmitted_client_hello->first;
+         release_reassembly_bytes(m_retransmitted_client_hello->second);
+         m_retransmitted_client_hello.reset();
+         return duplicate;
+      }
+
       return std::make_pair(Handshake_Type::None, std::vector<uint8_t>());
    }
 
@@ -655,6 +705,14 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
 
    if(result.first == Handshake_Type::ClientHello) {
       m_awaiting_cookie_client_hello = false;
+      m_last_client_hello_msg_seq = static_cast<uint16_t>(m_in_message_seq - 1);
+
+      // The ClientHello we were waiting for arrived, so a buffered duplicate of
+      // an earlier one has nothing left to tell us.
+      if(m_retransmitted_client_hello.has_value()) {
+         release_reassembly_bytes(m_retransmitted_client_hello->second);
+         m_retransmitted_client_hello.reset();
+      }
    }
 
    // Free the reassembly buffer for this delivered slot and uncommit its
@@ -699,6 +757,26 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
                                                                uint16_t epoch,
                                                                Handshake_Type msg_type,
                                                                size_t msg_length) {
+   /*
+   A ClientHello begins a handshake, so nothing already buffered in its slot can
+   belong to the same one. At epoch zero neither the buffered fragment nor the
+   ClientHello is authenticated, and throwing means the *ClientHello* is what
+   fails: anyone able to reach the address could plant one fragment before the
+   cookie exchange and every later handshake attempt would die on it. Start over
+   from the ClientHello instead, so a peer that retransmits can always make
+   progress. An authenticated peer contradicting itself is still an error.
+   */
+   const auto restart_for_client_hello = [&] {
+      m_epoch = epoch;
+      m_msg_type = msg_type;
+      m_msg_length = msg_length;
+      m_bytes_received = 0;
+      m_segments.clear();
+   };
+
+   const bool client_hello_supersedes_slot =
+      (msg_type == Handshake_Type::ClientHello && epoch == 0 && m_epoch == 0 && !complete());
+
    if(m_msg_type == Handshake_Type::None) {
       // First fragment for this message_seq
       m_epoch = epoch;
@@ -717,7 +795,10 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
       }
 
       if(msg_type != m_msg_type || msg_length != m_msg_length || epoch != m_epoch) {
-         throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
+         if(!client_hello_supersedes_slot) {
+            throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
+         }
+         restart_for_client_hello();
       }
    }
 
@@ -762,7 +843,12 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
       const size_t ov_end = std::min(seg_end, new_end);
       for(size_t i = ov_start; i < ov_end; ++i) {
          if(it->second[i - seg_start] != fragment[i - new_start]) {
-            throw Decoding_Error("Inconsistent overlapping DTLS handshake fragment");
+            if(!client_hello_supersedes_slot) {
+               throw Decoding_Error("Inconsistent overlapping DTLS handshake fragment");
+            }
+            restart_for_client_hello();
+            add_fragment(fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+            return;
          }
       }
 
@@ -897,12 +983,23 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
       m_send_hs(epoch, Record_Type::ChangeCipherSpec, msg_bits);
       return {};  // not included in handshake hashes
    } else if(msg_type == Handshake_Type::HelloVerifyRequest) {
-      // RFC 6347 3.2.1 explicitly excludes HelloVerifyRequest from timeout
-      // retransmission. A repeated ClientHello recreates the response using
-      // the original message sequence number without retaining a flight.
-      const uint16_t msg_seq = m_recreating_hello_verify_request ? m_out_message_seq - 1 : m_out_message_seq++;
+      // RFC 6347 3.2.1: "Note that timeout and retransmission do not apply to
+      // the HelloVerifyRequest, because this would require creating state on
+      // the server." So it is not retained as a flight, and a repeated
+      // ClientHello simply produces it again.
+      //
+      // RFC 6347 4.2.1, as corrected by erratum 5186, has it carry the
+      // message_seq of the ClientHello that triggered it. Deriving that from the
+      // outgoing counter instead breaks as soon as more than one cookie exchange
+      // has happened on the association.
+      const uint16_t msg_seq = m_last_client_hello_msg_seq.value_or(m_out_message_seq);
+
+      // The ServerHello that follows a cookie exchange takes the next sequence
+      // number (RFC 6347 4.2.2), but reissuing a HelloVerifyRequest for a
+      // repeated ClientHello must not rewind the counter.
+      m_out_message_seq = std::max<uint16_t>(m_out_message_seq, static_cast<uint16_t>(msg_seq + 1));
+
       m_awaiting_cookie_client_hello = true;
-      m_recreating_hello_verify_request = false;
       send_message(msg_seq, epoch, msg_type, msg_bits);
       return {};
    }

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -169,13 +169,16 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              uint64_t max_timeout_ms,
                                              std::optional<size_t> max_retransmissions,
                                              size_t max_handshake_msg_size,
-                                             bool is_server) :
+                                             bool is_server,
+                                             uint16_t initial_epoch) :
       m_seqs(seq),
       m_flights(1),
       m_flight_ccs(1),
       m_initial_timeout(initial_timeout_ms),
       m_max_timeout(max_timeout_ms),
       m_max_retransmissions(max_retransmissions),
+      m_initial_epoch(initial_epoch),
+      m_last_delivered_epoch(initial_epoch),
       m_send_hs(std::move(writer)),
       m_steady_clock_ms(std::move(steady_clock_ms)),
       m_mtu(mtu),
@@ -595,6 +598,32 @@ bool Datagram_Handshake_IO::process_handshake_fragment(const uint8_t fragment[],
       return false;
    }
 
+   // Epochs never decrease within a handshake, so a fragment carrying an
+   // older epoch belongs to an earlier handshake whose records were
+   // delayed into this one. Renegotiation restarts message_seq at zero,
+   // so without this such a record can occupy a slot the current
+   // handshake still needs.
+   if(epoch < m_last_delivered_epoch) {
+      return false;
+   }
+
+   /*
+   RFC 6347 4.2.2 keeps message_seq across a retransmission but gives the
+   record a new sequence number, and a rehandshake restarts message_seq at
+   zero. A delayed Finished from the previous handshake therefore arrives
+   with a plausible sequence number and, before this handshake's own
+   ChangeCipherSpec, the same epoch as its pre-CCS records, so neither the
+   sequence nor the epoch floor tells it apart. It cannot be genuine
+   though: a Finished is sent under the epoch its own ChangeCipherSpec
+   installed, which is always above the one this handshake began in.
+
+   Left in, it takes the slot the real Finished needs, and a complete slot
+   is never replaced, so verification fails against the wrong transcript.
+   */
+   if(msg_type == Handshake_Type::Finished && epoch <= m_initial_epoch) {
+      return false;
+   }
+
    /*
    RFC 6347 4.2.1 has the cookie exchange exist so that a server need not
    allocate state before the peer's reachability is proved. Until this
@@ -659,6 +688,17 @@ bool Datagram_Handshake_IO::process_handshake_fragment(const uint8_t fragment[],
    return false;
 }
 
+void Datagram_Handshake_IO::discard_stale_epoch_messages() {
+   for(auto i = m_messages.lower_bound(m_in_message_seq); i != m_messages.end();) {
+      if(i->second.epoch() < m_last_delivered_epoch) {
+         release_reassembly_bytes(i->second);
+         i = m_messages.erase(i);
+      } else {
+         ++i;
+      }
+   }
+}
+
 std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_record(bool expecting_ccs,
                                                                                        size_t /*max_message_size*/) {
    // Expecting a message means the last flight is concluded
@@ -721,6 +761,12 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
    // as an epoch-0 sentinel; it only needs the metadata, not the buffers.
    release_reassembly_bytes(i->second);
    i->second.release_buffers();
+
+   const uint16_t delivered_epoch = i->second.epoch();
+   if(delivered_epoch > m_last_delivered_epoch) {
+      m_last_delivered_epoch = delivered_epoch;
+      discard_stale_epoch_messages();
+   }
 
    // May erase the entry i refers to, so nothing below may use it.
    prune_delivered_messages();

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -124,6 +124,12 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // Lambda pointing to clock function (normally TLS::Callbacks::tls_current_monotonic_clock_ms)
       using steady_clock_fn = std::function<uint64_t()>;
 
+      // client_version(2) + random(32) + session_id length(1) + cookie length(1)
+      // + cipher_suites length(2) + one suite(2) + compression_methods
+      // length(1) + one method(1). RFC 6347 4.2.1 gives the DTLS ClientHello
+      // layout. A shorter declared length cannot be a real ClientHello.
+      static constexpr size_t MIN_CLIENT_HELLO_SIZE = 42;
+
       // msg_type(1) + length(3) + message_seq(2) + fragment_offset(3) +
       // fragment_length(3)
       static constexpr size_t DTLS_HANDSHAKE_HEADER_SIZE = 12;
@@ -135,7 +141,8 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                             uint64_t initial_timeout_ms,
                             uint64_t max_timeout_ms,
                             std::optional<size_t> max_retransmissions,
-                            size_t max_handshake_msg_size);
+                            size_t max_handshake_msg_size,
+                            bool is_server = false);
 
       Protocol_Version initial_record_version() const override;
 
@@ -170,6 +177,11 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       * requested. The terminal-flight sender retains reactive replay behavior.
       */
       void finalize_handshake(bool retransmit_terminal_flight);
+
+      // Sequence number of the next handshake message to be delivered upward.
+      // Zero until at least one full message has been reassembled and consumed
+      // by get_next_record.
+      uint16_t in_message_seq() const { return m_in_message_seq; }
 
    private:
       void add_record(const uint8_t record[],
@@ -212,6 +224,15 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // Drop delivered reassembly slots, keeping the lowest as the epoch
       // sentinel the expecting_ccs branch of get_next_record reads.
       void prune_delivered_messages();
+
+      // Whether this is a server that has yet to send a flight. Since a
+      // HelloVerifyRequest is not retained as one, that is exactly the window
+      // before a cookie has validated. Restricted to servers because a client
+      // legitimately receives a HelloRequest into a fresh IO that has not sent
+      // anything either.
+      bool server_awaiting_first_flight() const {
+         return m_is_server && m_flights.size() == 1 && m_flights.front().empty();
+      }
 
       std::vector<uint8_t> format_fragment(const uint8_t fragment[],
                                            size_t fragment_len,
@@ -347,7 +368,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
 
       std::optional<std::pair<uint16_t, Handshake_Reassembly>> m_retransmitted_client_hello;
       bool m_awaiting_cookie_client_hello = false;
-      bool m_recreating_hello_verify_request = false;
+
+      // message_seq of the most recently delivered ClientHello, which is what a
+      // HelloVerifyRequest answering it must carry.
+      std::optional<uint16_t> m_last_client_hello_msg_seq;
       bool m_finished = false;
       bool m_retransmit_terminal_flight = false;
 
@@ -380,6 +404,7 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       uint16_t m_mtu;
       size_t m_max_handshake_msg_size;
       size_t m_max_pending_reassembly;
+      bool m_is_server;
 };
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -142,7 +142,8 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                             uint64_t max_timeout_ms,
                             std::optional<size_t> max_retransmissions,
                             size_t max_handshake_msg_size,
-                            bool is_server = false);
+                            bool is_server = false,
+                            uint16_t initial_epoch = 0);
 
       Protocol_Version initial_record_version() const override;
 
@@ -217,6 +218,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                                                size_t msg_length,
                                                uint16_t message_seq,
                                                bool retransmitted_flight);
+
+      // Drop buffered messages left over from an earlier handshake, identified
+      // by an epoch below the most recently delivered one.
+      void discard_stale_epoch_messages();
 
       void retransmit_flight(size_t flight);
       void retransmit_last_flight();
@@ -398,6 +403,14 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // Whether any incoming message has been delivered. Not the same as
       // m_in_message_seq being non-zero once that counter wraps; see format().
       bool m_any_message_delivered = false;
+
+      // Epoch in force when this handshake began. Records from the previous one
+      // sit at or below it, and a Finished has to sit above it.
+      uint16_t m_initial_epoch;
+
+      // Epoch of the most recently delivered incoming handshake message. Used
+      // to reject records held over from a previous handshake.
+      uint16_t m_last_delivered_epoch = 0;
 
       writer_fn m_send_hs;
       steady_clock_fn m_steady_clock_ms;

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -124,6 +124,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // Lambda pointing to clock function (normally TLS::Callbacks::tls_current_monotonic_clock_ms)
       using steady_clock_fn = std::function<uint64_t()>;
 
+      // msg_type(1) + length(3) + message_seq(2) + fragment_offset(3) +
+      // fragment_length(3)
+      static constexpr size_t DTLS_HANDSHAKE_HEADER_SIZE = 12;
+
       Datagram_Handshake_IO(writer_fn writer,
                             steady_clock_fn clock_ms,
                             class Connection_Sequence_Numbers& seq,
@@ -174,6 +178,17 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                       uint64_t record_sequence,
                       bool retransmitted_flight);
 
+      // Handle one fragment parsed out of an incoming record, returning true
+      // if it cues a replay of our last flight.
+      bool process_handshake_fragment(const uint8_t fragment[],
+                                      size_t fragment_length,
+                                      size_t fragment_offset,
+                                      uint16_t epoch,
+                                      Handshake_Type msg_type,
+                                      size_t msg_length,
+                                      uint16_t message_seq,
+                                      bool retransmitted_flight);
+
       bool reassemble_retransmitted_fragment(const uint8_t fragment[],
                                              size_t fragment_length,
                                              size_t fragment_offset,
@@ -194,6 +209,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       void retransmit_flight(size_t flight);
       void retransmit_last_flight();
 
+      // Drop delivered reassembly slots, keeping the lowest as the epoch
+      // sentinel the expecting_ccs branch of get_next_record reads.
+      void prune_delivered_messages();
+
       std::vector<uint8_t> format_fragment(const uint8_t fragment[],
                                            size_t fragment_len,
                                            uint32_t frag_offset,
@@ -212,6 +231,14 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
 
       class Handshake_Reassembly final {
          public:
+            // Approximate real cost of one segment: red-black tree node holding
+            // the offset key and an inline std::vector, plus that vector's own
+            // heap allocation. Rounded up, since under-charging is what charging
+            // for segments at all is meant to prevent.
+            static constexpr size_t SEGMENT_OVERHEAD = 96;
+
+            // Callers charge the change in charged_bytes() against the per-IO
+            // reassembly budget; see recharge_reassembly_bytes.
             void add_fragment(const uint8_t fragment[],
                               size_t fragment_length,
                               size_t fragment_offset,
@@ -226,10 +253,31 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
             // 0 until the first fragment has set the declared msg_length.
             size_t msg_length() const { return m_msg_length; }
 
+            size_t bytes_received() const { return m_bytes_received; }
+
+            // What this reassembly costs against the budget. Payload alone is a
+            // poor proxy: a sparse segment costs far more in allocator and map
+            // overhead than it holds, so 1-byte fragments at alternating offsets
+            // would otherwise buy roughly a hundred times the memory the budget
+            // believes it has handed out.
+            // Zero once delivered: the buffers are gone, and m_bytes_received is
+            // kept only as a record of what the slot held.
+            size_t charged_bytes() const {
+               return m_delivered ? 0 : m_bytes_received + SEGMENT_OVERHEAD * m_segments.size();
+            }
+
+            // What charged_bytes() would report after add_fragment of this
+            // fragment: mirrors the merge walk without mutating, so overlap with
+            // already-buffered segments is not counted twice. On paths where
+            // add_fragment stores nothing it can only overestimate.
+            size_t charged_bytes_after_add(size_t fragment_length, size_t fragment_offset) const;
+
             std::pair<Handshake_Type, std::vector<uint8_t>> message() const;
 
             // Release the memory buffers; called after reassembly has completed
             void release_buffers();
+
+            bool delivered() const { return m_delivered; }
 
          private:
             Handshake_Type m_msg_type = Handshake_Type::None;
@@ -237,11 +285,38 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
             size_t m_bytes_received = 0;
             uint16_t m_epoch = 0;
 
-            // Reassembly buffer (sized to m_msg_length once known) and a parallel
-            // byte-mask marking which positions have already been seen.
-            std::vector<uint8_t> m_received_mask;
-            std::vector<uint8_t> m_message;
+            // Set by release_buffers. The entry lives on as an epoch sentinel
+            // with its metadata intact but no bytes behind it.
+            bool m_delivered = false;
+
+            // Sparse store of received fragments keyed by offset, with the
+            // invariant that segments are non-overlapping and eagerly merged
+            // (no two adjacent segments). Total memory is proportional to
+            // bytes actually received: a 1-byte fragment at any offset costs
+            // ~1 byte of payload + std::map node overhead, never the claimed
+            // msg_length. complete() iff the segments form a single span
+            // [0, m_msg_length).
+            std::map<size_t, std::vector<uint8_t>> m_segments;
       };
+
+      // Add a fragment to a reassembly slot, keeping the pending-reassembly
+      // budget in step with the slot's charged_bytes(). Returns false, adding
+      // nothing, if the budget ceiling would be exceeded.
+      bool charged_add_fragment(Handshake_Reassembly& reassembly,
+                                size_t ceiling,
+                                const uint8_t fragment[],
+                                size_t fragment_length,
+                                size_t fragment_offset,
+                                uint16_t epoch,
+                                Handshake_Type msg_type,
+                                size_t msg_length);
+
+      // Uncommit a reassembly buffer's bytes from the pending-reassembly budget.
+      void release_reassembly_bytes(const Handshake_Reassembly& reassembly);
+
+      // Apply the change in a reassembly's charged_bytes() to the running total.
+      // Merging adjacent segments can lower it, so this goes both ways.
+      void recharge_reassembly_bytes(size_t charged_before, const Handshake_Reassembly& reassembly);
 
       struct Message_Info final {
             Message_Info(uint16_t e, Handshake_Type mt, const std::vector<uint8_t>& msg) :
@@ -296,10 +371,15 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       uint16_t m_in_message_seq = 0;
       uint16_t m_out_message_seq = 0;
 
+      // Whether any incoming message has been delivered. Not the same as
+      // m_in_message_seq being non-zero once that counter wraps; see format().
+      bool m_any_message_delivered = false;
+
       writer_fn m_send_hs;
       steady_clock_fn m_steady_clock_ms;
       uint16_t m_mtu;
       size_t m_max_handshake_msg_size;
+      size_t m_max_pending_reassembly;
 };
 
 }  // namespace Botan::TLS

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -225,6 +225,11 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
 
       void retransmit_flight(size_t flight);
       void retransmit_last_flight();
+      void replay_last_flight_for_peer();
+
+      // Index of the last completed outgoing flight, or nullopt when no
+      // flight has been sent yet.
+      std::optional<size_t> last_completed_flight_index() const;
 
       // Drop delivered reassembly slots, keeping the lowest as the epoch
       // sentinel the expecting_ccs branch of get_next_record reads.
@@ -363,8 +368,6 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       std::optional<uint16_t> m_retransmitted_ccs_epoch;
       std::optional<uint16_t> m_retransmitted_finished_epoch;
       std::map<Handshake_Type, std::pair<uint16_t, Handshake_Reassembly>> m_retransmitted_messages;
-      bool m_retransmitted_server_hello_complete = false;
-      bool m_retransmitted_server_hello_done_complete = false;
       std::vector<std::vector<uint16_t>> m_flights;
       // Each entry records where in the corresponding flight a CCS was sent
       // and the epoch under which it was transmitted.
@@ -394,6 +397,11 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // A caller's clock may legitimately read zero, so the absence of a write
       // cannot be spelled as a reserved timestamp.
       std::optional<uint64_t> m_last_write;
+
+      // Flight replays the peer has cued since the current flight was sent.
+      // Kept apart from the timer's own budget because the cue for it is
+      // unauthenticated. See replay_last_flight_for_peer.
+      size_t m_peer_replay_count = 0;
 
       uint64_t m_next_timeout = 0;
 

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -476,12 +476,12 @@ Record_Header read_dtls_record(secure_vector<uint8_t>& readbuf,
    }
 
    if(epoch == 0) {
-      // Unencrypted initial handshake
+      // Unencrypted initial handshake. Epoch-0 records are unauthenticated and
+      // deliberately do not advance the replay window: one spoofed record with a
+      // high sequence number would otherwise silently drop every later record
+      // from the real peer. Duplicates are filtered by handshake reassembly.
       recbuf.assign(readbuf.begin() + DTLS_HEADER_SIZE, readbuf.begin() + DTLS_HEADER_SIZE + record_size);
       readbuf.clear();
-      if(sequence_numbers != nullptr && sequence_numbers->current_read_epoch() == 0) {
-         sequence_numbers->read_accept(sequence);
-      }
       return Record_Header(sequence, version, type);
    }
 

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -698,6 +698,8 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
                handle->ticket().value(),
                static_cast<uint32_t>(policy().session_ticket_lifetime().count())));
          }
+
+         note_resumption_handle(handle);
       }
 
       if(pending_state.new_session_ticket() == nullptr && pending_state.server_hello()->supports_session_ticket()) {
@@ -822,6 +824,8 @@ void Server_Impl_12::session_resume(Server_Handshake_State& pending_state,
          return session_manager().establish(session.session, session.handle.id());
       }
    }();
+
+   note_resumption_handle(new_handle);
 
    if(pending_state.server_hello()->supports_session_ticket()) {
       if(new_handle.has_value() && new_handle->is_ticket()) {

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -310,6 +310,12 @@ Server_Impl_12::Server_Impl_12(const Channel_Impl::Downgrade_Information& downgr
                       downgrade_info.io_buffer_size),
       m_creds(downgrade_info.creds) {}
 
+bool Server_Impl_12::dtls_epoch0_restart_enabled() const {
+   // A DTLS server cannot be constructed without a cookie secret, so the policy
+   // setting alone decides.
+   return policy().allow_dtls_epoch0_restart();
+}
+
 std::unique_ptr<Handshake_State> Server_Impl_12::new_handshake_state(std::unique_ptr<Handshake_IO> io) {
    auto state = std::make_unique<Server_Handshake_State>(std::move(io), callbacks());
    state->set_expected_next(Handshake_Type::ClientHello);
@@ -405,6 +411,13 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
    }
 
    if(pending_state.handshake_io().have_more_data()) {
+      // For an unauthenticated epoch-0 restart attempt, silently drop rather
+      // than alerting the active association: the trailing data may be
+      // attacker-injected garbage on the 5-tuple, and any alert here would
+      // tear down a session the peer hasn't proven it can authenticate.
+      if(epoch0_restart) {
+         return;
+      }
       throw TLS_Exception(Alert::UnexpectedMessage, "Have data remaining in buffer after ClientHello");
    }
 
@@ -473,18 +486,18 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
             pending_state.handshake_io().send(verify);
          }
 
+         // Reset the ClientHello state while keeping the Datagram_Handshake_IO
+         // object alive; it is needed to detect the cookie-bearing ClientHello
+         // expected at sequence #1. A bogus cookie cannot wedge the channel: a
+         // fresh msg_seq-0 ClientHello supersedes this pending exchange via
+         // discard_stale_cookie_exchange_state.
          pending_state.client_hello(nullptr);
          pending_state.set_expected_next(Handshake_Type::ClientHello);
          return;
       }
    }
 
-   if(epoch0_restart) {
-      // If we reached here then we were able to verify the cookie
-      reset_active_association_state();
-   }
-
-   secure_renegotiation_check(pending_state.client_hello());
+   secure_renegotiation_check(pending_state.client_hello(), epoch0_restart);
 
    // RFC 7627 / RFC 9325 4.4: optionally require Extended Master Secret
    if(policy().require_extended_master_secret() && !pending_state.client_hello()->supports_extended_master_secret()) {
@@ -532,11 +545,18 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
       }
    }
 
+   // For an epoch-0 restart the old association is discarded inside
+   // session_resume()/session_create(), at the point just before the new
+   // ServerHello is sent. Deferring it that far ensures a ClientHello that
+   // authenticates via the cookie but then fails a later check (e.g. no
+   // mutually-acceptable ciphersuite in choose_ciphersuite()) does not destroy
+   // the active session: the from_peer() epoch-0 catch rolls back
+   // m_pending_state, but it cannot un-reset m_active_state.
    if(session_info.has_value()) {
-      this->session_resume(pending_state, {session_info.value(), session_handle.value()});
+      this->session_resume(pending_state, {session_info.value(), session_handle.value()}, epoch0_restart);
    } else {
       // new session
-      this->session_create(pending_state);
+      this->session_create(pending_state, epoch0_restart);
    }
 }
 
@@ -742,13 +762,21 @@ void Server_Impl_12::process_handshake_msg(Handshake_State& state_base,
    }
 }
 
-void Server_Impl_12::session_resume(Server_Handshake_State& pending_state, const Session_with_Handle& session) {
+void Server_Impl_12::session_resume(Server_Handshake_State& pending_state,
+                                    const Session_with_Handle& session,
+                                    bool epoch0_restart) {
    // Only offer a resuming client a new ticket if they didn't send one this time,
    // ie, resumed via server-side resumption. TODO: also send one if expiring soon?
 
    const bool offer_new_session_ticket = pending_state.client_hello()->supports_session_ticket() &&
                                          pending_state.client_hello()->session_ticket().empty() &&
                                          session_manager().emits_session_tickets();
+
+   // Commit point for a DTLS epoch-0 restart; see the comment in
+   // session_create() for the rationale.
+   if(epoch0_restart) {
+      reset_active_association_state();
+   }
 
    pending_state.server_hello(std::make_unique<Server_Hello_12>(pending_state.handshake_io(),
                                                                 pending_state.hash(),
@@ -815,7 +843,7 @@ void Server_Impl_12::session_resume(Server_Handshake_State& pending_state, const
    pending_state.set_expected_next(Handshake_Type::HandshakeCCS);
 }
 
-void Server_Impl_12::session_create(Server_Handshake_State& pending_state) {
+void Server_Impl_12::session_create(Server_Handshake_State& pending_state, bool epoch0_restart) {
    std::map<std::string, std::vector<X509_Certificate>> cert_chains;
 
    const std::string sni_hostname = pending_state.client_hello()->sni_hostname();
@@ -851,6 +879,17 @@ void Server_Impl_12::session_create(Server_Handshake_State& pending_state) {
                                                 pending_state.version(),
                                                 ciphersuite,
                                                 session_manager().emits_session_tickets());
+
+   // Commit point for a DTLS epoch-0 restart: all validation that can throw has
+   // now passed (in particular choose_ciphersuite() above, which throws when the
+   // client offers no mutually-acceptable suite), and the next statement sends
+   // the ServerHello. Only here do we discard the old association. This must
+   // precede the Server_Hello_12 construction so that
+   // secure_renegotiation_data_for_server_hello() sees no active state and emits
+   // an empty (fresh-handshake) renegotiation_info.
+   if(epoch0_restart) {
+      reset_active_association_state();
+   }
 
    pending_state.server_hello(std::make_unique<Server_Hello_12>(pending_state.handshake_io(),
                                                                 pending_state.hash(),

--- a/src/lib/tls/tls12/tls_server_impl_12.h
+++ b/src/lib/tls/tls12/tls_server_impl_12.h
@@ -88,11 +88,15 @@ class Server_Impl_12 final : public Channel_Impl_12 {
                                 Handshake_Type type,
                                 const std::vector<uint8_t>& contents);
 
-      void session_resume(Server_Handshake_State& pending_state, const Session_with_Handle& session_info);
+      void session_resume(Server_Handshake_State& pending_state,
+                          const Session_with_Handle& session_info,
+                          bool epoch0_restart);
 
-      void session_create(Server_Handshake_State& pending_state);
+      void session_create(Server_Handshake_State& pending_state, bool epoch0_restart);
 
       std::unique_ptr<Handshake_State> new_handshake_state(std::unique_ptr<Handshake_IO> io) override;
+
+      bool dtls_epoch0_restart_enabled() const override;
 
       std::shared_ptr<Credentials_Manager> m_creds;
       std::string m_next_protocol;

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -512,6 +512,12 @@ size_t Policy::dtls_maximum_timeout() const {
    return 60 * 1000;
 }
 
+// Generous next to the one or two a legitimate cookie-secret rotation can
+// produce, while still bounding a forged stream.
+size_t Policy::dtls_maximum_hello_verify_requests() const {
+   return 4;
+}
+
 std::optional<size_t> Policy::dtls_maximum_retransmissions() const {
    // Matches BoringSSL's DTLS1_MAX_TIMEOUTS.
    //

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -597,6 +597,21 @@ class BOTAN_PUBLIC_API(2, 0) Policy /* NOLINT(*-special-member-functions) */ {
       virtual std::optional<size_t> dtls_maximum_retransmissions() const;
 
       /**
+      * @return the number of HelloVerifyRequest messages a DTLS client will act
+      * on within one handshake before abandoning it. Return 0 to accept them
+      * without limit.
+      *
+      * RFC 6347 4.2.1 requires more than one to be tolerated: "This may result
+      * in clients receiving multiple HelloVerifyRequest messages with different
+      * cookies. Clients SHOULD handle this by sending a new ClientHello with a
+      * cookie in response to the new HelloVerifyRequest." A HelloVerifyRequest
+      * is unauthenticated and carries no retransmission state of its own, so
+      * without a bound a forged stream of them makes a client re-send its
+      * ClientHello indefinitely.
+      */
+      virtual size_t dtls_maximum_hello_verify_requests() const;
+
+      /**
       * @return the maximum size of a single handshake message, in bytes.
       * Messages larger than this will be rejected prior to processing.
       * Return 0 to disable this and accept any size.
@@ -907,6 +922,9 @@ class BOTAN_PUBLIC_API(2, 0) Text_Policy : public Policy {
       size_t dtls_initial_timeout() const override;
 
       size_t dtls_maximum_timeout() const override;
+
+      size_t dtls_maximum_hello_verify_requests() const override;
+
 
       bool require_cert_revocation_info() const override;
 

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -190,6 +190,11 @@ size_t Text_Policy::dtls_maximum_timeout() const {
    return get_len("dtls_maximum_timeout", Policy::dtls_maximum_timeout());
 }
 
+size_t Text_Policy::dtls_maximum_hello_verify_requests() const {
+   return get_len("dtls_maximum_hello_verify_requests", Policy::dtls_maximum_hello_verify_requests());
+}
+
+
 bool Text_Policy::require_cert_revocation_info() const {
    return get_bool("require_cert_revocation_info", Policy::require_cert_revocation_info());
 }

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -209,6 +209,14 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_max_retransmissions(size_t lim
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
+// allow_dtls_epoch0_restart() off, which is the Policy default and the
+// configuration every DTLS client runs in.
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_without_epoch0_restart() {
+   DTLS_Policy_Options opts;
+   opts.allow_epoch0_restart = false;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
 std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_cipher(std::string cipher, bool allow_epoch0_restart) {
    DTLS_Policy_Options opts;
    opts.cipher = std::move(cipher);
@@ -1310,6 +1318,115 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // A bare handshake header declaring a zero-length message reassembles
+      // completely, so it is not rejected by add_record; it fails later, when
+      // the message is parsed or offered to the state machine. That route
+      // reached the same teardown until the guard was widened to cover
+      // delivery. The client is the exposed side: its pending IO has received
+      // nothing, so the stale-epoch check cannot help it.
+      static Test::Result test_forged_epoch0_message_during_renegotiation() {
+         Test::Result result("DTLS forged epoch-zero message during renegotiation");
+
+         auto rng = Test::new_shared_rng("dtls-core-forged-epoch0-message");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& server_recv = assoc->server_recv;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         result.test_no_throw("client starts renegotiation", [&] { client.renegotiate(true); });
+
+         // Drop the ClientHello. The client's pending IO has now received
+         // nothing at all, which is the state it spends the renegotiation in.
+         c2s.clear();
+
+         // ServerHello and Certificate: the first fails in the message parser,
+         // the second in the state machine. Each carries the message_seq the
+         // pending IO is waiting for, so each reaches dispatch.
+         const std::array<uint8_t, 2> forged_types = {0x02, 0x0B};
+
+         for(size_t i = 0; i != forged_types.size(); ++i) {
+            std::array<uint8_t, 12> header = {};
+            header[0] = forged_types[i];          // msg_type
+            header[5] = static_cast<uint8_t>(i);  // message_seq, in sequence
+                                                  // msg_len, fragment_offset, fragment_length all zero
+            const auto forged = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 9 + i, header);
+
+            result.test_no_throw("forged epoch-zero message is absorbed",
+                                 [&] { client.received_data(forged.data(), forged.size()); });
+            result.test_is_true("client remains active", client.is_active());
+            result.test_is_false("client did not close", client.is_closed());
+            result.test_is_true("client said nothing in reply", c2s.empty());
+         }
+
+         // The association still carries data under the established epoch. The
+         // pending renegotiation may not survive being desynchronized this way,
+         // but nothing unauthenticated may destroy what is already running.
+         client.send("still alive");
+         result.test_is_true("client can still write", !c2s.empty());
+         deliver(result, "application data after the forgery", c2s, server);
+         result.test_is_true("server received it", server_recv.size() == 11);
+
+         return result;
+      }
+
+      // A single forged epoch-zero record must not tear down an established
+      // association while a handshake is pending, whether it is malformed at the
+      // record layer or only once the new handshake IO reassembles it.
+      static Test::Result test_forged_epoch0_record_during_renegotiation() {
+         Test::Result result("DTLS forged epoch-zero record during renegotiation");
+
+         auto rng = Test::new_shared_rng("dtls-core-forged-epoch0-reneg");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         result.test_no_throw("client starts renegotiation", [&] { client.renegotiate(true); });
+         deliver(result, "renegotiation client hello", c2s, server);
+
+         // Hold the server's renegotiation flight back so that anything it emits
+         // in response to the forged records below is visible on its own.
+         std::vector<uint8_t> renegotiation_flight;
+         std::swap(renegotiation_flight, s2c);
+         result.test_is_true("server produced a renegotiation flight", !renegotiation_flight.empty());
+
+         // A ChangeCipherSpec payload must be 0x01, so this one is malformed.
+         const std::vector<uint8_t> bad_ccs_body = {0x02};
+         const auto bad_ccs = unprotected_dtls_record(Botan::TLS::Record_Type::ChangeCipherSpec, 7, bad_ccs_body);
+         result.test_no_throw("forged epoch-zero CCS is ignored",
+                              [&] { server.received_data(bad_ccs.data(), bad_ccs.size()); });
+         result.test_is_true("server remains active", server.is_active());
+         result.test_is_false("server did not close", server.is_closed());
+         result.test_is_true("server said nothing in reply", s2c.empty());
+
+         // A malformed handshake fragment must be equally harmless.
+         std::array<uint8_t, 12> bogus_handshake = {};
+         bogus_handshake[0] = 0xFF;
+         const auto forged_handshake = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 8, bogus_handshake);
+         result.test_no_throw("forged epoch-zero handshake record is ignored",
+                              [&] { server.received_data(forged_handshake.data(), forged_handshake.size()); });
+         result.test_is_true("server still active", server.is_active());
+
+         // The renegotiation itself survived and can still complete.
+         deliver_copy(result, "renegotiation server flight", renegotiation_flight, client);
+         deliver(result, "renegotiation client final flight", c2s, server);
+         deliver(result, "renegotiation server final flight", s2c, client);
+         result.test_is_true("client active after renegotiation", client.is_active());
+         result.test_is_true("server active after renegotiation", server.is_active());
+
+         return result;
+      }
+
       // A forged pre-cookie fragment must not poison the reassembly slot the
       // genuine ClientHello needs, which would close the channel before any
       // cookie was ever validated.
@@ -1980,6 +2097,8 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_coalesced_stale_client_hello_does_not_abort(),
                  test_unvalidated_client_hellos_do_not_lock_out_a_server(),
                  test_hello_verify_request_flood_is_bounded(),
+                 test_forged_epoch0_record_during_renegotiation(),
+                 test_forged_epoch0_message_during_renegotiation(),
                  test_short_client_hello_does_not_discard_cookie_state(),
                  test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
@@ -2088,6 +2207,103 @@ class DTLS_Reconnection_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_reconnect", DTLS_Reconnection_Test);
+
+// One unauthenticated epoch-0 record, from anyone able to target the
+// connection's 5-tuple, must not be able to end an established association.
+class DTLS_Epoch0_Inject_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+         results.push_back(run_one("server target", true));
+         results.push_back(run_one("client target", false));
+         return results;
+      }
+
+   private:
+      Test::Result run_one(const std::string& subtest, bool target_server) {
+         Test::Result result("DTLS epoch-0 inject: " + subtest);
+
+         auto rng = Test::new_shared_rng(this->test_name() + "/" + subtest);
+
+         // allow_dtls_epoch0_restart() is off, which is the vulnerable
+         // configuration and the default for every DTLS endpoint.
+         auto assoc = make_association(result, rng, dtls_policy_without_epoch0_restart());
+
+         result.test_is_true("DTLS handshake completed", assoc->pump());
+
+         // The sequence number is chosen so that, immediately after handshake
+         // completion, the bit at (m_window_highest - sequence) is unset and
+         // already_seen() returns false. With m_window_highest = 2^48 and
+         // m_window_bits = 0b1, sequence = 2^48 - 1 lands at offset 1 in the
+         // window, where the bit is zero.
+         const std::vector<uint8_t> body = {0xAA};
+         const auto attack = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, (uint64_t(1) << 48) - 1, body);
+
+         auto& target = target_server ? static_cast<Botan::TLS::Channel&>(*assoc->server)
+                                      : static_cast<Botan::TLS::Channel&>(*assoc->client);
+         result.test_no_throw("epoch-0 inject does not throw",
+                              [&] { target.received_data(attack.data(), attack.size()); });
+
+         result.test_is_true("target still active after inject", target.is_active());
+         result.test_is_false("target not closed after inject", target.is_closed());
+
+         // App data must still flow on the live keys.
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+         assoc->server_recv.clear();
+         assoc->client_recv.clear();
+         assoc->client->send(ping);
+         assoc->server->send(pong);
+         result.test_is_true("app data still flows after inject", assoc->pump_until([&] {
+            return assoc->server_recv == ping && assoc->client_recv == pong;
+         }));
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_inject", DTLS_Epoch0_Inject_Test);
+
+// A spoofed epoch-0 record at the top of the 48-bit sequence space must not
+// advance the read replay window past anything the legitimate peer can still
+// reach, which would silently drop every later record of its handshake.
+class DTLS_Epoch0_Window_Tampering_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("DTLS epoch-0 window tampering");
+
+         auto rng = Test::new_shared_rng(this->test_name());
+         auto assoc = make_association(result, rng, dtls_policy_without_epoch0_restart());
+
+         // One round-trip so the server has processed the first ClientHello and
+         // its sequence numbers exist with the window highest at 0.
+         result.test_is_true("client produced initial CH", !assoc->c2s.empty());
+         assoc->pump_one();
+
+         // Recentering the replay window here would drop every later
+         // ClientHello and key exchange from the legitimate client.
+         const std::vector<uint8_t> body = {0xAA};
+         const auto attack = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, (uint64_t(1) << 48) - 1, body);
+         result.test_no_throw("epoch-0 inject does not throw",
+                              [&] { assoc->server->received_data(attack.data(), attack.size()); });
+
+         result.test_is_true("handshake completed despite epoch-0 inject", assoc->pump());
+
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+         assoc->server_recv.clear();
+         assoc->client_recv.clear();
+         assoc->client->send(ping);
+         assoc->server->send(pong);
+         result.test_is_true("app data flows after recovery", assoc->pump_until([&] {
+            return assoc->server_recv == ping && assoc->client_recv == pong;
+         }));
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_window_tamper", DTLS_Epoch0_Window_Tampering_Test);
 
 // A restart ClientHello that authenticates via the DTLS cookie but then fails a
 // later, attacker-influenced validation step must not tear down the active

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -1195,6 +1195,73 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // Refusing a renegotiation is implemented by discarding the pending
+      // state, which is safe only before a ChangeCipherSpec: the association
+      // still owns both epochs, so dropping the handshake leaves it as it was.
+      static Test::Result test_no_renegotiation_before_ccs_is_accepted() {
+         Test::Result result("DTLS no_renegotiation before ChangeCipherSpec");
+
+         auto rng = Test::new_shared_rng("dtls-core-no-reneg-pre-ccs");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         client.renegotiate(true);
+         c2s.clear();
+
+         assoc->server->send_warning_alert(Botan::TLS::Alert::NoRenegotiation);
+         deliver(result, "pre-CCS refusal is accepted", s2c, client);
+         result.test_is_true("association survives the refusal", client.is_active());
+
+         // The pending handshake is gone, so another can be started.
+         result.test_no_throw("a further renegotiation can start", [&] { client.renegotiate(true); });
+         result.test_is_true("it emitted a ClientHello", !c2s.empty());
+
+         return result;
+      }
+
+      // Past a ChangeCipherSpec the pending state is all that keeps application
+      // data under the new, un-Finished keys from being delivered, and there is
+      // no rollback, so the association ends instead.
+      static Test::Result test_no_renegotiation_after_ccs_ends_the_association() {
+         Test::Result result("DTLS no_renegotiation after ChangeCipherSpec");
+
+         auto rng = Test::new_shared_rng("dtls-core-no-reneg-post-ccs");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         client.renegotiate(true);
+         deliver(result, "renegotiation client hello", c2s, server);
+         deliver(result, "renegotiation server flight", s2c, client);
+
+         // The client has now sent its own CCS and Finished.
+         result.test_is_true("client produced its final flight", !c2s.empty());
+         c2s.clear();
+         s2c.clear();
+
+         server.send_warning_alert(Botan::TLS::Alert::NoRenegotiation);
+         result.test_throws("post-CCS refusal ends the association", [&] {
+            std::vector<uint8_t> in;
+            std::swap(s2c, in);
+            client.received_data(in.data(), in.size());
+         });
+         result.test_is_false("client is no longer active", client.is_active());
+
+         return result;
+      }
+
       // Epoch numbers restart after an epoch-0 restart, so a retirement time
       // recorded for the first association's epoch 1 must not expire the second
       // association's epoch 1. Regression test: it previously did, and past the
@@ -2216,6 +2283,8 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_forged_epoch0_record_during_renegotiation(),
                  test_forged_epoch0_message_during_renegotiation(),
                  test_short_client_hello_does_not_discard_cookie_state(),
+                 test_no_renegotiation_before_ccs_is_accepted(),
+                 test_no_renegotiation_after_ccs_ends_the_association(),
                  test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -1501,6 +1501,105 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // RFC 6347 4.2.4: "Implementations MUST either discard or buffer all
+      // application data packets for the new epoch until they have received the
+      // Finished message for that epoch." Ordinary reordering produces exactly
+      // that whenever a peer writes immediately after activating, so it must not
+      // be fatal either.
+      static Test::Result test_app_data_reordered_before_finished_is_discarded() {
+         Test::Result result("DTLS application data ahead of Finished is discarded");
+
+         auto rng = Test::new_shared_rng("dtls-core-appdata-before-finished");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+         auto& client_recv = assoc->client_recv;
+
+         deliver(result, "client hello 1", c2s, server);
+         deliver(result, "hello verify request", s2c, client);
+         deliver(result, "client hello 2", c2s, server);
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         result.test_is_true("server became active", server.is_active());
+         result.test_is_false("client is still waiting for Finished", client.is_active());
+
+         // The server writes as soon as it activates, which is ordinary practice
+         // from tls_session_activated().
+         const std::vector<uint8_t> app_data = {0xAA, 0xBB, 0xCC};
+         result.test_no_throw("server sends application data", [&] { server.send(app_data); });
+
+         // Reorder so the application data overtakes the Finished.
+         std::vector<uint8_t> ccs;
+         std::vector<uint8_t> finished;
+         std::vector<uint8_t> application;
+         if(!split_first_dtls_record(result, s2c, ccs, finished)) {
+            return result;
+         }
+         std::vector<uint8_t> remainder;
+         if(!split_first_dtls_record(result, finished, remainder, application)) {
+            return result;
+         }
+         finished = remainder;
+         s2c.clear();
+
+         deliver_copy(result, "change cipher spec", ccs, client);
+         result.test_no_throw("application data ahead of Finished is not fatal",
+                              [&] { client.received_data(application.data(), application.size()); });
+         result.test_is_false("client did not close", client.is_closed());
+         result.test_is_true("nothing was delivered to the application", client_recv.empty());
+
+         // The handshake still completes, and traffic flows afterwards.
+         deliver_copy(result, "finished", finished, client);
+         result.test_is_true("client became active", client.is_active());
+
+         client_recv.clear();
+         result.test_no_throw("server sends again", [&] { server.send(app_data); });
+         deliver(result, "application data after activation", s2c, client);
+         result.test_bin_eq("delivered once the handshake completed", client_recv, app_data);
+
+         return result;
+      }
+
+      // RFC 6347 4.1 keeps the previous epoch usable, so a peer that keeps
+      // writing during a renegotiation must still be heard.
+      static Test::Result test_old_epoch_app_data_during_renegotiation() {
+         Test::Result result("DTLS old-epoch application data during renegotiation");
+
+         auto rng = Test::new_shared_rng("dtls-core-appdata-old-epoch");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+         auto& client_recv = assoc->client_recv;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         // Server writes under the established epoch, held back.
+         s2c.clear();
+         const std::vector<uint8_t> app_data = {0x44, 0x55};
+         result.test_no_throw("server sends application data", [&] { server.send(app_data); });
+         std::vector<uint8_t> old_epoch_data;
+         std::swap(old_epoch_data, s2c);
+
+         // The client opens a renegotiation, so it has a pending handshake.
+         result.test_no_throw("client starts renegotiation", [&] { client.renegotiate(true); });
+         result.test_is_true("client emitted a renegotiation ClientHello", !c2s.empty());
+
+         client_recv.clear();
+         result.test_no_throw("old-epoch application data is accepted",
+                              [&] { client.received_data(old_epoch_data.data(), old_epoch_data.size()); });
+         result.test_bin_eq("delivered to the application", client_recv, app_data);
+         result.test_is_true("client remains active", client.is_active());
+         result.test_is_false("client did not close", client.is_closed());
+
+         return result;
+      }
+
       static Test::Result test_duplicate_server_flight_defers_to_timer() {
          Test::Result result("DTLS duplicate server flight defers replay to timer");
 
@@ -2121,6 +2220,8 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),
                  test_pre_cookie_fragment_does_not_poison_a_handshake(),
+                 test_app_data_reordered_before_finished_is_discarded(),
+                 test_old_epoch_app_data_during_renegotiation(),
                  test_lost_server_final_flight_retransmits(),
                  test_stale_client_hello_does_not_replace_active_handshake(),
                  test_epoch0_client_hello_retransmit_while_restart_pending(),
@@ -2427,6 +2528,21 @@ class DTLS_Epoch0_Restart_Validation_Failure_Test : public Test {
 
          result.test_is_true("server still active after failed restart", assoc->server->is_active());
          result.test_is_false("server not closed after failed restart", assoc->server->is_closed());
+
+         // End-to-end proof that the original association still carries data.
+         // Guarded on is_active() so that when the bug is present this reports
+         // an assertion failure rather than throwing out of send().
+         bool data_ok = false;
+         if(assoc->both_active()) {
+            const std::vector<uint8_t> ping(16, 0xC1);
+            const std::vector<uint8_t> pong(16, 0x42);
+            assoc->server_recv.clear();
+            assoc->client_recv.clear();
+            assoc->client->send(ping);
+            assoc->server->send(pong);
+            data_ok = assoc->pump_until([&] { return assoc->server_recv == ping && assoc->client_recv == pong; });
+         }
+         result.test_is_true("legitimate session still carries app data after failed restart", data_ok);
 
          return {result};
       }

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -224,6 +224,14 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_cipher(std::string cipher, boo
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
+// So that a test's own find() call does not consume the ticket it is checking
+// for.
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_reusing_session_tickets() {
+   DTLS_Policy_Options opts;
+   opts.reuse_session_tickets = true;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
 std::unique_ptr<Botan::TLS::Client> make_dtls_client(const std::shared_ptr<Botan::TLS::Callbacks>& callbacks,
                                                      const std::shared_ptr<Botan::TLS::Session_Manager>& sessions,
                                                      const std::shared_ptr<Botan::Credentials_Manager>& creds,
@@ -2425,6 +2433,235 @@ class DTLS_Epoch0_Restart_Validation_Failure_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_restart_validation_failure", DTLS_Epoch0_Restart_Validation_Failure_Test);
+
+/*
+* RFC 5246 7.2.2 requires a fatally terminated connection to forget its keys and
+* to become unresumable, and 7.2.1 says data arriving after a closure alert is
+* ignored. These check the receive side of both, which previously only tore down
+* on locally generated alerts.
+*/
+class TLS_Closure_Teardown_Test : public Test {
+   private:
+      // Session_Manager::remove() reaches application storage and is not
+      // noexcept. A failure there must not be able to abort a fatal-alert
+      // teardown partway through.
+      class Throwing_Session_Manager final : public Botan::TLS::Session_Manager {
+         public:
+            explicit Throwing_Session_Manager(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) :
+                  Session_Manager(rng) {}
+
+            void store(const Botan::TLS::Session& /*session*/, const Botan::TLS::Session_Handle& /*handle*/) override {}
+
+            size_t remove(const Botan::TLS::Session_Handle& /*handle*/) override {
+               throw Botan::Invalid_State("session storage is unavailable");
+            }
+
+            size_t remove_all() override { return 0; }
+
+         protected:
+            std::optional<Botan::TLS::Session> retrieve_one(const Botan::TLS::Session_Handle& /*handle*/) override {
+               return std::nullopt;
+            }
+
+            std::vector<Botan::TLS::Session_with_Handle> find_some(const Botan::TLS::Server_Information& /*info*/,
+                                                                   size_t /*max_sessions_hint*/) override {
+               return {};
+            }
+      };
+
+      Test::Result fatal_alert_teardown(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("received fatal alert destroys connection state");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         result.test_no_throw("exporter works while active",
+                              [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         assoc->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         result.test_is_true("server emitted the alert", !assoc->s2c.empty());
+
+         std::vector<uint8_t> alert;
+         std::swap(assoc->s2c, alert);
+         result.test_no_throw("client accepts the alert record",
+                              [&] { assoc->client->received_data(alert.data(), alert.size()); });
+
+         result.test_sz_eq("the application saw the alert", assoc->client_cb->alerts_received(), size_t(1));
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_is_true("client is no longer active", !assoc->client->is_active());
+         result.test_is_true("handshake state is gone", !assoc->client->is_handshake_complete());
+
+         result.test_throws("exporter is refused after a fatal alert",
+                            [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         return result;
+      }
+
+      // RFC 5246 7.2.2 makes a fatally terminated connection's secrets unusable,
+      // but a clean close_notify does not, and TLS 1.3 keeps its exporter
+      // working across one. Keying the refusal on is_closed() broke both.
+      Test::Result exporter_after_clean_close(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("exporter survives close_notify but not a fatal alert");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         assoc->client->close();
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_no_throw("exporter still works after close_notify",
+                              [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         // A fatal alert is different: the teardown clears the active state, so
+         // the exporter refuses on that ground too.
+         auto fatal = make_association(result, rng, opts);
+         if(!result.test_is_true("second handshake completed", fatal->pump())) {
+            return result;
+         }
+         fatal->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(fatal->s2c, alert);
+         fatal->client->received_data(alert.data(), alert.size());
+         result.test_throws("exporter refuses after a fatal alert",
+                            [&] { fatal->client->key_material_export("test label", "", 32); });
+
+         return result;
+      }
+
+      // The teardown touches application storage. If that throws before the
+      // keys are destroyed, the channel is left half closed: inbound records
+      // dropped, but is_active() still true and the write side still usable.
+      Test::Result teardown_survives_a_throwing_session_manager(
+         const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("fatal teardown completes despite a throwing session manager");
+
+         DTLS_Association_Options opts;
+         opts.client_sessions = std::make_shared<Throwing_Session_Manager>(rng);
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         // Locally generated fatal alert, which invalidates cached sessions
+         // before the channel state is torn down.
+         result.test_no_throw("local fatal alert does not surface the storage failure",
+                              [&] { assoc->client->send_fatal_alert(Botan::TLS::Alert::InternalError); });
+
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_is_true("client is not active", !assoc->client->is_active());
+         result.test_is_true("connection state is gone", !assoc->client->is_handshake_complete());
+         result.test_throws("writes are refused", [&] { assoc->client->send("nope"); });
+         result.test_throws("exporter is refused", [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         // And the receive side, where the callback also runs before teardown.
+         DTLS_Association_Options received_opts;
+         received_opts.client_sessions = std::make_shared<Throwing_Session_Manager>(rng);
+         received_opts.tolerate_fatal_alerts = true;
+         auto received = make_association(result, rng, received_opts);
+         if(!result.test_is_true("second handshake completed", received->pump())) {
+            return result;
+         }
+         received->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(received->s2c, alert);
+         result.test_no_throw("received fatal alert does not surface the storage failure",
+                              [&] { received->client->received_data(alert.data(), alert.size()); });
+         result.test_is_true("client is closed", received->client->is_closed());
+         result.test_is_true("connection state is gone", !received->client->is_handshake_complete());
+
+         return result;
+      }
+
+      Test::Result ticket_invalidated(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("received fatal alert invalidates a ticket-backed session");
+
+         DTLS_Association_Options opts;
+         opts.policy = dtls_policy_reusing_session_tickets();
+         opts.stateless_tickets = true;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         auto policy = DTLS_PSK_Policy();
+         const auto cached =
+            assoc->client_sessions->find(Botan::TLS::Server_Information("localhost"), *assoc->client_cb, policy);
+         if(!result.test_is_true("client cached a resumable session", !cached.empty())) {
+            return result;
+         }
+         // The ServerHello session ID, which is all the channel used to track,
+         // does not identify this session.
+         result.test_is_true("the session is ticket-backed, not ID-backed", cached[0].handle.is_ticket());
+
+         assoc->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(assoc->s2c, alert);
+         assoc->client->received_data(alert.data(), alert.size());
+
+         const auto after =
+            assoc->client_sessions->find(Botan::TLS::Server_Information("localhost"), *assoc->client_cb, policy);
+         result.test_is_true("the ticket was removed from the client cache", after.empty());
+
+         return result;
+      }
+
+      Test::Result data_after_close_notify(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("data reordered behind a close_notify is ignored");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         // Send application data and then close, but hand the client the
+         // close_notify first. Reordering is ordinary for DTLS, and it must not
+         // turn a clean shutdown into a fatal error.
+         const std::string payload = "reordered";
+         assoc->server->send(payload);
+         std::vector<uint8_t> app_data;
+         std::swap(assoc->s2c, app_data);
+         result.test_is_true("app data record captured", !app_data.empty());
+
+         assoc->server->close();
+         std::vector<uint8_t> close_notify;
+         std::swap(assoc->s2c, close_notify);
+         result.test_is_true("close_notify record captured", !close_notify.empty());
+
+         result.test_no_throw("client accepts the close_notify",
+                              [&] { assoc->client->received_data(close_notify.data(), close_notify.size()); });
+         result.test_is_true("client is closed", assoc->client->is_closed());
+
+         result.test_no_throw("late application data is ignored, not rejected",
+                              [&] { assoc->client->received_data(app_data.data(), app_data.size()); });
+         result.test_is_true("the ignored data was not delivered", assoc->client_recv.empty());
+
+         return result;
+      }
+
+   public:
+      std::vector<Test::Result> run() override {
+         auto rng = Test::new_shared_rng(this->test_name());
+
+         return {fatal_alert_teardown(rng),
+                 ticket_invalidated(rng),
+                 data_after_close_notify(rng),
+                 exporter_after_clean_close(rng),
+                 teardown_survives_a_throwing_session_manager(rng)};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_closure_teardown", TLS_Closure_Teardown_Test);
 
 /*
 * A DTLS server must have a cookie secret, but a stream server has no use for

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -209,6 +209,13 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_max_retransmissions(size_t lim
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_cipher(std::string cipher, bool allow_epoch0_restart) {
+   DTLS_Policy_Options opts;
+   opts.cipher = std::move(cipher);
+   opts.allow_epoch0_restart = allow_epoch0_restart;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
 std::unique_ptr<Botan::TLS::Client> make_dtls_client(const std::shared_ptr<Botan::TLS::Callbacks>& callbacks,
                                                      const std::shared_ptr<Botan::TLS::Session_Manager>& sessions,
                                                      const std::shared_ptr<Botan::Credentials_Manager>& creds,
@@ -449,6 +456,13 @@ std::vector<uint8_t> dtls_handshake_fragment(Botan::TLS::Handshake_Type type,
    msg.insert(msg.end(), fragment.begin(), fragment.end());
 
    return msg;
+}
+
+// A complete, unfragmented DTLS handshake message.
+std::vector<uint8_t> dtls_handshake_message(Botan::TLS::Handshake_Type type,
+                                            uint16_t message_sequence,
+                                            std::span<const uint8_t> body) {
+   return dtls_handshake_fragment(type, body.size(), message_sequence, 0, body);
 }
 
 // A record carrying only a handshake header: it declares `message_length` bytes
@@ -943,6 +957,228 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // A record carrying the cookie-bearing ClientHello followed by a stale copy
+      // of the original must not abort the handshake: delivering the duplicate
+      // first makes the real ClientHello look like trailing data.
+      static Test::Result test_coalesced_stale_client_hello_does_not_abort() {
+         Test::Result result("DTLS ClientHello packed with a stale duplicate completes");
+
+         auto rng = Test::new_shared_rng("dtls-core-coalesced-stale-client-hello");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         const std::vector<uint8_t> client_hello_1 = c2s;
+         deliver(result, "client hello 1", c2s, server);
+         deliver(result, "hello verify request", s2c, client);
+         if(!result.test_is_true("cookie-bearing client hello was produced", !c2s.empty())) {
+            return result;
+         }
+         const std::vector<uint8_t> client_hello_2 = c2s;
+         c2s.clear();
+         s2c.clear();
+
+         const auto coalesced = coalesce_dtls_records(client_hello_2, client_hello_1);
+         deliver_copy(result, "cookie client hello packed with the stale one", coalesced, server);
+
+         if(!result.test_is_true("server answered the cookie-bearing ClientHello", !s2c.empty())) {
+            return result;
+         }
+         result.test_is_true("server response is the handshake flight",
+                             contains_dtls_handshake_type(s2c, Botan::TLS::Handshake_Type::ServerHello));
+         result.test_is_false("server did not close the connection", server.is_closed());
+
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         deliver(result, "server final flight", s2c, client);
+
+         result.test_is_true("client became active", client.is_active());
+         result.test_is_true("server became active", server.is_active());
+
+         return result;
+      }
+
+      // ClientHellos that never validate must not permanently advance the pending
+      // cookie exchange's handshake sequence numbers, which would make every
+      // fresh handshake starting at message_seq 0 look like a stale duplicate.
+      // Needs no epoch-zero restart: this is the ordinary initial handshake.
+      static Test::Result test_unvalidated_client_hellos_do_not_lock_out_a_server() {
+         Test::Result result("DTLS repeated unvalidated ClientHellos do not lock out a server");
+
+         auto rng = Test::new_shared_rng("dtls-core-cookie-lockout");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+         auto server_sessions = std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng);
+
+         std::vector<uint8_t> s2c;
+         std::vector<uint8_t> server_recv;
+         auto server_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, s2c, server_recv);
+         Botan::TLS::Server server(server_callbacks, server_sessions, creds, policy, rng, true);
+
+         std::vector<uint8_t> c2s;
+         std::vector<uint8_t> client_recv;
+         auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, c2s, client_recv);
+         Botan::TLS::Client client(client_callbacks,
+                                   std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                   creds,
+                                   policy,
+                                   rng,
+                                   Botan::TLS::Server_Information("localhost"),
+                                   Botan::TLS::Protocol_Version::latest_dtls_version());
+
+         // The client's initial ClientHello carries no cookie, so replaying it
+         // is enough to make the server answer with a HelloVerifyRequest.
+         const std::vector<uint8_t> client_hello = c2s;
+         c2s.clear();
+
+         constexpr size_t dtls_header_len = 13;
+         if(!result.test_is_true("captured a ClientHello", client_hello.size() > dtls_header_len + 6)) {
+            return result;
+         }
+
+         auto with_message_seq = [&](uint16_t seq) {
+            auto record = client_hello;
+            record[dtls_header_len + 4] = static_cast<uint8_t>(seq >> 8);
+            record[dtls_header_len + 5] = static_cast<uint8_t>(seq);
+            return record;
+         };
+
+         for(uint16_t seq = 0; seq != 2; ++seq) {
+            s2c.clear();
+            const auto spoofed = with_message_seq(seq);
+            deliver_copy(result, "unvalidated client hello", spoofed, server);
+            result.test_is_true("server answered with HelloVerifyRequest",
+                                contains_dtls_handshake_type(s2c, Botan::TLS::Handshake_Type::HelloVerifyRequest));
+         }
+         s2c.clear();
+
+         // The genuine client now handshakes on the same association.
+         deliver_copy(result, "genuine client hello", client_hello, server);
+         deliver(result, "hello verify request", s2c, client);
+         deliver(result, "cookie-bearing client hello", c2s, server);
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         deliver(result, "server final flight", s2c, client);
+
+         result.test_is_true("client became active", client.is_active());
+         result.test_is_true("server became active", server.is_active());
+
+         return result;
+      }
+
+      // A HelloVerifyRequest is unauthenticated and resets the retransmission
+      // counter, so without a bound a forged stream of them makes a client
+      // re-send its ClientHello forever.
+      static Test::Result test_hello_verify_request_flood_is_bounded() {
+         Test::Result result("DTLS HelloVerifyRequest flood is bounded");
+
+         auto rng = Test::new_shared_rng("dtls-core-hvr-flood");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+
+         std::vector<uint8_t> c2s;
+         std::vector<uint8_t> client_recv;
+         // This client is expected to fail, so do not fail the test on its alert.
+         Test::Result ignored_alerts("ignored");
+         auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(ignored_alerts, c2s, client_recv);
+         Botan::TLS::Client client(client_callbacks,
+                                   std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                   creds,
+                                   policy,
+                                   rng,
+                                   Botan::TLS::Server_Information("localhost"),
+                                   Botan::TLS::Protocol_Version::latest_dtls_version());
+
+         const size_t first_client_hello = c2s.size();
+         result.test_is_true("client sent an initial ClientHello", first_client_hello > 0);
+
+         const size_t limit = policy->dtls_maximum_hello_verify_requests();
+         result.test_is_true("policy bounds HelloVerifyRequests", limit > 0);
+
+         size_t answered = 0;
+         size_t emitted = 0;
+         for(size_t i = 0; i != limit + 20; ++i) {
+            // Body of a HelloVerifyRequest: version, then a cookie.
+            std::vector<uint8_t> body = {0xFE, 0xFD, 0x08};
+            body.insert(body.end(), 8, static_cast<uint8_t>(i));
+
+            const auto forged = unprotected_dtls_record(
+               Botan::TLS::Record_Type::Handshake,
+               1000 + i,
+               dtls_handshake_message(Botan::TLS::Handshake_Type::HelloVerifyRequest, static_cast<uint16_t>(i), body));
+            c2s.clear();
+            try {
+               client.received_data(forged.data(), forged.size());
+            } catch(const Botan::TLS::TLS_Exception&) {
+               break;
+            }
+            if(!c2s.empty()) {
+               answered += 1;
+               emitted += c2s.size();
+            }
+         }
+
+         result.test_sz_eq("client answered at most the configured number", answered, limit);
+         result.test_is_true("client abandoned the handshake", client.is_closed());
+         result.test_is_true("outbound traffic stayed bounded", emitted <= limit * 2 * first_client_hello);
+
+         return result;
+      }
+
+      // discard_stale_cookie_exchange_state resets a pending cookie exchange
+      // when a fresh ClientHello supersedes it. A bare 12-byte header claiming
+      // a zero-length message is not a ClientHello and must not qualify.
+      static Test::Result test_short_client_hello_does_not_discard_cookie_state() {
+         Test::Result result("DTLS undersized ClientHello header during cookie exchange");
+
+         auto rng = Test::new_shared_rng("dtls-core-short-ch-cookie-state");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+
+         std::vector<uint8_t> c2s;
+         std::vector<uint8_t> s2c;
+         std::vector<uint8_t> client_recv;
+         std::vector<uint8_t> server_recv;
+
+         auto server_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, s2c, server_recv);
+         auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, c2s, client_recv);
+
+         Botan::TLS::Server server(
+            server_callbacks, std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng), creds, policy, rng, true);
+         Botan::TLS::Client client(client_callbacks,
+                                   std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng),
+                                   creds,
+                                   policy,
+                                   rng,
+                                   Botan::TLS::Server_Information("localhost"),
+                                   Botan::TLS::Protocol_Version::latest_dtls_version());
+
+         // Drive the server into a cookie exchange: it has answered with a
+         // HelloVerifyRequest and is waiting for the cookie to come back.
+         deliver(result, "client hello 1", c2s, server);
+         deliver(result, "hello verify request", s2c, client);
+
+         // A bare header at message_seq 0, declaring length 0.
+         std::array<uint8_t, 12> header = {};
+         header[0] = static_cast<uint8_t>(Botan::TLS::Handshake_Type::ClientHello);
+         const auto forged = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 9, header);
+         result.test_no_throw("undersized ClientHello header is ignored",
+                              [&] { server.received_data(forged.data(), forged.size()); });
+
+         // If it had discarded the cookie state, the cookie-bearing ClientHello
+         // at message_seq 1 would be out of sequence for a fresh one and the
+         // handshake would stall here.
+         deliver(result, "client hello 2", c2s, server);
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         deliver(result, "server final flight", s2c, client);
+         result.test_is_true("handshake still completed", client.is_active() && server.is_active());
+
+         return result;
+      }
+
       // Epoch numbers restart after an epoch-0 restart, so a retirement time
       // recorded for the first association's epoch 1 must not expire the second
       // association's epoch 1. Regression test: it previously did, and past the
@@ -1070,6 +1306,72 @@ class DTLS_Core_Regression_Tests final : public Test {
 
          result.test_no_throw("another renegotiation can start", [&] { client.renegotiate(true); });
          result.test_is_true("it emitted a ClientHello", !c2s.empty());
+
+         return result;
+      }
+
+      // A forged pre-cookie fragment must not poison the reassembly slot the
+      // genuine ClientHello needs, which would close the channel before any
+      // cookie was ever validated.
+      static Test::Result test_pre_cookie_fragment_does_not_poison_a_handshake() {
+         Test::Result result("DTLS pre-cookie fragment does not poison a handshake");
+
+         auto rng = Test::new_shared_rng("dtls-core-pre-cookie-poison");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+         auto server_sessions = std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng);
+
+         std::vector<uint8_t> s2c;
+         std::vector<uint8_t> server_recv;
+         auto server_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, s2c, server_recv);
+         Botan::TLS::Server server(server_callbacks, server_sessions, creds, policy, rng, true);
+
+         std::vector<uint8_t> c2s;
+         std::vector<uint8_t> client_recv;
+         auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, c2s, client_recv);
+         Botan::TLS::Client client(client_callbacks,
+                                   std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                   creds,
+                                   policy,
+                                   rng,
+                                   Botan::TLS::Server_Information("localhost"),
+                                   Botan::TLS::Protocol_Version::latest_dtls_version());
+
+         // One byte at a high offset of a ClientHello declaring 64 KiB, so the
+         // declared length conflicts with any real ClientHello.
+         std::vector<uint8_t> poison = {static_cast<uint8_t>(Botan::TLS::Handshake_Type::ClientHello),
+                                        0x01,
+                                        0x00,
+                                        0x00,  // msg_len 65536
+                                        0x00,
+                                        0x00,  // message_seq 0
+                                        0x00,
+                                        0xFF,
+                                        0xFF,  // fragment_offset 65535
+                                        0x00,
+                                        0x00,
+                                        0x01,  // fragment_length 1
+                                        0xAA};
+         const auto poison_record = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 1, poison);
+
+         result.test_no_throw("poison fragment is accepted quietly",
+                              [&] { server.received_data(poison_record.data(), poison_record.size()); });
+         result.test_is_true("no reply to the poison fragment", s2c.empty());
+
+         // The genuine handshake must still complete.
+         deliver(result, "client hello 1", c2s, server);
+         result.test_is_false("server did not close", server.is_closed());
+         result.test_is_true("server answered with HelloVerifyRequest",
+                             contains_dtls_handshake_type(s2c, Botan::TLS::Handshake_Type::HelloVerifyRequest));
+
+         deliver(result, "hello verify request", s2c, client);
+         deliver(result, "client hello 2", c2s, server);
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         deliver(result, "server final flight", s2c, client);
+
+         result.test_is_true("client became active", client.is_active());
+         result.test_is_true("server became active", server.is_active());
 
          return result;
       }
@@ -1675,9 +1977,14 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_lost_server_flight_retransmits(),
                  test_duplicate_server_flight_defers_to_timer(),
                  test_hello_request_during_handshake_is_ignored(),
+                 test_coalesced_stale_client_hello_does_not_abort(),
+                 test_unvalidated_client_hellos_do_not_lock_out_a_server(),
+                 test_hello_verify_request_flood_is_bounded(),
+                 test_short_client_hello_does_not_discard_cookie_state(),
                  test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),
+                 test_pre_cookie_fragment_does_not_poison_a_handshake(),
                  test_lost_server_final_flight_retransmits(),
                  test_stale_client_hello_does_not_replace_active_handshake(),
                  test_epoch0_client_hello_retransmit_while_restart_pending(),
@@ -1781,6 +2088,109 @@ class DTLS_Reconnection_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_reconnect", DTLS_Reconnection_Test);
+
+// A restart ClientHello that authenticates via the DTLS cookie but then fails a
+// later, attacker-influenced validation step must not tear down the active
+// association. The step exercised here is choose_ciphersuite(): the restarting
+// client offers only a ciphersuite the server does not accept.
+class DTLS_Epoch0_Restart_Validation_Failure_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("DTLS epoch-0 restart validation failure preserves active session");
+
+         auto rng = Test::new_shared_rng(this->test_name());
+
+         // The server and the legitimate client agree on AES-128/GCM; the
+         // restarting client below offers only AES-256/GCM, so the server's
+         // choose_ciphersuite() finds no overlap and throws after the cookie
+         // has already validated.
+         DTLS_Association_Options opts;
+         opts.policy = dtls_policy_with_cipher("AES-128/GCM", true);
+         opts.client_policy = dtls_policy_with_cipher("AES-128/GCM", false);
+         auto assoc = make_association(result, rng, opts);
+
+         result.test_is_true("legitimate DTLS session established", assoc->pump());
+
+         // The restart attempt: a valid cookie, then no acceptable cipher.
+         std::vector<uint8_t> bad_c2s;
+         std::vector<uint8_t> bad_recv;
+         auto bad_cb = std::make_shared<DTLS_Test_Callbacks>(result, bad_c2s, bad_recv);
+         bad_cb->tolerate_fatal_alerts();
+         auto bad_client = make_dtls_client(bad_cb,
+                                            std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                            assoc->creds,
+                                            dtls_policy_with_cipher("AES-256/GCM", false),
+                                            rng);
+
+         // The server completes the cookie exchange and throws inside
+         // choose_ciphersuite(); the throw is swallowed by the epoch-0 restart
+         // catch in from_peer(), so no alert is emitted and both buffers drain.
+         result.test_no_throw("server survives the failed restart without throwing", [&] {
+            pump_records(bad_c2s, *assoc->server, assoc->s2c, *bad_client, [] { return false; });
+         });
+
+         result.test_is_true("server still active after failed restart", assoc->server->is_active());
+         result.test_is_false("server not closed after failed restart", assoc->server->is_closed());
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_restart_validation_failure", DTLS_Epoch0_Restart_Validation_Failure_Test);
+
+/*
+* A DTLS server must have a cookie secret, but a stream server has no use for
+* one. Looking it up regardless meant a credentials manager that reports an
+* unsupported context by throwing could no longer construct a TLS 1.2 server.
+*/
+class TLS_Stream_Server_Cookie_Lookup_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("stream TLS server construction ignores the DTLS cookie secret");
+
+         auto rng = Test::new_shared_rng(this->test_name());
+         auto creds = std::make_shared<Strict_Credentials>();
+         auto policy = std::make_shared<Botan::TLS::Policy>();
+         auto callbacks = std::make_shared<Quiet_Callbacks>();
+
+         result.test_no_throw("stream server constructs", [&] {
+            Botan::TLS::Server(
+               callbacks, std::make_shared<Botan::TLS::Session_Manager_Noop>(), creds, policy, rng, false);
+         });
+
+         result.test_throws("datagram server still reports the missing secret", [&] {
+            Botan::TLS::Server(
+               callbacks, std::make_shared<Botan::TLS::Session_Manager_Noop>(), creds, policy, rng, true);
+         });
+
+         return {result};
+      }
+
+   private:
+      // Rejects every context it does not know, which is what a strict
+      // application-supplied manager does.
+      class Strict_Credentials final : public Botan::Credentials_Manager {
+         public:
+            Botan::SymmetricKey psk(const std::string& type,
+                                    const std::string& context,
+                                    const std::string& identity) override {
+               throw Botan::Invalid_Argument("no PSK for " + type + "/" + context + "/" + identity);
+            }
+      };
+
+      class Quiet_Callbacks final : public Botan::TLS::Callbacks {
+         public:
+            void tls_emit_data(std::span<const uint8_t> /*data*/) override {}
+
+            void tls_record_received(uint64_t /*seq_no*/, std::span<const uint8_t> /*data*/) override {}
+
+            void tls_alert(Botan::TLS::Alert /*alert*/) override {}
+
+            std::string tls_peer_network_identity() override { return "test-peer"; }
+      };
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_stream_server_cookie_lookup", TLS_Stream_Server_Cookie_Lookup_Test);
 
 #endif
 

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -2208,6 +2208,69 @@ class DTLS_Reconnection_Test : public Test {
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_reconnect", DTLS_Reconnection_Test);
 
+// End-to-end coverage for DTLS 1.2 renegotiation in both directions. RFC 6347
+// 4.2.2 restarts msg_seq at 0 for each handshake, so the message that opens a
+// renegotiation looks like a stray retransmit to a naive sequence check.
+//
+// BoGo does not exercise DTLS renegotiation at all (BoringSSL itself does not
+// support it), so this test is the only regression coverage.
+class DTLS_Renegotiation_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+         results.push_back(run_one("client-initiated", false));
+         results.push_back(run_one("server-initiated", true));
+         return results;
+      }
+
+   private:
+      Test::Result run_one(const std::string& subtest, bool server_initiates) {
+         Test::Result result("DTLS renegotiation: " + subtest);
+
+         auto rng = Test::new_shared_rng(this->test_name() + "/" + subtest);
+         auto assoc = make_association(result, rng);
+
+         const auto sessions_established = [&](size_t n) {
+            return assoc->client_cb->sessions_established() == n && assoc->server_cb->sessions_established() == n &&
+                   assoc->both_active();
+         };
+
+         result.test_is_true("initial DTLS handshake completed",
+                             assoc->pump_until([&] { return sessions_established(1); }));
+
+         // App data must flow before and after the renegotiation, under each
+         // set of keys in turn.
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+
+         const auto exchange_app_data = [&](const std::string& label) {
+            assoc->server_recv.clear();
+            assoc->client_recv.clear();
+            assoc->client->send(ping);
+            assoc->server->send(pong);
+            result.test_is_true(
+               label, assoc->pump_until([&] { return assoc->server_recv == ping && assoc->client_recv == pong; }));
+         };
+
+         exchange_app_data("app data exchanged before renegotiation");
+
+         // If the receiver drops the initiator because msg_seq is below the
+         // active handshake's, this pump exhausts its rounds with one session.
+         if(server_initiates) {
+            assoc->server->renegotiate();
+         } else {
+            assoc->client->renegotiate();
+         }
+         result.test_is_true("renegotiation completed", assoc->pump_until([&] { return sessions_established(2); }));
+
+         exchange_app_data("app data exchanged after renegotiation");
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_renegotiate", DTLS_Renegotiation_Test);
+
 // One unauthenticated epoch-0 record, from anyone able to target the
 // connection's 5-tuple, must not be able to end an established association.
 class DTLS_Epoch0_Inject_Test : public Test {

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -1617,14 +1617,23 @@ class DTLS_Core_Regression_Tests final : public Test {
          // A delayed retransmission of the cookie-bearing ClientHello has
          // message_seq 1. It belongs to the completed handshake, whereas a
          // genuinely new association starts at message_seq 0.
+         //
+         // It draws no response. Once the server has completed, the peer's last
+         // flight is the one ending in its Finished, so a peer still
+         // retransmitting a ClientHello cannot be asking for the final flight.
+         // Answering would also let a replayed epoch-zero record pull a flight
+         // out of the server without limit.
          deliver_copy(result, "stale client hello 2", cookie_client_hello, server);
          result.test_is_true("server remains active", server.is_active());
-         result.test_is_true("stale ClientHello replays the final server flight", !s2c.empty());
-         s2c.clear();
+         result.test_is_true("stale ClientHello draws no response", s2c.empty());
 
+         // Recovery still works: the client's own retransmitted final flight is
+         // what asks for the server's final flight, and it is authenticated.
          fire_retransmission_timer(result, *assoc->client_cb, client, c2s);
          deliver(result, "retransmitted client final flight", c2s, server);
          result.test_is_true("client final flight still receives a response", !s2c.empty());
+         deliver(result, "server final flight", s2c, client);
+         result.test_is_true("client became active", client.is_active());
 
          return result;
       }

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -8,13 +8,17 @@
 
 #if defined(BOTAN_HAS_TLS_12)
 
+   #include <botan/rng.h>
+   #include <botan/tls_exceptn.h>
    #include <botan/tls_handshake_msg.h>
    #include <botan/tls_magic.h>
+   #include <botan/tls_policy.h>
    #include <botan/internal/fmt.h>
    #include <botan/internal/tls_handshake_io.h>
    #include <botan/internal/tls_seq_numbers.h>
 
    #include <algorithm>
+   #include <cstring>
    #include <vector>
 
 namespace Botan_Tests {
@@ -23,12 +27,43 @@ namespace {
 
 using namespace Botan::TLS;
 
+// Build a DTLS handshake record (12-byte header + payload). This is the
+// stream-of-bytes that Datagram_Handshake_IO::add_record consumes; the
+// outer DTLS record-layer header is stripped before this call.
+std::vector<uint8_t> dtls_hs_record(Handshake_Type msg_type,
+                                    uint32_t msg_len,
+                                    uint16_t message_seq,
+                                    uint32_t fragment_offset,
+                                    std::span<const uint8_t> fragment_bytes) {
+   const uint32_t fragment_length = static_cast<uint32_t>(fragment_bytes.size());
+   std::vector<uint8_t> r(12 + fragment_bytes.size());
+   r[0] = static_cast<uint8_t>(msg_type);
+   r[1] = static_cast<uint8_t>((msg_len >> 16) & 0xFF);
+   r[2] = static_cast<uint8_t>((msg_len >> 8) & 0xFF);
+   r[3] = static_cast<uint8_t>(msg_len & 0xFF);
+   r[4] = static_cast<uint8_t>((message_seq >> 8) & 0xFF);
+   r[5] = static_cast<uint8_t>(message_seq & 0xFF);
+   r[6] = static_cast<uint8_t>((fragment_offset >> 16) & 0xFF);
+   r[7] = static_cast<uint8_t>((fragment_offset >> 8) & 0xFF);
+   r[8] = static_cast<uint8_t>(fragment_offset & 0xFF);
+   r[9] = static_cast<uint8_t>((fragment_length >> 16) & 0xFF);
+   r[10] = static_cast<uint8_t>((fragment_length >> 8) & 0xFF);
+   r[11] = static_cast<uint8_t>(fragment_length & 0xFF);
+   if(!fragment_bytes.empty()) {
+      std::memcpy(r.data() + 12, fragment_bytes.data(), fragment_bytes.size());
+   }
+   return r;
+}
+
 class Datagram_IO_Fixture {
    public:
+      static constexpr size_t k_max_handshake_msg_size = 65536;  // default TLS::Policy value
+
       explicit Datagram_IO_Fixture(uint64_t initial_timeout_ms = 1000,
                                    uint64_t max_timeout_ms = 60000,
                                    std::optional<size_t> max_retransmissions = std::nullopt,
-                                   uint16_t mtu = 1500) :
+                                   uint16_t mtu = 1500,
+                                   size_t max_handshake_msg_size = k_max_handshake_msg_size) :
             m_io(
                [this](uint16_t, Record_Type type, const std::vector<uint8_t>& record) {
                   if(type == Record_Type::Handshake) {
@@ -42,7 +77,16 @@ class Datagram_IO_Fixture {
                initial_timeout_ms,
                max_timeout_ms,
                max_retransmissions,
-               65536) {}
+               max_handshake_msg_size) {}
+
+      void feed(std::span<const uint8_t> record, uint16_t epoch = 0) {
+         const uint64_t record_seq = static_cast<uint64_t>(epoch) << 48;
+         m_io.add_record(record.data(), record.size(), Record_Type::Handshake, record_seq);
+      }
+
+      std::pair<Handshake_Type, std::vector<uint8_t>> next_message() {
+         return m_io.get_next_record(false, k_max_handshake_msg_size);
+      }
 
       Datagram_Handshake_IO& io() { return m_io; }
 
@@ -69,6 +113,8 @@ class Datagram_IO_Fixture {
       Datagram_Handshake_IO m_io;
 };
 
+// Minimal Handshake_Message stub for tests that need to drive sends through
+// Datagram_Handshake_IO::send (and therefore exercise the timer state).
 class Stub_Handshake_Message final : public Botan::TLS::Handshake_Message {
    public:
       Stub_Handshake_Message(Handshake_Type type, std::vector<uint8_t> bytes) :
@@ -84,6 +130,10 @@ class Stub_Handshake_Message final : public Botan::TLS::Handshake_Message {
 };
 
 std::vector<Test::Result> dtls12_handshake_io_tests() {
+   const auto rng = Test::new_rng("dtls12_handshake_io_tests");
+
+   auto make_payload = [&rng](size_t len) { return rng->random_vec<std::vector<uint8_t>>(len); };
+
    return {
       CHECK(
          "protected handshake records respect MTU",
@@ -124,6 +174,319 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
             result.test_sz_eq(
                "unprotected message of that size is not fragmented", plaintext.sent_record_sizes().size(), size_t(1));
          }),
+
+      CHECK("single in-order ClientHello is delivered",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto payload = make_payload(64);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, payload));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered ClientHello", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload matches", bytes, payload);
+            }),
+
+      CHECK("multi-fragment reassembly in order",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto payload = make_payload(100);
+
+               const std::vector<uint8_t> p1(payload.begin(), payload.begin() + 40);
+               const std::vector<uint8_t> p2(payload.begin() + 40, payload.begin() + 75);
+               const std::vector<uint8_t> p3(payload.begin() + 75, payload.end());
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, p1));
+               result.test_is_true("not yet complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 40, p2));
+               result.test_is_true("still not complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 75, p3));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after final fragment", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("reassembled payload", bytes, payload);
+            }),
+
+      CHECK("out-of-order msg_seq waits for in-sequence message",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto p_seq0 = make_payload(50);
+               const auto p_seq1 = make_payload(60);
+
+               // Deliver message_seq=1 first
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 60, 1, 0, p_seq1));
+               result.test_is_true("seq=1 not delivered while waiting for seq=0",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // Now deliver message_seq=0; both should come out in order.
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, p_seq0));
+               auto [t0, b0] = fix.next_message();
+               result.test_enum_eq("first delivery is seq=0", t0, Handshake_Type::ClientHello);
+               result.test_bin_eq("seq=0 payload", b0, p_seq0);
+
+               auto [t1, b1] = fix.next_message();
+               result.test_enum_eq("second delivery is seq=1", t1, Handshake_Type::Certificate);
+               result.test_bin_eq("seq=1 payload", b1, p_seq1);
+            }),
+
+      // Regression test for the asymmetric DoS reported against the
+      // claim-based reassembly budget: an attacker sends header-only records
+      // for future message_seq values with a large declared msg_len. Before
+      // the fix, those records reserved the entire claimed msg_len against
+      // m_pending_reassembly_bytes and starved the legitimate ClientHello
+      // arriving at message_seq=0.
+      CHECK("header-only future-seq records do not block legit ClientHello",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               // Exhaust the cap if claim-based: 4 * 65536 == max_pending.
+               for(uint16_t seq = 1; seq <= 4; ++seq) {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size, seq, 0, {}));
+               }
+               result.test_is_true("attacker records yield no in-sequence message",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // The legit ClientHello must still get through.
+               const auto payload = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, payload));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit ClientHello delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("legit payload intact", bytes, payload);
+            }),
+
+      // Sparse segments cost far more than their payload, so a per-segment
+      // constant is charged as well. They also arrive out of sequence here, and
+      // out-of-sequence slots may only use part of the budget, so however many
+      // are sent the message actually being waited on still gets through.
+      CHECK("sparse one-byte segments cannot starve the expected message",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> one_byte = {0x42};
+               const uint32_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+
+               for(uint32_t offset = 0; offset < 40000; offset += 2) {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, big, 1, offset, one_byte));
+               }
+
+               const auto payload = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, payload));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("expected message still delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("its body is intact", bytes, payload);
+            }),
+
+      CHECK("tiny future-seq fragments do not exhaust the reassembly budget",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> fragment = {0x42};
+
+               // Saturate the reassembly window with 1-byte fragments
+               // claiming max msg_len at out-of-order msg_seq values.
+               for(uint16_t seq = 1; seq <= 8; ++seq) {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size, seq, 0, fragment));
+               }
+               result.test_is_true("no in-sequence delivery yet", fix.next_message().first == Handshake_Type::None);
+
+               // The legit msg_seq=0 ClientHello must still go through.
+               const std::vector<uint8_t> legit = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, legit));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit msg_seq=0 delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("legit body intact", bytes, legit);
+            }),
+
+      // Reassembly storage is sparse: a single-byte fragment at offset
+      // msg_length-1 must not pre-allocate msg_length bytes of buffer.
+      // Filling the gap afterwards still completes the message.
+      CHECK("sparse reassembly tolerates fragments at high offset",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const size_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+               const auto payload = make_payload(big);
+
+               // First the trailing 1 byte at offset big-1, then the
+               // leading big-1 bytes at offset 0. Eager merging produces a
+               // single contiguous segment and delivery succeeds.
+               const std::vector<uint8_t> tail(payload.end() - 1, payload.end());
+               const std::vector<uint8_t> head(payload.begin(), payload.end() - 1);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, static_cast<uint32_t>(big), 0, big - 1, tail));
+               result.test_is_true("not yet complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, static_cast<uint32_t>(big), 0, 0, head));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after gap fill", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("reassembled payload intact", bytes, payload);
+            }),
+
+      // Sibling check to the "tiny future-seq" test above using fully
+      // delivered payloads instead of one-byte fragments; confirms the cap
+      // is enforced symmetrically regardless of how much of each message
+      // the attacker actually sends.
+      CHECK("legitimately-large future-seq fragments are capped",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const size_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+
+               // max_pending = min(4 * 65536, 1 MiB) = 256 KiB, and each of these
+               // is charged its 64 KiB payload plus one segment's overhead, so
+               // only three fit. Whichever exceeds the cap must be dropped
+               // silently rather than throwing.
+               for(uint16_t seq = 1; seq <= 5; ++seq) {
+                  result.test_no_throw("oversize future-seq fragment dropped without exception", [&] {
+                     fix.feed(dtls_hs_record(
+                        Handshake_Type::ClientHello, static_cast<uint32_t>(big), seq, 0, make_payload(big)));
+                  });
+               }
+
+               // Fill the rest of what out-of-sequence slots are allowed with
+               // non-adjacent one-byte fragments.
+               const std::vector<uint8_t> one_byte = {0x42};
+               for(uint32_t offset = 0; offset < 4000; offset += 2) {
+                  fix.feed(
+                     dtls_hs_record(Handshake_Type::Certificate, static_cast<uint32_t>(big), 6, offset, one_byte));
+               }
+
+               // Whatever those slots consumed, the message being waited on keeps
+               // its own share of the budget.
+               const auto expected = make_payload(16);
+               result.test_no_throw("expected msg_seq=0 is still admitted",
+                                    [&] { fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 16, 0, 0, expected)); });
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("expected message delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("its body is intact", bytes, expected);
+            }),
+
+      // A whole-message retransmission overlapping an already-buffered partial
+      // copy must not be charged as if all its bytes were new: near the budget
+      // ceiling that misestimate dropped the one fragment able to complete the
+      // message, stalling reassembly permanently.
+      CHECK("overlapping retransmission is admitted near the budget ceiling",
+            [&](Test::Result& result) {
+               // max_pending = 4 * 512 = 2048, future-seq slots limited to half
+               Datagram_IO_Fixture fix(1000, 60000, std::nullopt, 1500, 512);
+
+               const auto msg = make_payload(512);
+
+               // Consume most of the out-of-sequence half of the budget
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 1, 0, make_payload(300)));
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 2, 0, make_payload(300)));
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 3, 0, make_payload(100)));
+
+               // All but the tail of the awaited message
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 0, 0, std::span(msg).first(500)));
+               result.test_is_true("partial message not yet complete",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // The peer retransmits the message unfragmented. Charged naively
+               // this would exceed the ceiling; merged, it replaces the partial
+               // copy and adds only the missing tail.
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 0, 0, msg));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("retransmitted message delivered", type, Handshake_Type::Certificate);
+               result.test_bin_eq("its body is intact", bytes, msg);
+            }),
+
+      // Empty handshake messages (msg_len == 0, e.g. ServerHelloDone) use a
+      // single record with fragment_length == 0; the zero-length filter must
+      // not eat them.
+      CHECK("empty handshake message is delivered",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               fix.feed(dtls_hs_record(Handshake_Type::ServerHelloDone, 0, 0, 0, {}));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered ServerHelloDone", type, Handshake_Type::ServerHelloDone);
+               result.test_sz_eq("no payload bytes", bytes.size(), size_t(0));
+            }),
+
+      CHECK("fragment past end of message is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // msg_len=10 but fragment claims offset=0, length=20.
+               result.template test_throws<Botan::Decoding_Error>("overflow rejected", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 10, 0, 0, make_payload(20)));
+               });
+            }),
+
+      CHECK("inconsistent fragment metadata is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, make_payload(20)));
+               result.template test_throws<Botan::Decoding_Error>("metadata mismatch rejected", [&] {
+                  // Same message_seq but advertise a different msg_type.
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 20, make_payload(10)));
+               });
+            }),
+
+      // RFC 6347 4.2.3 permits overlapping retransmissions, and overlapping bytes
+      // that disagree are a protocol error. For anything other than a
+      // ClientHello that stays an error.
+      CHECK("inconsistent overlapping bytes are rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // Partial first fragment so the slot is not yet complete; a
+               // completed slot silently ignores retransmissions.
+               const auto base = make_payload(50);
+               const std::vector<uint8_t> first(base.begin(), base.begin() + 30);
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 0, first));
+
+               auto bad = first;
+               bad[10] ^= 0xFF;
+               result.template test_throws<Botan::Decoding_Error>("overlap mismatch rejected", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 0, bad));
+               });
+            }),
+
+      CHECK("consistent retransmits are tolerated",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto p = make_payload(100);
+               const std::vector<uint8_t> half1(p.begin(), p.begin() + 50);
+               const std::vector<uint8_t> half2(p.begin() + 50, p.end());
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, half1));
+               // Same first half, repeated. Must not throw or alter state.
+               result.test_no_throw("retransmit accepted",
+                                    [&] { fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, half1)); });
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 50, half2));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after retransmit", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload unchanged by retransmit", bytes, p);
+            }),
+
+      CHECK("msg_len above policy max is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               result.template test_throws<TLS_Exception>("oversize msg_len rejected", [&] {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size + 1, 0, 0, {}));
+               });
+            }),
+
+      CHECK("message_seq beyond reassembly window is dropped",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // Window is 16 starting at m_in_message_seq=0, so seq=16 is
+               // out of window and should be silently ignored.
+               result.test_no_throw("out-of-window seq is silently dropped", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 32, 16, 0, make_payload(32)));
+               });
+               // The legit in-sequence message still works.
+               const auto p = make_payload(20);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 20, 0, 0, p));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit message delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload intact", bytes, p);
+            }),
 
       // Once the backoff saturates at m_max_timeout, the elapsed time since the
       // last write keeps growing, so a retransmit must re-anchor it. Otherwise
@@ -248,6 +611,44 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                fix.advance_clock_ms(next);
                result.test_throws("give-up only after the reset budget is exhausted",
                                   [&] { fix.io().timeout_check(); });
+            }),
+
+      // message_seq is 16 bits. Once it wraps, the next expected slot is one
+      // already delivered, whose buffers were released. Such a slot must not
+      // report itself complete: message() would fail its single-segment
+      // invariant.
+      CHECK("message_seq wrapping onto a delivered slot does not assert",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> body(4, 0x5A);
+               bool all_delivered = true;
+               for(size_t i = 0; i <= 0xFFFF && all_delivered; ++i) {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 4, static_cast<uint16_t>(i), 0, body));
+                  all_delivered = (fix.next_message().first == Handshake_Type::Certificate);
+               }
+               result.test_is_true("every message_seq up to the wrap was delivered", all_delivered);
+
+               // m_in_message_seq is back at 0, where a delivered sentinel sits.
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 4, 0, 0, body));
+
+               std::pair<Handshake_Type, std::vector<uint8_t>> after;
+               result.test_no_throw("wrapped slot is not mistaken for a complete message",
+                                    [&] { after = fix.next_message(); });
+               result.test_is_true("nothing is delivered from the released slot", after.first == Handshake_Type::None);
+
+               // format() names the message just delivered, so its guard is
+               // that one exists rather than that the counter is non-zero.
+               // Those differ here, and the difference used to be a reachable
+               // assertion. The subtraction wraps to 65535 of its own accord,
+               // which is the right sequence number for that message.
+               std::vector<uint8_t> formatted;
+               result.test_no_throw("format does not assert after the wrap",
+                                    [&] { formatted = fix.io().format(body, Handshake_Type::Certificate); });
+               if(result.test_is_true("format produced a header", formatted.size() >= 12)) {
+                  const uint16_t msg_seq = (static_cast<uint16_t>(formatted[4]) << 8) | formatted[5];
+                  result.test_sz_eq("it names the wrapped sequence number", msg_seq, size_t(0xFFFF));
+               }
             }),
 
       // A caller's monotonic clock may legitimately read zero, so sending the

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -445,6 +445,57 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                });
             }),
 
+      // A ClientHello is different: it begins a handshake, so nothing already in
+      // its slot belongs to the same one, and at epoch zero neither candidate is
+      // authenticated. Throwing would mean the ClientHello is what fails, so one
+      // planted fragment could deny every later handshake attempt. The newest
+      // ClientHello wins instead.
+      CHECK("a conflicting ClientHello supersedes an unauthenticated slot",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               // A planted fragment claiming a large message, at a high offset.
+               const std::vector<uint8_t> planted = {0xAA};
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 65536, 0, 65535, planted));
+               result.test_is_true("planted fragment completes nothing",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // The genuine ClientHello declares a different length.
+               const auto genuine = make_payload(48);
+               result.test_no_throw("conflicting ClientHello is not an error",
+                                    [&] { fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 48, 0, 0, genuine)); });
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("genuine ClientHello delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("genuine body intact", bytes, genuine);
+            }),
+
+      // Same reasoning for a byte-level conflict within a matching header.
+      CHECK("a ClientHello with conflicting overlap supersedes the slot",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto base = make_payload(50);
+               const std::vector<uint8_t> first(base.begin(), base.begin() + 30);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, first));
+
+               auto conflicting = first;
+               conflicting[10] ^= 0xFF;
+               result.test_no_throw("conflicting overlap is not an error", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, conflicting));
+               });
+
+               // The newest bytes are what remain, so completing from them works.
+               const std::vector<uint8_t> rest(base.begin() + 30, base.end());
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 30, rest));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after restart", type, Handshake_Type::ClientHello);
+               result.test_sz_eq("full length reassembled", bytes.size(), size_t(50));
+               result.test_bin_eq("first 30 bytes are the newer copy",
+                                  std::vector<uint8_t>(bytes.begin(), bytes.begin() + 30),
+                                  conflicting);
+            }),
+
       CHECK("consistent retransmits are tolerated",
             [&](Test::Result& result) {
                Datagram_IO_Fixture fix;

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -664,6 +664,49 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                                   [&] { fix.io().timeout_check(); });
             }),
 
+      // An unset dtls_maximum_retransmissions() means "retransmit on my own
+      // timer forever", which is a different proposition from "replay whenever an
+      // unauthenticated packet asks me to". The peer-cued budget must stay
+      // bounded whatever the timer policy says.
+      CHECK("peer-cued replays stay bounded when the timer budget is unlimited",
+            [&](Test::Result& result) {
+               constexpr std::optional<size_t> unlimited = std::nullopt;
+               Datagram_IO_Fixture fix(1000, 60000, unlimited);
+
+               fix.advance_clock_ms(1);
+               const auto real_ch = dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64));
+               fix.feed(real_ch);
+               result.test_is_true("priming ClientHello delivered",
+                                   fix.next_message().first == Handshake_Type::ClientHello);
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.reset_send_counter();
+
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               for(int i = 0; i < 200; ++i) {
+                  fix.feed(cue);
+               }
+
+               // With no timer budget to spend, the replay bound falls back to the
+               // policy default rather than becoming unlimited.
+               const size_t fallback_budget = Botan::TLS::Policy().dtls_maximum_retransmissions().value();
+               result.test_sz_eq(
+                  "replays bounded despite the unlimited timer", fix.handshake_records_sent(), fallback_budget);
+
+               // An authenticated record proves the peer is live and restores
+               // the budget; RFC 6347 4.2.4 requires answering its retransmits
+               // for as long as the association lasts.
+               const auto authenticated = dtls_hs_record(Handshake_Type::Certificate, 4, 1000, 0, make_payload(4));
+               fix.feed(authenticated, 1);
+               fix.reset_send_counter();
+
+               fix.feed(cue);
+               result.test_sz_eq(
+                  "an authenticated record restores the budget", fix.handshake_records_sent(), size_t(1));
+            }),
+
       // message_seq is 16 bits. Once it wraps, the next expected slot is one
       // already delivered, whose buffers were released. Such a slot must not
       // report itself complete: message() would fail its single-segment
@@ -700,6 +743,83 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                   const uint16_t msg_seq = (static_cast<uint16_t>(formatted[4]) << 8) | formatted[5];
                   result.test_sz_eq("it names the wrapped sequence number", msg_seq, size_t(0xFFFF));
                }
+            }),
+
+      // RFC 6347 4.2.4 has us replay our flight when the peer retransmits
+      // theirs, but the cue is unauthenticated epoch-zero data, so it must not
+      // be able to draw out a flight per datagram.
+      CHECK("peer-cued flight replays are bounded",
+            [&](Test::Result& result) {
+               constexpr uint64_t initial_timeout = 1000;
+               constexpr size_t max_replays = 3;
+               Datagram_IO_Fixture fix(initial_timeout, 60000, max_replays);
+
+               fix.advance_clock_ms(1);
+
+               // Deliver and consume a ClientHello so a msg_seq 0 record is
+               // afterwards a fragment of a previous message, then send a flight.
+               const auto real_ch = dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64));
+               fix.feed(real_ch);
+               result.test_is_true("priming ClientHello delivered",
+                                   fix.next_message().first == Handshake_Type::ClientHello);
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.reset_send_counter();
+
+               // The cue: a bare ClientHello whose body is never parsed.
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               // A legitimate peer's retransmit is answered at once, up to the
+               // per-flight budget. Past it the cues draw nothing.
+               for(size_t i = 0; i < max_replays; ++i) {
+                  fix.feed(cue);
+               }
+               result.test_sz_eq(
+                  "cues within the budget each replay the flight", fix.handshake_records_sent(), max_replays);
+
+               fix.reset_send_counter();
+               for(int i = 0; i < 20; ++i) {
+                  fix.feed(cue);
+               }
+               result.test_sz_eq("cues past the budget draw nothing", fix.handshake_records_sent(), size_t(0));
+
+               // Forward progress restores it, as it does for the timer. The
+               // flight now holds two messages, so a replay emits two records.
+               const Stub_Handshake_Message next(Handshake_Type::Certificate, std::vector<uint8_t>(64, 0x33));
+               fix.io().send(next);
+               fix.reset_send_counter();
+               fix.feed(cue);
+               result.test_sz_eq("a new flight restores the replay budget", fix.handshake_records_sent(), size_t(2));
+            }),
+
+      // A peer cueing faster than the timeout must not re-anchor the timer:
+      // that keeps it from ever expiring, so the handshake never gives up.
+      CHECK("peer cues do not hold off the give-up timer",
+            [&](Test::Result& result) {
+               constexpr uint64_t initial_timeout = 1000;
+               Datagram_IO_Fixture fix(initial_timeout, 60000, 3);
+
+               fix.advance_clock_ms(1);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64)));
+               fix.next_message();
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x22));
+               fix.io().send(sh);
+
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               bool gave_up = false;
+               for(int i = 0; i < 200 && !gave_up; ++i) {
+                  fix.advance_clock_ms(initial_timeout - 100);
+                  fix.feed(cue);
+                  try {
+                     fix.io().timeout_check();
+                  } catch(const Botan::TLS::TLS_Exception&) {
+                     gave_up = true;
+                  }
+               }
+               result.test_is_true("the handshake still gives up while being cued", gave_up);
             }),
 
       // A caller's monotonic clock may legitimately read zero, so sending the
@@ -784,7 +904,6 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                seqs.new_read_cipher_state();  // epoch 3
                result.test_is_true("window released two rekeys later", !seqs.already_seen(epoch1_seq));
             }),
-
    };
 }
 


### PR DESCRIPTION
Hardens DTLS against misbehaving peers and networks. The individual commits are fairly well contained. The main themes of the overall branch are

* Offpath attackers injecting packets should not be able to successfully disrupt an active connection or in-progress handshake.
* Avoid denial of service from a misbehaving peer. Prevent fragmented handshake messages from consuming unbounded memory. Bound retransmissions and eventually give up rather than transmitting forever. Discard state that is no longer needed.
* Avoid allowing unsafe configurations. It is now required for DTLS servers to implement `tls_peer_network_identity` and to have a non-empty DTLS cookie secret. CBC mode and CCM-8 are both outright prohibited in DTLS; CBC due to the residual Lucky13 timing channel and CCM-8 due to the short MAC which allows packet forgery given sufficient attempts.

This also extends the BoGo shim to implement the clock manipulation logic and enables a number of DTLS retransmission tests.

@reneme would appreciate a review, I know timeline is short but I think this is a must-merge for 3.13, I would rather delay the release by another week than not ship.
@Thiesius fyi