### PR TITLE
Refuse unsafe ciphersuites in DTLS

### DIFF
--- a/src/lib/tls/tls_ciphersuite.cpp
+++ b/src/lib/tls/tls_ciphersuite.cpp
@@ -100,6 +100,11 @@ bool Ciphersuite::aead_ciphersuite() const {
    return (mac_algo() == "AEAD");
 }
 
+bool Ciphersuite::uses_short_authentication_tag() const {
+   // The only AEAD we currently support that has a short tag is CCM-8
+   return cipher_algo().ends_with("/CCM(8)");
+}
+
 bool Ciphersuite::signature_used() const {
    return auth_method() != Auth_Method::IMPLICIT;
 }

--- a/src/lib/tls/tls_ciphersuite.h
+++ b/src/lib/tls/tls_ciphersuite.h
@@ -86,6 +86,12 @@ class BOTAN_PUBLIC_API(2, 0) Ciphersuite final {
        */
       bool aead_ciphersuite() const;
 
+      /**
+       * @return true if this suite uses a short (less than 128 bit)
+       * authentication tag, for instance one of the _CCM_8 suites.
+       */
+      bool uses_short_authentication_tag() const;
+
       bool signature_used() const;
 
       /**

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -606,6 +606,23 @@ std::vector<uint16_t> Policy::ciphersuite_list(Protocol_Version version) const {
          continue;  // unsupported cipher
       }
 
+      // Our non EtM TLS-CBC decryption step still has a residual Lucky13 timing
+      // channel. The leak is minor but for DTLS, which allows repeated
+      // observations, that is likely more than enough to allow plaintext
+      // recovery. Refuse CBC suites in DTLS.
+      if(version.is_datagram_protocol() && suite.cbc_ciphersuite()) {
+         continue;
+      }
+
+      // In DTLS, prohibit any potentially brute-forceable MACs
+      //
+      // DTLS allows repeated attempts without a connection teardown, and we
+      // don't currently offer any facility for an application to respond to
+      // a flood of invalid packets.
+      if(version.is_datagram_protocol() && suite.uses_short_authentication_tag()) {
+         continue;
+      }
+
       // these checks are irrelevant for TLS 1.3
       // TODO: consider making a method for this logic
       if(version.is_pre_tls_13()) {

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -924,6 +924,27 @@ class TLS_Unit_Tests final : public Test {
          };
       }
 
+      // Policy::ciphersuite_list refuses both CBC+HMAC and _CCM_8 suites for
+      // DTLS, so those policies leave no DTLS ciphersuite to negotiate.
+      static std::vector<Botan::TLS::Protocol_Version> versions_for_policy(
+         std::vector<Test::Result>& results,
+         std::vector<Botan::TLS::Protocol_Version> versions,
+         const std::string& cipher_policy,
+         const std::string& mac_policy) {
+         const bool dtls_has_no_suite =
+            (mac_policy != "AEAD") || (cipher_policy != "NULL") || cipher_policy.find("CCM(8)") != std::string::npos;
+
+         if(dtls_has_no_suite) {
+            std::erase_if(versions, [](const auto& version) { return version.is_datagram_protocol(); });
+            Test::Result result("DTLS ciphersuite filtering");
+   #if defined(BOTAN_HAS_TLS_12)
+            result.test_sz_gte("At least one testable version remains", versions.size(), 1);
+   #endif
+            results.push_back(result);
+         }
+         return versions;
+      }
+
       static void enable_versions([[maybe_unused]] const std::shared_ptr<Test_Policy>& policy,
                                   [[maybe_unused]] std::span<const Botan::TLS::Protocol_Version> versions) {
          for(const auto& version : versions) {
@@ -1014,7 +1035,9 @@ class TLS_Unit_Tests final : public Test {
             policy->set("signature_methods", "IMPLICIT");
          }
 
-         return test_with_policy(test_descr, results, creds, legacy_versions(), policy, rng, client_auth);
+         const auto versions = versions_for_policy(results, legacy_versions(), cipher_policy, mac_policy);
+
+         return test_with_policy(test_descr, results, creds, versions, policy, rng, client_auth);
       }
 
       /**
@@ -1059,7 +1082,9 @@ class TLS_Unit_Tests final : public Test {
             policy->set(kv.first, kv.second);
          }
 
-         return test_with_policy(test_descr, results, creds, available_versions(), policy, rng, client_auth);
+         const auto versions = versions_for_policy(results, available_versions(), cipher_policy, mac_policy);
+
+         return test_with_policy(test_descr, results, creds, versions, policy, rng, client_auth);
       }
 
       void test_session_established_abort(std::vector<Test::Result>& results,

--- a/src/tests/unit_tls_policy.cpp
+++ b/src/tests/unit_tls_policy.cpp
@@ -9,6 +9,8 @@
 #include "tests.h"
 
 #if defined(BOTAN_HAS_TLS)
+   #include <botan/assert.h>
+   #include <botan/tls_ciphersuite.h>
    #include <botan/tls_exceptn.h>
    #include <botan/tls_policy.h>
 #endif
@@ -50,8 +52,70 @@ class TLS_Policy_Unit_Tests final : public Test {
          results.push_back(test_peer_key_acceptable_dh());
          results.push_back(test_key_exchange_groups_to_offer());
          results.push_back(test_require_extended_master_secret());
+         results.push_back(test_dtls_refuses_weak_ciphersuites());
 
          return results;
+      }
+
+      // RFC 9147 4.5.3 forbids _CCM_8 in DTLS absent forgery safeguards Botan does
+      // not implement, and CBC+HMAC keeps a residual timing channel that DTLS
+      // makes observable many times per association. Both are refused for DTLS
+      // while remaining available to stream TLS.
+      static Test::Result test_dtls_refuses_weak_ciphersuites() {
+         Test::Result result("TLS Policy DTLS ciphersuite refusals");
+
+         class Permissive_Policy final : public Botan::TLS::Policy {
+            public:
+               std::vector<std::string> allowed_ciphers() const override {
+                  return {"AES-256/CCM(8)", "AES-128/CCM(8)", "AES-256/CCM", "AES-128/CCM", "AES-128/GCM", "AES-128"};
+               }
+
+               std::vector<std::string> allowed_macs() const override { return {"AEAD", "SHA-256", "SHA-1"}; }
+
+               bool allow_tls12() const override { return true; }
+
+               bool allow_dtls12() const override { return true; }
+         };
+
+         const Permissive_Policy policy;
+
+         auto classify = [&](Botan::TLS::Protocol_Version version) {
+            size_t ccm_8 = 0;
+            size_t cbc = 0;
+            for(const auto id : policy.ciphersuite_list(version)) {
+               const auto suite = Botan::TLS::Ciphersuite::by_id(id);
+               if(!suite.has_value()) {
+                  continue;
+               }
+               if(suite->uses_short_authentication_tag()) {
+                  ccm_8 += 1;
+               }
+               if(suite->cbc_ciphersuite()) {
+                  cbc += 1;
+               }
+            }
+            return std::make_pair(ccm_8, cbc);
+         };
+
+         const auto [tls_ccm_8, tls_cbc] = classify(Botan::TLS::Protocol_Version::TLS_V12);
+         const auto [dtls_ccm_8, dtls_cbc] = classify(Botan::TLS::Protocol_Version::DTLS_V12);
+
+         // Guard against the test passing because the policy offered none at all.
+   #if defined(BOTAN_HAS_AEAD_CCM)
+         result.test_is_true("TLS 1.2 still offers CCM_8 suites", tls_ccm_8 > 0);
+   #endif
+   #if defined(BOTAN_HAS_TLS_CBC)
+         result.test_is_true("TLS 1.2 still offers CBC suites", tls_cbc > 0);
+   #endif
+         BOTAN_UNUSED(tls_ccm_8, tls_cbc);
+
+         result.test_sz_eq("DTLS 1.2 offers no CCM_8 suite", dtls_ccm_8, 0);
+         result.test_sz_eq("DTLS 1.2 offers no CBC suite", dtls_cbc, 0);
+         result.test_sz_gte("DTLS 1.2 still has usable suites",
+                            policy.ciphersuite_list(Botan::TLS::Protocol_Version::DTLS_V12).size(),
+                            1);
+
+         return result;
       }
 
       static Test::Result test_require_extended_master_secret() {


### PR DESCRIPTION
Our Lucky13 countermeasure is decent but not completely constant time, and DTLS offers a repeated oracle. So reject CBC modes in DTLS.

Similarly, CCM-8 has only a 64-bit MAC so the relevant standards suggest not supporting CCM-8 in DTLS.

Extracted from #5783 