### PR TITLE
Require address-bound cookies for DTLS servers

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -2149,6 +2149,8 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks {
          return g_now + m_clock_skew;
       }
 
+      std::string tls_peer_network_identity() override { return "bogo-shim-peer"; }
+
       void tls_inspect_handshake_msg(const Botan::TLS::Handshake_Message& msg) override {
          if(msg.type() == Botan::TLS::Handshake_Type::HelloRetryRequest) {
             m_hello_retry_request = true;

--- a/src/lib/tls/tls12/msg_hello_verify.cpp
+++ b/src/lib/tls/tls12/msg_hello_verify.cpp
@@ -32,9 +32,9 @@ Hello_Verify_Request::Hello_Verify_Request(std::span<const uint8_t> buf) {
 
 Hello_Verify_Request::Hello_Verify_Request(std::span<const uint8_t> client_hello_bits,
                                            std::string_view client_identity,
-                                           const SymmetricKey& secret_key) {
+                                           std::span<const uint8_t> cookie_secret) {
    auto hmac = MessageAuthenticationCode::create_or_throw("HMAC(SHA-256)");
-   hmac->set_key(secret_key);
+   hmac->set_key(cookie_secret);
 
    hmac->update_be(static_cast<uint64_t>(client_hello_bits.size()));
    hmac->update(client_hello_bits);

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -259,6 +259,28 @@ std::map<std::string, std::vector<X509_Certificate>> get_server_certs(
    return cert_chains;
 }
 
+secure_vector<uint8_t> load_dtls_cookie_secret(Credentials_Manager& creds) {
+   auto cookie_secret = [&]() -> secure_vector<uint8_t> {
+      try {
+         return creds.psk("tls-server", "dtls-cookie-secret", "").bits_of();
+      } catch(...) {
+         return {};
+      }
+   }();
+
+   if(cookie_secret.empty()) {
+      // TODO(Botan4): Simplify this error message that was meant to ease the
+      //               burden on users running into a deliberate semver violation.
+      throw Invalid_State(
+         "Since Botan 3.13 DTLS server requires setting a non-empty cookie secret. "
+         "Either override Credentials_Manager::dtls_cookie_secret() or disable the "
+         "cookie exchange using TLS::Policy::dtls_server_require_cookie_exchange(), "
+         "if you understand the security implications of doing so.");
+   }
+
+   return cookie_secret;
+}
+
 }  // namespace
 
 Server_Impl_12::Server_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
@@ -270,6 +292,12 @@ Server_Impl_12::Server_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
                                size_t io_buf_sz) :
       Channel_Impl_12(callbacks, session_manager, rng, policy, true, is_datagram, io_buf_sz), m_creds(creds) {
    BOTAN_ASSERT_NONNULL(m_creds);
+
+   // Try to load the cookie secret on initialization, rather than waiting to fail
+   // until the first client connects.
+   if(is_datagram && policy->dtls_server_require_cookie_exchange()) {
+      load_dtls_cookie_secret(*m_creds);
+   }
 }
 
 Server_Impl_12::Server_Impl_12(const Channel_Impl::Downgrade_Information& downgrade_info) :
@@ -420,31 +448,34 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
       throw TLS_Exception(Alert::IllegalParameter, "Client did not offer NULL compression");
    }
 
-   if(initial_handshake && datagram) {
-      SymmetricKey cookie_secret;
+   if(initial_handshake && datagram && policy().dtls_server_require_cookie_exchange()) {
+      // The cookie secret is read each time to allow for refreshing the key
+      const auto cookie_secret = load_dtls_cookie_secret(*m_creds);
 
-      try {
-         cookie_secret = m_creds->psk("tls-server", "dtls-cookie-secret", "");
-      } catch(...) {}
+      const std::string client_identity = callbacks().tls_peer_network_identity();
+      if(client_identity.empty()) {
+         // RFC 9147 Section 11: the cookie MUST depend on the client's address
+         //
+         // Without an application-supplied identity the cookie is reusable from
+         // any source address, defeating the whole point of the cookie exchange.
+         //
+         // TODO(Botan4): Remove the version hint about the breaking change.
+         throw Invalid_State(
+            "Since Botan 3.13 DTLS server requires tls_peer_network_identity() return a non-empty value");
+      }
+      const Hello_Verify_Request verify(
+         pending_state.client_hello()->cookie_input_data(), client_identity, cookie_secret);
 
-      if(!cookie_secret.empty()) {
-         const std::string client_identity = callbacks().tls_peer_network_identity();
-         const Hello_Verify_Request verify(
-            pending_state.client_hello()->cookie_input_data(), client_identity, cookie_secret);
-
-         if(!CT::is_equal<uint8_t>(pending_state.client_hello()->cookie(), verify.cookie()).as_bool()) {
-            if(epoch0_restart) {
-               pending_state.handshake_io().send_under_epoch(verify, 0);
-            } else {
-               pending_state.handshake_io().send(verify);
-            }
-
-            pending_state.client_hello(nullptr);
-            pending_state.set_expected_next(Handshake_Type::ClientHello);
-            return;
+      if(!CT::is_equal<uint8_t>(pending_state.client_hello()->cookie(), verify.cookie()).as_bool()) {
+         if(epoch0_restart) {
+            pending_state.handshake_io().send_under_epoch(verify, 0);
+         } else {
+            pending_state.handshake_io().send(verify);
          }
-      } else if(epoch0_restart) {
-         throw TLS_Exception(Alert::HandshakeFailure, "Reuse of DTLS association requires DTLS cookie secret be set");
+
+         pending_state.client_hello(nullptr);
+         pending_state.set_expected_next(Handshake_Type::ClientHello);
+         return;
       }
    }
 

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -638,14 +638,16 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks /* NOLINT(*-special-member-functions) */ 
       virtual std::optional<OCSP::Response> tls_parse_ocsp_response(const std::vector<uint8_t>& raw_response);
 
       /**
-       * Optional callback: return peer network identity
+       * Callback: return peer network identity
        *
        * There is no expected or specified format. The only expectation is this
        * function will return a unique value. For example returning the peer
        * host IP and port.
        *
-       * This is used to bind the DTLS cookie to a particular network identity.
-       * It is only called if the dtls-cookie-secret PSK is also defined.
+       * This is used to bind the DTLS cookie to a particular network identity
+       * (RFC 6347 4.2.1 / RFC 9147 11: "the cookie MUST depend on the client's
+       * address"). DTLS servers MUST override this to return a non-empty value;
+       * the default empty implementation will cause cookie verification to throw.
        */
       virtual std::string tls_peer_network_identity();
 

--- a/src/lib/tls/tls_messages.h
+++ b/src/lib/tls/tls_messages.h
@@ -30,9 +30,6 @@ class X509_Certificate;
 class X509_DN;
 class RandomNumberGenerator;
 
-class OctetString;
-typedef OctetString SymmetricKey;
-
 namespace OCSP {
 class Response;
 }
@@ -67,7 +64,7 @@ class BOTAN_UNSTABLE_API Hello_Verify_Request final : public Handshake_Message {
 
       Hello_Verify_Request(std::span<const uint8_t> client_hello_bits,
                            std::string_view client_identity,
-                           const SymmetricKey& secret_key);
+                           std::span<const uint8_t> cookie_secret);
 
    private:
       std::vector<uint8_t> m_cookie;

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -471,6 +471,22 @@ bool Policy::allow_dtls_epoch0_restart() const {
    return false;
 }
 
+bool Policy::dtls_server_require_cookie_exchange() const {
+   /*
+   RFC 9147 Section 11 "Security Considerations":
+
+      The primary additional security consideration raised by DTLS is that of
+      denial of service by excessive resource consumption. DTLS includes a
+      cookie exchange designed to protect against denial of service. [...]
+      In particular, DTLS servers that do not use the cookie exchange may be
+      used as attack amplifiers even if they themselves are not experiencing
+      DoS. Therefore, DTLS servers SHOULD use the cookie exchange unless there
+      is good reason to believe that amplification is not a threat in their
+      environment.
+   */
+   return true;
+}
+
 size_t Policy::maximum_handshake_message_size() const {
    return 65536;
 }

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -535,6 +535,31 @@ class BOTAN_PUBLIC_API(2, 0) Policy /* NOLINT(*-special-member-functions) */ {
       virtual bool allow_dtls_epoch0_restart() const;
 
       /**
+      * DTLS defines an cookie exchange protocol which is used to ensure routability on
+      * the path between the server and client. This is especially useful when using a
+      * connectionless datagram layer like UDP, where a client's source address can
+      * easily be spoofed.
+      *
+      * This cookie exchange prevents abusing the server for DoS amplification attacks,
+      * and additionally provides assurance for the server that the client's purported
+      * address is theirs, which can be helpful for attribution/logging purposes.
+      *
+      * The server creates cookies by hashing the original client hello and the peer's
+      * source address along with a secret key. The cookie value is then sent back to
+      * the client address. The client can then retry the connection, with their updated
+      * client hello including the cookie value. So this cookie exchange implies one
+      * extra round trip during the handshake.
+      *
+      * By default this function returns true. If this function returns true then the
+      * DTLS session cookie `Credentials_Manager::dtls_cookie_secret` must be set, and
+      * `TLS::Callbacks::tls_peer_network_identity` must return a non-empty string.
+      *
+      * It is unsafe to disable this cookie exchange if the server is exposed to
+      * arbitrary Internet traffic.
+      */
+      virtual bool dtls_server_require_cookie_exchange() const;
+
+      /**
       * Return allowed ciphersuites, in order of preference for the provided
       * protocol version.
       *

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -76,6 +76,9 @@ class DTLS_Test_Callbacks final : public Botan::TLS::Callbacks {
          }
       }
 
+      // A DTLS server requires a non-empty peer identity to bind the cookie to.
+      std::string tls_peer_network_identity() override { return "test-peer"; }
+
       void tls_session_established(const Botan::TLS::Session_Summary& session) override {
          m_session_was_resumption = session.was_resumption();
          ++m_sessions_established;
@@ -879,6 +882,49 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // RFC 6347 4.2.1: "Note to implementors: This may result in clients
+      // receiving multiple HelloVerifyRequest messages with different cookies.
+      // Clients SHOULD handle this by sending a new ClientHello with a cookie
+      // in response to the new HelloVerifyRequest."
+      static Test::Result test_rotated_cookie_secret_produces_fresh_hello_verify_request() {
+         Test::Result result("DTLS fresh HelloVerifyRequest after cookie secret rotation");
+
+         auto rng = Test::new_shared_rng("dtls-core-rotated-cookie-secret");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         deliver(result, "client hello 1", c2s, server);
+         result.test_is_true("server sent HelloVerifyRequest",
+                             contains_dtls_handshake_type(s2c, Botan::TLS::Handshake_Type::HelloVerifyRequest));
+         deliver(result, "hello verify request", s2c, client);
+
+         // The cookie the client is about to present is now signed under a
+         // secret the server no longer uses.
+         assoc->creds->rotate_cookie_secret();
+
+         deliver(result, "client hello 2 carrying the stale cookie", c2s, server);
+         result.test_is_true("server re-challenges with a fresh HelloVerifyRequest",
+                             contains_dtls_handshake_type(s2c, Botan::TLS::Handshake_Type::HelloVerifyRequest));
+
+         deliver(result, "fresh hello verify request", s2c, client);
+         if(!result.test_is_true("client answers the fresh HelloVerifyRequest", !c2s.empty())) {
+            return result;
+         }
+
+         deliver(result, "client hello 3 carrying the rotated cookie", c2s, server);
+         deliver(result, "server handshake flight", s2c, client);
+         deliver(result, "client final flight", c2s, server);
+         deliver(result, "server final flight", s2c, client);
+
+         result.test_is_true("client became active", client.is_active());
+         result.test_is_true("server became active", server.is_active());
+
+         return result;
+      }
+
       static Test::Result test_duplicate_server_flight_defers_to_timer() {
          Test::Result result("DTLS duplicate server flight defers replay to timer");
 
@@ -1475,6 +1521,7 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_retransmitted_epoch_transition_flight_includes_ccs(),
                  test_lost_hello_verify_request_retransmits(),
                  test_duplicate_hello_verify_request_is_tolerated(),
+                 test_rotated_cookie_secret_produces_fresh_hello_verify_request(),
                  test_partial_server_flight_does_not_advance_client(),
                  test_lost_server_flight_retransmits(),
                  test_duplicate_server_flight_defers_to_timer(),

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -515,6 +515,8 @@ class TLS_Handshake_Test final {
                return "test/1";
             }
 
+            std::string tls_peer_network_identity() override { return "test-peer"; }
+
             std::unique_ptr<Botan::PK_Key_Agreement_Key> tls_generate_ephemeral_key(
                const std::variant<Botan::TLS::Group_Params, Botan::DL_Group>& group,
                Botan::RandomNumberGenerator& rng) override {


### PR DESCRIPTION
Previously an application could skip implementing tls_peer_network_identity, which would have the effect of making the cookie exchange trivially bypassed since the cookies would not be bound to the source address. Now, if DTLS cookies are being used, tls_peer_network_identity must return a non-empty string.

Additionally, add a new Policy toggle dtls_server_require_cookie_exchange. If true (the default) then the cookie exchange is required. Previously an application indicated a desire to use the cookie exchange by returning a DTLS cookie secret. But a misconfigured application could easily just not configure such a secret, in which case the cookie exchange is silently disabled. The new policy switch makes such a misconfiguration a hard error - an application must now do something *explicit* (namely overriding dtls_server_require_cookie_exchange to return false) in order to disable the cookie exchange.

Split out from #5783 