### PR TITLE
Ensure TLS roles are respected during session resumption

### DIFF
--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -82,6 +82,13 @@ std::optional<Session> check_for_resume(const Session_Handle& handle_to_resume,
       return std::nullopt;
    }
 
+   // A session manager shared with our client role must not resume a session
+   // here that we stored as a client: its peer certificates are a remote
+   // server's, and this connection would adopt them as the client's.
+   if(session->side() != Connection_Side::Server) {
+      return std::nullopt;
+   }
+
    // wrong version
    if(client_hello->legacy_version() != session->version()) {
       return std::nullopt;

--- a/src/lib/tls/tls13/tls_extensions_psk.cpp
+++ b/src/lib/tls/tls13/tls_extensions_psk.cpp
@@ -303,11 +303,16 @@ std::unique_ptr<PSK> PSK::select_offered_psk(std::string_view host,
          session_mgr.choose_from_offered_tickets(psk_identities, cipher.prf_algo(), callbacks, policy)) {
       auto& [session, psk_index] = selected_session.value();
 
+      // A session manager shared with our client role must not resume a session
+      // here that we stored as a client: its peer certificates are a remote
+      // server's, and this connection would adopt them as the client's.
+      const bool established_as_server = session.side() == Connection_Side::Server;
+
       // Refuse to resume a ticket across SNI: a session minted for one
       // virtual host must not be presentable against another. Treat as a
       // cache miss and fall through to the external PSK path rather than
       // failing the connection.
-      if(session.server_info().hostname() == host) {
+      if(established_as_server && session.server_info().hostname() == host) {
          // RFC 8446 4.6.1
          //    Any ticket MUST only be resumed with a cipher suite that has the
          //    same KDF hash algorithm as that used to establish the original

--- a/src/lib/tls/tls_session_manager.cpp
+++ b/src/lib/tls/tls_session_manager.cpp
@@ -52,6 +52,14 @@ std::optional<Session> Session_Manager::retrieve(const Session_Handle& handle,
       return std::nullopt;
    }
 
+   // A session stored while acting as a TLS client must never be resumed in the
+   // server role. Its peer certificates are a remote *server's*, so accepting it
+   // here would present them as this connection's client certificates. The
+   // session is left in storage; it remains valid for the client role.
+   if(session->side() != Connection_Side::Server) {
+      return std::nullopt;
+   }
+
    // A value of '0' means: No policy restrictions.
    const std::chrono::seconds policy_lifetime =
       (policy.session_ticket_lifetime().count() > 0) ? policy.session_ticket_lifetime() : std::chrono::seconds::max();
@@ -108,6 +116,16 @@ std::vector<Session_with_Handle> Session_Manager::find_and_filter(const Server_I
       sessions_and_handles = find_some(info, max_sessions_hint);
 
       // ... underlying implementation didn't find anything. Early exit.
+      if(sessions_and_handles.empty()) {
+         break;
+      }
+
+      // The counterpart to the role check in retrieve(): a session established
+      // while acting as a TLS server must not be offered for resumption as a
+      // client. These are left in storage as they remain valid for the server
+      // role, so a retry would just yield them again.
+      std::erase_if(sessions_and_handles,
+                    [](const auto& session) { return session.session.side() != Connection_Side::Client; });
       if(sessions_and_handles.empty()) {
          break;
       }

--- a/src/lib/tls/tls_session_manager.h
+++ b/src/lib/tls/tls_session_manager.h
@@ -137,6 +137,11 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager /* NOLINT(*-special-member-function
        * check fails, the default implementation calls Session_Manager::remove()
        * for the provided @p handle.
        *
+       * Sessions that were stored by a TLS client (via Session_Manager::store())
+       * are never returned, as applications may share a single manager between
+       * a client and a server role. Such sessions are not removed; they remain
+       * valid for the client role.
+       *
        * Applications that wish to implement their own Session_Manager may
        * override the default implementation to add further policy checks.
        * Though, typically implementing Session_Manager::retrieve_one() and
@@ -161,6 +166,11 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager /* NOLINT(*-special-member-function
        * The default implementation will invoke Session_Manager::find_some() and
        * filter the result against a policy. Most notably an expiry check.
        * Expired sessions will be removed via Session_Manager::remove().
+       *
+       * Sessions that were established by a TLS server (via
+       * Session_Manager::establish()) are never returned, as applications may
+       * share a single manager between a client and a server role. Such
+       * sessions are not removed; they remain valid for the server role.
        *
        * The TLS client implementations will query the session manager exactly
        * once per handshake attempt. If no reuse is desired, the session manager

--- a/src/tests/test_tls_rfc8448.cpp
+++ b/src/tests/test_tls_rfc8448.cpp
@@ -810,6 +810,27 @@ std::vector<MockSignature> make_mock_signatures(const VarMap& vars) {
 }
 
 /**
+ * RFC 8448 records resumption state from the client's point of view. A server
+ * would hold the same session under its own role, with the peer certificates
+ * being the client's (here: none, the client did not authenticate). Sessions do
+ * not cross the client/server boundary, so server tests need this variant.
+ */
+Botan::TLS::Session as_server_session(const Botan::TLS::Session& session) {
+   return Botan::TLS::Session(
+      session.master_secret(),
+      session.supports_early_data() ? std::optional(session.max_early_data_bytes()) : std::nullopt,
+      session.session_age_add(),
+      session.lifetime_hint(),
+      session.version(),
+      session.ciphersuite_code(),
+      Botan::TLS::Connection_Side::Server,
+      {},
+      nullptr,
+      session.server_info(),
+      session.start_time());
+}
+
+/**
  * Traffic transcripts and supporting data for the TLS RFC 8448 and TLS policy
  * configuration is kept in data files (accessible via `Test:::data_file()`).
  *
@@ -1779,7 +1800,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                         add_early_data_and_sort,
                         make_mock_signatures(vars),
                         false,
-                        std::pair{Botan::TLS::Session(vars.get_req_bin("Client_SessionData")),
+                        std::pair{as_server_session(Botan::TLS::Session(vars.get_req_bin("Client_SessionData"))),
                                   Botan::TLS::Session_Ticket(vars.get_req_bin("SessionTicket"))});
                      result.test_is_true("server not closed", !ctx->server.is_closed());
 
@@ -1950,7 +1971,7 @@ class Test_TLS_RFC8448_Server : public Test_TLS_RFC8448 {
                         add_cookie_and_sort,
                         make_mock_signatures(vars),
                         false,
-                        std::pair{Botan::TLS::Session(vars.get_req_bin("Client_SessionData")),
+                        std::pair{as_server_session(Botan::TLS::Session(vars.get_req_bin("Client_SessionData"))),
                                   Botan::TLS::Session_Ticket(vars.get_req_bin("SessionTicket"))});
                      result.test_is_true("server not closed", !ctx->server.is_closed());
 

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -123,6 +123,33 @@ const Botan::TLS::Server_Information& server_info() {
    return si;
 }
 
+using Named_Session_Manager = std::pair<std::string, std::unique_ptr<Botan::TLS::Session_Manager>>;
+
+/**
+ * A freshly constructed instance of every Session_Manager that can both store
+ * and look up sessions in this build. Session_Manager_Stateless is omitted as
+ * it can do neither.
+ */
+std::vector<Named_Session_Manager> all_available_session_managers(
+   const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+   std::vector<Named_Session_Manager> managers;
+
+   managers.emplace_back("In Memory", std::make_unique<Botan::TLS::Session_Manager_In_Memory>(rng, 10));
+
+   managers.emplace_back("Hybrid",
+                         std::make_unique<Botan::TLS::Session_Manager_Hybrid>(
+                            std::make_unique<Botan::TLS::Session_Manager_In_Memory>(rng, 10),
+                            std::make_shared<Test_Credentials_Manager>(),
+                            rng));
+
+   #if defined(BOTAN_HAS_TLS_SQLITE3_SESSION_MANAGER)
+   managers.emplace_back("SQLite",
+                         std::make_unique<Botan::TLS::Session_Manager_SQLite>("secure_pw", rng, ":memory:", 10));
+   #endif
+
+   return managers;
+}
+
 decltype(auto) default_session(Botan::TLS::Connection_Side side,
                                Botan::TLS::Callbacks& cbs,
                                Botan::TLS::Protocol_Version version = Botan::TLS::Protocol_Version::TLS_V12) {
@@ -195,17 +222,11 @@ std::vector<Test::Result> test_session_manager_in_memory() {
                }
             }),
 
-      CHECK(
-         "obtain session from server info",
-         [&](auto& result) {
-            auto sessions = mgr->find(server_info(), cbs, plcy);
-            if(result.test_is_true("session was found successfully", sessions.size() == 1)) {
-               result.test_u16_eq("protocol version was echoed", sessions[0].session.version().version_code(), 0x0303);
-               result.test_u16_eq("ciphersuite was echoed", sessions[0].session.ciphersuite_code(), uint16_t(0x009C));
-               result.test_bin_eq("ID was echoed", sessions[0].handle.id().value(), default_id);
-               result.test_is_true("not a ticket", !sessions[0].handle.ticket().has_value());
-            }
-         }),
+      CHECK("server-side session is not offered to the client role",
+            [&](auto& result) {
+               result.test_is_true("session established as a server is not found via server info",
+                                   mgr->find(server_info(), cbs, plcy).empty());
+            }),
 
       CHECK("obtain session from ID",
             [&](auto& result) {
@@ -255,7 +276,8 @@ std::vector<Test::Result> test_session_manager_in_memory() {
             const Botan::TLS::Session_ID new_id = random_id(*rng);
 
             mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs), new_id);
-            result.require("obtain via ID", mgr->retrieve(new_id, cbs, plcy).has_value());
+            result.test_is_true("client-side session is not retrievable by the server role",
+                                !mgr->retrieve(new_id, cbs, plcy).has_value());
 
             auto sessions = mgr->find(server_info(), cbs, plcy);
             if(result.test_is_true("found via server info", sessions.size() == 1)) {
@@ -301,12 +323,15 @@ std::vector<Test::Result> test_session_manager_in_memory() {
                   "saving worked",
                   new_session2.has_value() && new_session2->id().has_value() && !new_session2->ticket().has_value());
 
-               result.test_sz_eq("can find via server info", local_mgr.find(server_info(), cbs, plcy).size(), 2);
+               result.test_is_true("can obtain both via ID",
+                                   local_mgr.retrieve(default_id, cbs, plcy).has_value() &&
+                                      local_mgr.retrieve(new_session2->id().value(), cbs, plcy).has_value());
 
                result.test_sz_eq("one was deleted", local_mgr.remove(default_id), 1);
                result.test_is_true("cannot obtain via default ID anymore",
                                    !local_mgr.retrieve(default_id, cbs, plcy).has_value());
-               result.test_sz_eq("can find less via server info", local_mgr.find(server_info(), cbs, plcy).size(), 1);
+               result.test_is_true("the other one is still there",
+                                   local_mgr.retrieve(new_session2->id().value(), cbs, plcy).has_value());
 
                result.test_sz_eq("last one was deleted",
                                  local_mgr.remove(Botan::TLS::Opaque_Session_Handle(new_session2->id().value())),
@@ -1000,6 +1025,106 @@ std::vector<Test::Result> test_session_manager_sqlite() {
    #endif
 }
 
+// Applications may share a single Session_Manager between a TLS client and a
+// TLS server role. A session must never cross that boundary.
+
+std::vector<Test::Result> tls_session_manager_client_session_not_for_server() {
+   auto rng = Test::new_shared_rng(__func__);
+   Session_Manager_Callbacks cbs;
+   Session_Manager_Policy plcy;
+
+   std::vector<Test::Result> results;
+   for(auto& [name, mgr] : all_available_session_managers(rng)) {
+      Test::Result result(Botan::fmt("TLS client session cannot be resumed by the server role ({})", name));
+
+      const auto handle = random_id(*rng);
+      mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle);
+
+      result.test_is_true("not retrievable by ID", !mgr->retrieve(handle, cbs, plcy).has_value());
+      result.test_is_true("not retrievable by handle",
+                          !mgr->retrieve(Botan::TLS::Opaque_Session_Handle(handle.get()), cbs, plcy).has_value());
+
+      result.test_is_true("client can still find it", !mgr->find(server_info(), cbs, plcy).empty());
+
+      results.push_back(result);
+   }
+
+   return results;
+}
+
+std::vector<Test::Result> tls_session_manager_server_session_not_for_client() {
+   auto rng = Test::new_shared_rng(__func__);
+   Session_Manager_Callbacks cbs;
+   Session_Manager_Policy plcy;
+
+   std::vector<Test::Result> results;
+   for(auto& [name, mgr] : all_available_session_managers(rng)) {
+      Test::Result result(Botan::fmt("TLS server session is not offered by the client role ({})", name));
+      const auto handle = mgr->establish(default_session(Botan::TLS::Connection_Side::Server, cbs));
+      result.require("establishment worked", handle.has_value());
+
+      result.test_is_true("not found via server info", mgr->find(server_info(), cbs, plcy).empty());
+      result.test_is_true("the server can still find it", mgr->retrieve(handle.value(), cbs, plcy).has_value());
+      results.push_back(result);
+   }
+
+   return results;
+}
+
+std::vector<Test::Result> tls_session_manager_wrong_role_lookup_does_not_evict() {
+   auto rng = Test::new_shared_rng(__func__);
+   Session_Manager_Callbacks cbs;
+   Session_Manager_Policy plcy;
+
+   std::vector<Test::Result> results;
+   for(auto& [name, mgr] : all_available_session_managers(rng)) {
+      Test::Result result(Botan::fmt("TLS wrong-role session lookup does not evict ({})", name));
+
+      const auto client_handle = random_id(*rng);
+      mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs), client_handle);
+      const auto server_handle = mgr->establish(default_session(Botan::TLS::Connection_Side::Server, cbs));
+      result.require("establishment worked", server_handle.has_value());
+
+      result.test_is_true("server role rejects a client session", !mgr->retrieve(client_handle, cbs, plcy).has_value());
+
+      auto found = mgr->find(server_info(), cbs, plcy);
+      if(result.test_sz_eq("client role finds only its own session", found.size(), 1)) {
+         result.test_bin_eq("it is the client session", found.front().handle.id().value(), client_handle);
+      }
+      result.test_is_true("server session still exists", mgr->retrieve(server_handle.value(), cbs, plcy).has_value());
+
+      results.push_back(result);
+   }
+
+   return results;
+}
+
+std::vector<Test::Result> tls_session_manager_client_session_not_chosen_as_psk() {
+   std::vector<Test::Result> results;
+
+   #if defined(BOTAN_HAS_TLS_13)
+   auto rng = Test::new_shared_rng(__func__);
+   Session_Manager_Callbacks cbs;
+   Session_Manager_Policy plcy;
+
+   for(auto& [name, mgr] : all_available_session_managers(rng)) {
+      Test::Result result(Botan::fmt("a client session is not chosen for PSK resumption ({})", name));
+
+      const auto handle = random_id(*rng);
+      mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs, Botan::TLS::Version_Code::TLS_V13), handle);
+
+      const auto offered =
+         std::vector{Botan::TLS::PskIdentity(Botan::TLS::Opaque_Session_Handle(handle.get()).get(), 0)};
+      result.test_is_true("no PSK chosen",
+                          !mgr->choose_from_offered_tickets(offered, "SHA-256", cbs, plcy).has_value());
+
+      results.push_back(result);
+   }
+   #endif
+
+   return results;
+}
+
 std::vector<Test::Result> tls_session_manager_expiry() {
    auto rng = Test::new_shared_rng(__func__);
    Session_Manager_Callbacks cbs;
@@ -1060,12 +1185,10 @@ std::vector<Test::Result> tls_session_manager_expiry() {
 
                       auto handle_old = random_id(*rng);
                       mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle_old);
-                      result.require("session was found", mgr->retrieve(handle_old, cbs, plcy).has_value());
 
                       cbs.tick();
                       auto handle_new = random_id(*rng);
                       mgr->store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle_new);
-                      result.require("session was found", mgr->retrieve(handle_new, cbs, plcy).has_value());
 
                       auto sessions_and_handles = mgr->find(server_info(), cbs, plcy);
                       result.require("sessions are found", !sessions_and_handles.empty());
@@ -1183,6 +1306,10 @@ BOTAN_REGISTER_TEST_FN("tls",
                        test_session_manager_stateless,
                        test_session_manager_hybrid,
                        test_session_manager_sqlite,
+                       tls_session_manager_client_session_not_for_server,
+                       tls_session_manager_server_session_not_for_client,
+                       tls_session_manager_wrong_role_lookup_does_not_evict,
+                       tls_session_manager_client_session_not_chosen_as_psk,
                        tls_session_manager_expiry);
 
 }  // namespace


### PR DESCRIPTION
An application which acted as both a TLS server and a TLS client, and which shared a session manager between those two roles, could end up accepting a resumed session that resumed in the wrong role.