### PR TITLE
Make legacy McEliece GF2m caches thread-safe

### DIFF
--- a/src/lib/pubkey/mce/gf2m_small_m.cpp
+++ b/src/lib/pubkey/mce/gf2m_small_m.cpp
@@ -12,6 +12,7 @@
 
 #include <botan/exceptn.h>
 #include <botan/internal/ct_utils.h>
+#include <array>
 #include <string>
 
 namespace Botan {
@@ -19,6 +20,8 @@ namespace Botan {
 const size_t MAX_EXT_DEG = 15;
 
 namespace {
+
+using GF2m_Tables = std::array<std::vector<gf2m>, MAX_EXT_DEG + 1>;
 
 const gf2m prim_poly[MAX_EXT_DEG + 1] = {
    01,      /* extension degree 0 (!) never used */
@@ -53,18 +56,22 @@ std::vector<gf2m> gf_exp_table(size_t deg, gf2m prime_poly) {
    return tab;
 }
 
-const std::vector<gf2m>& exp_table(size_t deg) {
-   static std::vector<gf2m> tabs[MAX_EXT_DEG + 1];
+const GF2m_Tables& exp_tables() {
+   static const GF2m_Tables tables = [] {
+      GF2m_Tables result;
+      for(size_t degree = 2; degree <= MAX_EXT_DEG; ++degree) {
+         result[degree] = gf_exp_table(degree, prim_poly[degree]);
+      }
+      return result;
+   }();
+   return tables;
+}
 
+const std::vector<gf2m>& exp_table(size_t deg) {
    if(deg < 2 || deg > MAX_EXT_DEG) {
       throw Invalid_Argument("GF2m_Field does not support degree " + std::to_string(deg));
    }
-
-   if(tabs[deg].empty()) {
-      tabs[deg] = gf_exp_table(deg, prim_poly[deg]);
-   }
-
-   return tabs[deg];
+   return exp_tables()[deg];
 }
 
 std::vector<gf2m> gf_log_table(size_t deg, const std::vector<gf2m>& exp) {
@@ -77,18 +84,22 @@ std::vector<gf2m> gf_log_table(size_t deg, const std::vector<gf2m>& exp) {
    return tab;
 }
 
-const std::vector<gf2m>& log_table(size_t deg) {
-   static std::vector<gf2m> tabs[MAX_EXT_DEG + 1];
+const GF2m_Tables& log_tables() {
+   static const GF2m_Tables tables = [] {
+      GF2m_Tables result;
+      for(size_t degree = 2; degree <= MAX_EXT_DEG; ++degree) {
+         result[degree] = gf_log_table(degree, exp_table(degree));
+      }
+      return result;
+   }();
+   return tables;
+}
 
+const std::vector<gf2m>& log_table(size_t deg) {
    if(deg < 2 || deg > MAX_EXT_DEG) {
       throw Invalid_Argument("GF2m_Field does not support degree " + std::to_string(deg));
    }
-
-   if(tabs[deg].empty()) {
-      tabs[deg] = gf_log_table(deg, exp_table(deg));
-   }
-
-   return tabs[deg];
+   return log_tables()[deg];
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary

Legacy McEliece's exponent and logarithm tables used unsynchronized check-then-assignment into process-global vectors. Concurrent first construction of separate private keys could race vector publication and deallocation, causing use-after-free and double-free.

Botan documents that separate objects may be used concurrently. The regression uses a separate independently seeded RNG and key construction in every thread, so the caller does not share a Botan object.

## Changes

- Construct the complete table sets through thread-safe function-local initialization.
- Publish the completed tables as immutable vectors.
- Preserve field arithmetic and supported extension degrees 2 through 15.
- Add a cold, synchronized concurrency regression using independent field objects.

## Testing

The regression was checked in a minimized ASan/UBSan build:

```text
./configure.py --minimized-build --enable-modules=mce --build-targets=static,tests --build-tool=ninja --without-documentation --enable-sanitizers=address,undefined --with-debug-info
ninja -j4 botan-test
ASAN_OPTIONS=detect_leaks=0:halt_on_error=1 ./botan-test gf2m
```

On the test-only commit, the first run aborts with an ASan heap-use-after-free in `Botan::GF2m_Field::GF2m_Field()`. The freed allocation and read are reached through separate workers in the new regression.

With the fix applied, the same command completes without sanitizer findings:

```text
GF2m ran 131064 tests all ok
GF2m concurrent initialization ran 1 tests all ok
Tests complete ran 131065 tests in 4.92 msec all tests ok
```

The separate-object behavior, valid and invalid degree boundaries, and field-operation compatibility were also checked independently.
