### PR TITLE
Account for record expansion due to AEAD when fragmenting handshakes

### DIFF
--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -694,26 +694,26 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_message(uint16_t msg_seq,
                                                          const std::vector<uint8_t>& msg_bits) {
    auto no_fragment = format_w_seq(msg_bits, msg_type, msg_seq);
 
-   if(no_fragment.size() + DTLS_HEADER_SIZE <= m_mtu) {
+   /**
+   * Since CBC suites are no longer supported/allowed in DTLS, the largest
+   * possible ciphersuite overhead is 48 bytes, from NULL_WITH_SHA384. The AEAD
+   * suites add at most 24 bytes (8 byte explicit nonce plus 16 byte tag).
+   */
+   const size_t ciphersuite_overhead = (epoch > 0) ? 48 : 0;
+
+   if(no_fragment.size() + DTLS_HEADER_SIZE + ciphersuite_overhead <= m_mtu) {
+      // We think the entire final packet will fit into the MTU
       m_send_hs(epoch, Record_Type::Handshake, no_fragment);
    } else {
       size_t frag_offset = 0;
 
-      /**
-      * Largest possible overhead is for SHA-384 CBC ciphers, with 16 byte IV,
-      * 16+ for padding and 48 bytes for MAC. 128 is probably a strict
-      * over-estimate here. When CBC ciphers are removed this can be reduced
-      * since AEAD modes have no padding, at most 16 byte mac, and smaller
-      * per-record nonce.
-      */
-      const size_t ciphersuite_overhead = (epoch > 0) ? 128 : 0;
-      const size_t header_overhead = DTLS_HEADER_SIZE + DTLS_HANDSHAKE_HEADER_SIZE;
+      constexpr size_t DTLS_HANDSHAKE_OVERHEAD = DTLS_HEADER_SIZE + DTLS_HANDSHAKE_HEADER_SIZE;
 
-      if(m_mtu <= (header_overhead + ciphersuite_overhead)) {
+      if(m_mtu <= (DTLS_HANDSHAKE_OVERHEAD + ciphersuite_overhead)) {
          throw Invalid_Argument("DTLS MTU is too small to send headers");
       }
 
-      const size_t max_rec_size = m_mtu - (header_overhead + ciphersuite_overhead);
+      const size_t max_rec_size = m_mtu - (DTLS_HANDSHAKE_OVERHEAD + ciphersuite_overhead);
 
       while(frag_offset != msg_bits.size()) {
          const size_t frag_len = std::min<size_t>(msg_bits.size() - frag_offset, max_rec_size);

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -10,6 +10,7 @@
 
    #include <botan/tls_handshake_msg.h>
    #include <botan/tls_magic.h>
+   #include <botan/internal/fmt.h>
    #include <botan/internal/tls_handshake_io.h>
    #include <botan/internal/tls_seq_numbers.h>
 
@@ -26,16 +27,18 @@ class Datagram_IO_Fixture {
    public:
       explicit Datagram_IO_Fixture(uint64_t initial_timeout_ms = 1000,
                                    uint64_t max_timeout_ms = 60000,
-                                   std::optional<size_t> max_retransmissions = std::nullopt) :
+                                   std::optional<size_t> max_retransmissions = std::nullopt,
+                                   uint16_t mtu = 1500) :
             m_io(
-               [this](uint16_t, Record_Type type, const std::vector<uint8_t>&) {
+               [this](uint16_t, Record_Type type, const std::vector<uint8_t>& record) {
                   if(type == Record_Type::Handshake) {
                      ++m_handshake_records_sent;
+                     m_sent_record_sizes.push_back(record.size());
                   }
                },
                [this]() -> uint64_t { return m_clock_ms; },
                m_seqs,
-               1500,
+               mtu,
                initial_timeout_ms,
                max_timeout_ms,
                max_retransmissions,
@@ -49,11 +52,19 @@ class Datagram_IO_Fixture {
 
       size_t handshake_records_sent() const { return m_handshake_records_sent; }
 
-      void reset_send_counter() { m_handshake_records_sent = 0; }
+      // Sizes of the handshake payloads handed to the record layer, before
+      // record framing and cipher expansion are added.
+      const std::vector<size_t>& sent_record_sizes() const { return m_sent_record_sizes; }
+
+      void reset_send_counter() {
+         m_handshake_records_sent = 0;
+         m_sent_record_sizes.clear();
+      }
 
    private:
       uint64_t m_clock_ms = 0;
       size_t m_handshake_records_sent = 0;
+      std::vector<size_t> m_sent_record_sizes;
       Datagram_Sequence_Numbers m_seqs;
       Datagram_Handshake_IO m_io;
 };
@@ -74,6 +85,45 @@ class Stub_Handshake_Message final : public Botan::TLS::Handshake_Message {
 
 std::vector<Test::Result> dtls12_handshake_io_tests() {
    return {
+      CHECK(
+         "protected handshake records respect MTU",
+         [&](Test::Result& result) {
+            constexpr uint16_t mtu = 1232;           // the default policy value
+            constexpr size_t cipher_expansion = 48;  // matches NULL_WITH_SHA384 overhead
+            constexpr size_t dtls_header = Botan::TLS::DTLS_HEADER_SIZE;
+
+            size_t largest = 0;
+            size_t largest_body = 0;
+
+            for(size_t body = 900; body <= 1300; ++body) {
+               Datagram_IO_Fixture fix(1000, 60000, std::nullopt, mtu);
+               const Stub_Handshake_Message msg(Handshake_Type::Certificate, std::vector<uint8_t>(body, 0xAB));
+               fix.io().send_under_epoch(msg, 1);
+
+               for(const size_t fragment : fix.sent_record_sizes()) {
+                  const size_t on_the_wire = dtls_header + fragment + cipher_expansion;
+                  if(on_the_wire > largest) {
+                     largest = on_the_wire;
+                     largest_body = body;
+                  }
+               }
+            }
+
+            result.test_is_true("Something was sent", largest > 0);
+            result.test_sz_lte(Botan::fmt("Largest protected record ({} bytes from {} byte body) fits within MTU ({})",
+                                          largest,
+                                          largest_body,
+                                          mtu),
+                               largest,
+                               mtu);
+
+            // Epoch zero is unprotected, so the full MTU stays available there.
+            Datagram_IO_Fixture plaintext(1000, 60000, std::nullopt, mtu);
+            const Stub_Handshake_Message big(Handshake_Type::ClientHello, std::vector<uint8_t>(1150, 0xCD));
+            plaintext.io().send_under_epoch(big, 0);
+            result.test_sz_eq(
+               "unprotected message of that size is not fragmented", plaintext.sent_record_sizes().size(), size_t(1));
+         }),
 
       // Once the backoff saturates at m_max_timeout, the elapsed time since the
       // last write keeps growing, so a retransmit must re-anchor it. Otherwise


### PR DESCRIPTION
Depending on the MTU value we might end up deciding a packet would fit within the MTU, then when the nonce/tag were added it would exceed the MTU and be dropped.

Also update the maximum expected ciphersuite overhead, now that CBC ciphersuites are no longer allowed in DTLS.

Split out of #5783 