### PR TITLE
In (D)TLS discard old cipher state, and prevent DTLS epoch wraparound

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -38,6 +38,32 @@ bool is_new_dtls_association_client_hello(std::span<const uint8_t> msg_and_heade
           load_be(msg_and_header.subspan<4, 2>()) == 0;
 }
 
+// Cap on the number of non-zero-epoch cipher states retained per direction.
+// The current epoch is in active use; one earlier epoch covers any in-flight
+// DTLS records sent immediately before a rekey. Epoch 0 is the pre-handshake
+// plaintext placeholder and is always retained.
+//
+// Note the logic in prune_epochs in tls_seq_numbers.h assumes this is exactly 2
+// so adjust that code if changing this.
+constexpr size_t TLS_RETAINED_CIPHERSTATES = 2;
+
+// The "default MSL specified for TCP" of RFC 6347 4.1; RFC 793 sets it to two
+// minutes. Bounds how long a retired DTLS read epoch stays usable.
+constexpr uint64_t TCP_MSL_MS = 2 * 60 * 1000;
+
+template <typename T>
+void prune_old_cipher_states(std::map<uint16_t, T>& states) {
+   // std::map iterates in ascending key order. Drop the lowest non-zero
+   // entries until at most TLS_RETAINED_CIPHERSTATES remain. The newly
+   // installed epoch is the highest key, so it is preserved.
+   size_t non_zero = states.size() - states.count(0);
+   auto it = states.lower_bound(1);
+   while(non_zero > TLS_RETAINED_CIPHERSTATES) {
+      it = states.erase(it);
+      --non_zero;
+   }
+}
+
 }  // namespace
 
 Channel_Impl_12::Channel_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
@@ -61,7 +87,7 @@ Channel_Impl_12::Channel_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
 
    /* epoch 0 is plaintext, thus null cipher state */
    m_write_cipher_states[0] = nullptr;
-   m_read_cipher_states[0] = nullptr;
+   m_read_cipher_states[0] = {};
 
    m_writebuf.reserve(reserved_io_buffer_size);
    m_readbuf.reserve(reserved_io_buffer_size);
@@ -84,7 +110,7 @@ void Channel_Impl_12::reset_active_association_state() {
    m_write_cipher_states.clear();
 
    m_write_cipher_states[0] = nullptr;
-   m_read_cipher_states[0] = nullptr;
+   m_read_cipher_states[0] = {};
 
    if(m_sequence_numbers) {
       m_sequence_numbers->reset();  // NOLINT(*-ambiguous-smartptr-reset-call)
@@ -103,7 +129,23 @@ std::shared_ptr<Connection_Cipher_State> Channel_Impl_12::read_cipher_state_epoc
    if(i == m_read_cipher_states.end()) {
       throw Internal_Error("TLS::Channel_Impl_12 No read cipherstate for epoch " + std::to_string(epoch));
    }
-   return i->second;
+
+   // RFC 6347 4.1: "In general, implementations SHOULD discard packets from
+   // earlier epochs, but if packet loss causes noticeable problems they MAY
+   // choose to retain keying material from previous epochs for up to the
+   // default MSL specified for TCP [TCP] to allow for packet reordering."
+   // read_dtls_record drops the record when this throws.
+   if(const auto& retired_at = i->second.retired_at; retired_at.has_value()) {
+      const auto now = callbacks().tls_current_monotonic_clock_ms();
+      const auto retired = retired_at.value();
+      BOTAN_ASSERT_NOMSG(now >= retired);
+      if(now - retired > TCP_MSL_MS) {
+         throw Invalid_State("TLS::Channel_Impl_12 Read cipherstate for epoch " + std::to_string(epoch) +
+                             " is past its retention window");
+      }
+   }
+
+   return i->second.state;
 }
 
 std::shared_ptr<Connection_Cipher_State> Channel_Impl_12::write_cipher_state_epoch(uint16_t epoch) const {
@@ -244,7 +286,8 @@ bool Channel_Impl_12::timeout_check() {
       }
    }
 
-   //FIXME: scan cipher suites and remove epochs older than 2*MSL
+   // Old cipher states are pruned at install time (see prune_old_cipher_states),
+   // so no periodic cleanup is needed here.
    return false;
 }
 
@@ -254,6 +297,14 @@ void Channel_Impl_12::renegotiate(bool force_full_renegotiation) {
    }
 
    if(m_active_state.has_value()) {
+      // A DTLS handshake consumes one read and one write epoch. Refuse here if
+      // either is spent, so the caller learns before the handshake tears the
+      // working association down partway through. See next_epoch().
+      if(m_is_datagram &&
+         (sequence_numbers().current_read_epoch() == 0xFFFF || sequence_numbers().current_write_epoch() == 0xFFFF)) {
+         throw Invalid_State("DTLS epoch counter exhausted, a new association is required");
+      }
+
       if(!force_full_renegotiation) {
          force_full_renegotiation = !policy().allow_resumption_for_renegotiation();
       }
@@ -292,7 +343,17 @@ void Channel_Impl_12::change_cipher_spec_reader(Connection_Side side) {
       pending->session_keys(),
       pending->server_hello()->supports_encrypt_then_mac());
 
-   m_read_cipher_states[epoch] = read_state;
+   // The epoch we just left is retained only to absorb reordering, so start its
+   // clock now (see read_cipher_state_epoch). Epoch 0 is the plaintext
+   // placeholder and holds no keys, so the window does not apply to it.
+   if(m_is_datagram && epoch > 1) {
+      if(auto prev = m_read_cipher_states.find(static_cast<uint16_t>(epoch - 1)); prev != m_read_cipher_states.end()) {
+         prev->second.retired_at = callbacks().tls_current_monotonic_clock_ms();
+      }
+   }
+
+   m_read_cipher_states[epoch] = Retained_Read_Cipher_State{.state = read_state, .retired_at = std::nullopt};
+   prune_old_cipher_states(m_read_cipher_states);
 }
 
 void Channel_Impl_12::change_cipher_spec_writer(Connection_Side side) {
@@ -318,6 +379,7 @@ void Channel_Impl_12::change_cipher_spec_writer(Connection_Side side) {
                                                                 pending->server_hello()->supports_encrypt_then_mac());
 
    m_write_cipher_states[epoch] = write_state;
+   prune_old_cipher_states(m_write_cipher_states);
 }
 
 bool Channel_Impl_12::is_handshake_complete() const {

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -251,9 +251,24 @@ class Channel_Impl_12 : public Channel_Impl {
 
       void clear_pending_handshake_state();
 
+      /*
+      A read cipher state together with the point at which it stopped being the
+      current epoch, in Callbacks::tls_current_monotonic_clock_ms units, if it has.
+
+      The two are stored together deliberately. Epoch numbers are not unique for
+      the lifetime of the channel: reset_active_association_state() rewinds them,
+      so a DTLS epoch-0 restart produces a second epoch 1. A retirement time held
+      apart from the state it describes therefore outlives it and gets applied to
+      the reused epoch, expiring a brand new cipher state.
+      */
+      struct Retained_Read_Cipher_State final {
+            std::shared_ptr<Connection_Cipher_State> state;
+            std::optional<uint64_t> retired_at;
+      };
+
       /* cipher states for each epoch */
       std::map<uint16_t, std::shared_ptr<Connection_Cipher_State>> m_write_cipher_states;
-      std::map<uint16_t, std::shared_ptr<Connection_Cipher_State>> m_read_cipher_states;
+      std::map<uint16_t, Retained_Read_Cipher_State> m_read_cipher_states;
 
       /* I/O buffers */
       secure_vector<uint8_t> m_writebuf;

--- a/src/lib/tls/tls12/tls_seq_numbers.h
+++ b/src/lib/tls/tls12/tls_seq_numbers.h
@@ -98,13 +98,15 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
       }
 
       void new_read_cipher_state() override {
-         m_read_epoch++;
+         m_read_epoch = next_epoch(m_read_epoch);
          m_read_windows.try_emplace(m_read_epoch);
+         prune_epochs(m_read_windows, m_read_epoch);
       }
 
       void new_write_cipher_state() override {
-         m_write_epoch++;
+         m_write_epoch = next_epoch(m_write_epoch);
          m_write_seqs[m_write_epoch] = 0;
+         prune_epochs(m_write_seqs, m_write_epoch);
       }
 
       uint16_t current_read_epoch() const override { return m_read_epoch; }
@@ -113,7 +115,9 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
 
       uint64_t next_write_sequence(uint16_t epoch) override {
          auto i = m_write_seqs.find(epoch);
-         BOTAN_ASSERT(i != m_write_seqs.end(), "Found epoch");
+         if(i == m_write_seqs.end()) {
+            throw Invalid_State("DTLS epoch not found");
+         }
          if(i->second > 0x0000FFFFFFFFFFFF) {
             throw Invalid_State("DTLS write sequence number overflow");
          }
@@ -171,9 +175,11 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
                // We've received an old sequence but still within our window
                window.bits |= (static_cast<uint64_t>(1) << offset);
             } else {
-               // This occurs only if we have reset state (DTLS reconnection case)
+               // DTLS reconnection: recenter the window on this sequence. Bit 0
+               // marks the sequence itself as seen so an immediate replay is
+               // detected; the other branches above set this implicitly.
                window.highest = record_sequence;
-               window.bits = 0;
+               window.bits = 1;
             }
          }
       }
@@ -183,6 +189,41 @@ class Datagram_Sequence_Numbers final : public Connection_Sequence_Numbers {
             uint64_t highest = 0;
             uint64_t bits = 0;
       };
+
+      /*
+      * RFC 6347 4.1: "Similarly, implementations MUST NOT allow the epoch to
+      * wrap, but instead MUST establish a new association, terminating the old
+      * association as described in Section 4.2.8."
+      *
+      * Throwing leaves the counters untouched; the channel turns it into a
+      * fatal alert, which is the termination the requirement asks for.
+      */
+      static uint16_t next_epoch(uint16_t epoch) {
+         if(epoch == std::numeric_limits<uint16_t>::max()) {
+            throw Invalid_State("DTLS epoch counter exhausted");
+         }
+         return static_cast<uint16_t>(epoch + 1);
+      }
+
+      /*
+      * Only the current epoch and the one it replaced can still carry traffic;
+      *
+      * The behavior of this function must match the value of TLS_RETAINED_CIPHERSTATES
+      * in tls_channel_impl_12.cpp
+      *
+      * Epoch 0 is exempt: a HelloVerifyRequest is written under it
+      * however many times the association has rekeyed.
+      */
+      template <typename T>
+      static void prune_epochs(std::map<uint16_t, T>& epochs, uint16_t current) {
+         for(auto i = epochs.begin(); i != epochs.end();) {
+            if(i->first == 0 || i->first + 1 >= current) {
+               ++i;
+            } else {
+               i = epochs.erase(i);
+            }
+         }
+      }
 
       std::map<uint16_t, uint64_t> m_write_seqs;
       std::map<uint16_t, Replay_Window> m_read_windows;

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -943,6 +943,78 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // Epoch numbers restart after an epoch-0 restart, so a retirement time
+      // recorded for the first association's epoch 1 must not expire the second
+      // association's epoch 1. Regression test: it previously did, and past the
+      // retention window the restarted handshake could not complete at all.
+      static Test::Result test_epoch_retirement_does_not_outlive_a_restart() {
+         Test::Result result("DTLS epoch retention window survives an association restart");
+
+         auto rng = Test::new_shared_rng("dtls-core-epoch-retirement-restart");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+         auto server_sessions = std::make_shared<Botan::TLS::Session_Manager_In_Memory>(rng);
+
+         std::vector<uint8_t> s2c;
+         std::vector<uint8_t> server_recv;
+         auto server_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, s2c, server_recv);
+         Botan::TLS::Server server(server_callbacks, server_sessions, creds, policy, rng, true);
+
+         // Drive a full handshake plus a renegotiation, which advances the
+         // server to epoch 2 and so retires its epoch 1.
+         auto associate = [&](const std::string& label, bool renegotiate) {
+            std::vector<uint8_t> c2s;
+            std::vector<uint8_t> client_recv;
+            auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(result, c2s, client_recv);
+            auto client = std::make_shared<Botan::TLS::Client>(client_callbacks,
+                                                               std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                                               creds,
+                                                               policy,
+                                                               rng,
+                                                               Botan::TLS::Server_Information("localhost"),
+                                                               Botan::TLS::Protocol_Version::latest_dtls_version());
+
+            deliver(result, label + " client hello 1", c2s, server);
+            deliver(result, label + " hello verify request", s2c, *client);
+            deliver(result, label + " client hello 2", c2s, server);
+            deliver(result, label + " server handshake flight", s2c, *client);
+            deliver(result, label + " client final flight", c2s, server);
+            deliver(result, label + " server final flight", s2c, *client);
+
+            result.test_is_true(label + " client became active", client->is_active());
+            result.test_is_true(label + " server became active", server.is_active());
+
+            if(renegotiate) {
+               result.test_no_throw(label + " renegotiates", [&] { client->renegotiate(true); });
+               deliver(result, label + " renegotiation client hello", c2s, server);
+               deliver(result, label + " renegotiation server flight", s2c, *client);
+               deliver(result, label + " renegotiation client final flight", c2s, server);
+               deliver(result, label + " renegotiation server final flight", s2c, *client);
+               result.test_is_true(label + " still active after renegotiation",
+                                   client->is_active() && server.is_active());
+            }
+
+            return client;
+         };
+
+         associate("first association", true);
+
+         // The renegotiation is what retires epoch 1, so the test is only
+         // meaningful if it actually happened.
+         result.test_sz_eq(
+            "handshake plus renegotiation established two sessions", server_callbacks->sessions_established(), 2);
+
+         // Well past the RFC 6347 4.1 retention window for the retired epoch 1.
+         server_callbacks->advance_clock_ms(5 * 60 * 1000);
+
+         s2c.clear();
+         associate("restarted association", false);
+
+         result.test_sz_eq("the restart established a third session", server_callbacks->sessions_established(), 3);
+
+         return result;
+      }
+
       // Poll the retransmission timer forward until the handshake gives up.
       static bool run_out_the_clock(DTLS_Test_Callbacks& cb, Botan::TLS::Channel& channel) {
          for(int i = 0; i < 200; ++i) {
@@ -1603,6 +1675,7 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_lost_server_flight_retransmits(),
                  test_duplicate_server_flight_defers_to_timer(),
                  test_hello_request_during_handshake_is_ignored(),
+                 test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),
                  test_lost_server_final_flight_retransmits(),

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -273,6 +273,66 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                result.test_sz_eq("the flight was resent", fix.handshake_records_sent(), size_t(2));
             }),
 
+      // RFC 6347 4.1: "implementations MUST NOT allow the epoch to wrap, but
+      // instead MUST establish a new association". Reaching 0xFFFF is legal;
+      // the increment past it is refused without disturbing the counter.
+      CHECK("DTLS epoch counters refuse to wrap",
+            [&](Test::Result& result) {
+               Datagram_Sequence_Numbers seqs;
+
+               for(size_t i = 0; i != 0xFFFF; ++i) {
+                  seqs.new_write_cipher_state();
+                  seqs.new_read_cipher_state();
+               }
+               result.test_sz_eq("write epoch reaches the maximum", seqs.current_write_epoch(), size_t(0xFFFF));
+               result.test_sz_eq("read epoch reaches the maximum", seqs.current_read_epoch(), size_t(0xFFFF));
+
+               result.test_throws("write epoch will not wrap", [&] { seqs.new_write_cipher_state(); });
+               result.test_throws("read epoch will not wrap", [&] { seqs.new_read_cipher_state(); });
+
+               // Refusing left the counters where they were, rather than
+               // rolling over onto the retained epoch 0 and reusing its keys.
+               result.test_sz_eq("write epoch unchanged by the refusal", seqs.current_write_epoch(), size_t(0xFFFF));
+               result.test_sz_eq("read epoch unchanged by the refusal", seqs.current_read_epoch(), size_t(0xFFFF));
+               result.test_is_true("the final epoch is still writable",
+                                   seqs.next_write_sequence(0xFFFF) == (uint64_t(0xFFFF) << 48));
+            }),
+
+      // Write sequence counters and replay windows are pruned as the
+      // association rekeys, so a long-lived connection does not accumulate an
+      // entry per epoch. Epoch 0 is exempt: a HelloVerifyRequest is written
+      // under it at any point in the association's life.
+      CHECK("stale DTLS epoch state is pruned",
+            [&](Test::Result& result) {
+               Datagram_Sequence_Numbers seqs;
+
+               seqs.new_write_cipher_state();  // epoch 1
+               seqs.next_write_sequence(1);
+               seqs.new_write_cipher_state();  // epoch 2
+               result.test_is_true("epoch 1 still writable one rekey later",
+                                   seqs.next_write_sequence(1) == ((uint64_t(1) << 48) | 1));
+
+               seqs.new_write_cipher_state();  // epoch 3
+               result.test_throws("epoch 1 dropped two rekeys later", [&] { seqs.next_write_sequence(1); });
+               result.test_is_true("epoch 2 retained", seqs.next_write_sequence(2) == (uint64_t(2) << 48));
+               result.test_is_true("epoch 0 retained for HelloVerifyRequest", seqs.next_write_sequence(0) == 0);
+
+               // Replay windows follow the same schedule. By the time a window
+               // is released the epoch's cipher state is gone as well, so no
+               // record under it can be decrypted to be replayed.
+               const uint64_t epoch1_seq = (uint64_t(1) << 48) | 7;
+
+               seqs.new_read_cipher_state();  // epoch 1
+               seqs.read_accept(epoch1_seq);
+               result.test_is_true("replay caught while the window is live", seqs.already_seen(epoch1_seq));
+
+               seqs.new_read_cipher_state();  // epoch 2
+               result.test_is_true("window survives one rekey", seqs.already_seen(epoch1_seq));
+
+               seqs.new_read_cipher_state();  // epoch 3
+               result.test_is_true("window released two rekeys later", !seqs.already_seen(epoch1_seq));
+            }),
+
    };
 }
 


### PR DESCRIPTION
Extracted from #5783 