### PR TITLE
Bound DTLS handshake reassembly memory and improve fragment handling

### DIFF
--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -157,6 +157,35 @@ std::vector<uint8_t> Stream_Handshake_IO::start_with_client_hello_from_downgrade
 
 #endif
 
+namespace {
+
+size_t max_pending_reassembly(size_t policy_hs_max) {
+   /*
+   * Here we set arbitrary but probably more than sufficient bounds on the *overall*
+   * allocation that is allowed across the entire handshake.
+   *
+   * If the policy set a limit on individual handshake message sizes, accept up to 4
+   * times that for the whole handshake. This is more than generous considering most
+   * handshake messages are fixed length or are relatively tightly bounded. The default
+   * per-handshake message bound is 64 KiB so without application intervention this will
+   * top out at 256 KiB for a handshake.
+   *
+   * If the application explicitly disables the per handshake message bound, still apply
+   * an arbitrary upper bound of 16 MiB for the handshake.
+   */
+   constexpr size_t overall_cap = 16 * 1024 * 1024;
+
+   if(policy_hs_max == 0 || policy_hs_max >= overall_cap / 4) {
+      // If disabled or huge just take our max
+      return overall_cap;
+   } else {
+      // Otherwise 4x the per-message max
+      return policy_hs_max * 4;
+   }
+}
+
+}  // namespace
+
 Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              steady_clock_fn steady_clock_ms,
                                              class Connection_Sequence_Numbers& seq,
@@ -174,7 +203,8 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
       m_send_hs(std::move(writer)),
       m_steady_clock_ms(std::move(steady_clock_ms)),
       m_mtu(mtu),
-      m_max_handshake_msg_size(max_handshake_msg_size) {}
+      m_max_handshake_msg_size(max_handshake_msg_size),
+      m_max_pending_reassembly(max_pending_reassembly(m_max_handshake_msg_size)) {}
 
 Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
    return Protocol_Version::DTLS_V12;
@@ -315,18 +345,60 @@ bool Datagram_Handshake_IO::reassemble_retransmitted_fragment(const uint8_t frag
    auto [i, inserted] = m_retransmitted_messages.try_emplace(msg_type, message_seq, Handshake_Reassembly{});
 
    if(!inserted && i->second.first != message_seq) {
+      release_reassembly_bytes(i->second.second);
       i->second = std::make_pair(message_seq, Handshake_Reassembly());
    }
 
    auto& reassembly = i->second.second;
-   reassembly.add_fragment(fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+
+   // These buffers hold unauthenticated input, so they are charged against the
+   // same budget as the main reassembly path rather than growing on their own.
+   if(!charged_add_fragment(reassembly,
+                            m_max_pending_reassembly,
+                            fragment,
+                            fragment_length,
+                            fragment_offset,
+                            epoch,
+                            msg_type,
+                            msg_length)) {
+      return false;
+   }
 
    if(!reassembly.complete()) {
       return false;
    }
 
+   release_reassembly_bytes(reassembly);
    m_retransmitted_messages.erase(i);
    return true;
+}
+
+bool Datagram_Handshake_IO::charged_add_fragment(Handshake_Reassembly& reassembly,
+                                                 size_t ceiling,
+                                                 const uint8_t fragment[],
+                                                 size_t fragment_length,
+                                                 size_t fragment_offset,
+                                                 uint16_t epoch,
+                                                 Handshake_Type msg_type,
+                                                 size_t msg_length) {
+   // We allocate the entire block on the first fragment, so charge it against
+   // the bound at that point. Later fragments must agree with the declared
+   // length, so admission is decided once per slot and retransmissions are
+   // never re-charged.
+   if(!reassembly.initialized()) {
+      if(m_pending_reassembly_bytes + msg_length > ceiling) {
+         return false;
+      }
+      m_pending_reassembly_bytes += msg_length;
+   }
+
+   reassembly.add_fragment(fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+   return true;
+}
+
+void Datagram_Handshake_IO::release_reassembly_bytes(const Handshake_Reassembly& reassembly) {
+   BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= reassembly.msg_length());
+   m_pending_reassembly_bytes -= reassembly.msg_length();
 }
 
 bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fragment[],
@@ -350,11 +422,20 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
    if(msg_type == Handshake_Type::ClientHello) {
       if(!retransmitted_flight && m_awaiting_cookie_client_hello) {
          if(!m_retransmitted_client_hello.has_value() || m_retransmitted_client_hello->first != message_seq) {
+            if(m_retransmitted_client_hello.has_value()) {
+               release_reassembly_bytes(m_retransmitted_client_hello->second);
+            }
             m_retransmitted_client_hello = std::make_pair(message_seq, Handshake_Reassembly());
          }
 
-         m_retransmitted_client_hello->second.add_fragment(
-            fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length);
+         charged_add_fragment(m_retransmitted_client_hello->second,
+                              m_max_pending_reassembly,
+                              fragment,
+                              fragment_length,
+                              fragment_offset,
+                              epoch,
+                              msg_type,
+                              msg_length);
          return false;
       }
 
@@ -467,10 +548,15 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
       // Bound the out-of-order reassembly window.
       constexpr uint16_t reassembly_window = 16;
 
-      // Independently cap total bytes committed to in-flight reassembly slots
-      const size_t max_pending = 4 * m_max_handshake_msg_size;
-
       if(message_seq >= m_in_message_seq && (message_seq - m_in_message_seq) < reassembly_window) {
+         // A wrapped counter would alias new messages onto long-delivered
+         // sequence numbers. No legitimate handshake gets here, so go quiet.
+         if(m_in_message_seq_wrapped) {
+            record += total_size;
+            record_len -= total_size;
+            continue;
+         }
+
          if(retransmitted_flight) {
             if(fragment_length == 0) {
                record += total_size;
@@ -481,19 +567,35 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
             throw TLS_Exception(Alert::UnexpectedMessage, "Unexpected new DTLS handshake message");
          }
 
-         auto [it, inserted] = m_messages.try_emplace(message_seq);
-         if(inserted) {
-            if(m_max_handshake_msg_size > 0 && m_pending_reassembly_bytes + msg_len > max_pending) {
-               m_messages.erase(it);
-               record += total_size;
-               record_len -= total_size;
-               continue;
-            }
-            m_pending_reassembly_bytes += msg_len;
+         // An empty fragment for a non-empty message is garbage; drop it
+         // before it can create and charge a reassembly slot.
+         if(fragment_length == 0 && msg_len > 0) {
+            record += total_size;
+            record_len -= total_size;
+            continue;
          }
-         it->second.add_fragment(
-            &record[DTLS_HANDSHAKE_HEADER_SIZE], fragment_length, fragment_offset, epoch, msg_type, msg_len);
-      } else {
+
+         // Reserve headroom for the message actually being waited on. Otherwise
+         // fragments for the fifteen slots beyond it can consume the whole
+         // budget, after which every fragment of the expected message is
+         // silently dropped and the handshake cannot proceed.
+         const size_t ceiling =
+            (message_seq == m_in_message_seq) ? m_max_pending_reassembly : m_max_pending_reassembly / 2;
+
+         auto [it, inserted] = m_messages.try_emplace(message_seq);
+
+         const bool accepted = charged_add_fragment(it->second,
+                                                    ceiling,
+                                                    &record[DTLS_HANDSHAKE_HEADER_SIZE],
+                                                    fragment_length,
+                                                    fragment_offset,
+                                                    epoch,
+                                                    msg_type,
+                                                    msg_len);
+         if(!accepted && inserted) {
+            m_messages.erase(it);
+         }
+      } else if(message_seq < m_in_message_seq) {
          retransmit_response |= process_previous_handshake_fragment(&record[DTLS_HANDSHAKE_HEADER_SIZE],
                                                                     fragment_length,
                                                                     fragment_offset,
@@ -503,6 +605,9 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
                                                                     message_seq,
                                                                     retransmitted_flight);
       }
+      // else: beyond the reassembly window is not a retransmission of anything
+      // we have seen, so it must not be able to pull a flight replay out of
+      // us. Drop it silently: the sender has proven nothing at this point.
 
       record += total_size;
       record_len -= total_size;
@@ -522,18 +627,17 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
    }
 
    if(expecting_ccs) {
-      if(!m_messages.empty()) {
-         const uint16_t current_epoch = m_messages.begin()->second.epoch();
-
-         if(m_ccs_epochs.contains(current_epoch)) {
-            return std::make_pair(Handshake_Type::HandshakeCCS, std::vector<uint8_t>());
-         }
+      // CCS is expected under the epoch the peer's handshake messages have
+      // been arriving on, and always follows at least one delivered message.
+      if(m_first_delivered_epoch.has_value() && m_ccs_epochs.contains(*m_first_delivered_epoch)) {
+         return std::make_pair(Handshake_Type::HandshakeCCS, std::vector<uint8_t>());
       }
       return std::make_pair(Handshake_Type::None, std::vector<uint8_t>());
    }
 
    if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
       auto result = m_retransmitted_client_hello->second.message();
+      release_reassembly_bytes(m_retransmitted_client_hello->second);
       m_retransmitted_client_hello.reset();
       m_recreating_hello_verify_request = true;
       return result;
@@ -546,6 +650,13 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
    }
 
    m_in_message_seq += 1;
+   if(m_in_message_seq == 0) {
+      m_in_message_seq_wrapped = true;
+   }
+
+   if(!m_first_delivered_epoch.has_value()) {
+      m_first_delivered_epoch = i->second.epoch();
+   }
 
    auto result = i->second.message();
 
@@ -553,22 +664,10 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
       m_awaiting_cookie_client_hello = false;
    }
 
-   // Free the reassembly buffer for this delivered slot and uncommit its
-   // bytes against the cap. The entry itself stays in m_messages because
-   // the expecting_ccs branch above uses m_messages.begin()->second.epoch()
-   // as an epoch-0 sentinel; it only needs the metadata, not the buffers.
-   BOTAN_ASSERT_NOMSG(m_pending_reassembly_bytes >= i->second.msg_length());
-   m_pending_reassembly_bytes -= i->second.msg_length();
-   i->second.release_buffers();
+   release_reassembly_bytes(i->second);
+   m_messages.erase(i);
 
    return result;
-}
-
-void Datagram_Handshake_IO::Handshake_Reassembly::release_buffers() {
-   m_received_mask.clear();
-   m_received_mask.shrink_to_fit();
-   m_message.clear();
-   m_message.shrink_to_fit();
 }
 
 void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fragment[],
@@ -585,12 +684,15 @@ void Datagram_Handshake_IO::Handshake_Reassembly::add_fragment(const uint8_t fra
       m_message.resize(msg_length);
       m_received_mask.assign(msg_length, 0);
    } else {
-      if(msg_type != m_msg_type || msg_length != m_msg_length || epoch != m_epoch) {
-         throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
+      if(complete()) {
+         // Ignore even if the header fields disagree: a stray or forged
+         // retransmission must not tear down the connection once the
+         // message has already been fully received.
+         return;
       }
 
-      if(complete()) {
-         return;  // already have entire message, ignore this
+      if(msg_type != m_msg_type || msg_length != m_msg_length || epoch != m_epoch) {
+         throw Decoding_Error("Inconsistent values in fragmented DTLS handshake header");
       }
    }
 
@@ -663,8 +765,12 @@ std::vector<uint8_t> Datagram_Handshake_IO::format_w_seq(const std::vector<uint8
 }
 
 std::vector<uint8_t> Datagram_Handshake_IO::format(const std::vector<uint8_t>& msg, Handshake_Type type) const {
-   BOTAN_ASSERT_NOMSG(m_in_message_seq > 0);
-   return format_w_seq(msg, type, m_in_message_seq - 1);
+   // Formats the message just delivered, so the guard is that one exists, not
+   // that the counter is non-zero. Those differ once m_in_message_seq wraps,
+   // where the subtraction wraps to 65535 of its own accord, which is the
+   // right sequence number for that message.
+   BOTAN_ASSERT_NOMSG(m_first_delivered_epoch.has_value());
+   return format_w_seq(msg, type, static_cast<uint16_t>(m_in_message_seq - 1));
 }
 
 std::vector<uint8_t> Datagram_Handshake_IO::send(const Handshake_Message& msg) {

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -231,6 +231,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                               Handshake_Type msg_type,
                               size_t msg_length);
 
+            // Set by the first fragment, which fixes the header metadata and
+            // (in Datagram_Handshake_IO) charges the reassembly budget.
+            bool initialized() const { return m_msg_type != Handshake_Type::None; }
+
             bool complete() const;
 
             uint16_t epoch() const { return m_epoch; }
@@ -239,9 +243,6 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
             size_t msg_length() const { return m_msg_length; }
 
             std::pair<Handshake_Type, std::vector<uint8_t>> message() const;
-
-            // Release the memory buffers; called after reassembly has completed
-            void release_buffers();
 
          private:
             Handshake_Type m_msg_type = Handshake_Type::None;
@@ -254,6 +255,21 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
             std::vector<uint8_t> m_received_mask;
             std::vector<uint8_t> m_message;
       };
+
+      // Add a fragment to a reassembly slot, charging the slot's declared
+      // length against the pending-reassembly budget at its first fragment.
+      // Returns false, adding nothing, if the budget ceiling would be exceeded.
+      bool charged_add_fragment(Handshake_Reassembly& reassembly,
+                                size_t ceiling,
+                                const uint8_t fragment[],
+                                size_t fragment_length,
+                                size_t fragment_offset,
+                                uint16_t epoch,
+                                Handshake_Type msg_type,
+                                size_t msg_length);
+
+      // Uncommit a reassembly buffer's bytes from the pending-reassembly budget.
+      void release_reassembly_bytes(const Handshake_Reassembly& reassembly);
 
       struct Message_Info final {
             Message_Info(uint16_t e, Handshake_Type mt, const std::vector<uint8_t>& msg) :
@@ -308,10 +324,20 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       uint16_t m_in_message_seq = 0;
       uint16_t m_out_message_seq = 0;
 
+      // Epoch of the first delivered incoming message; its presence also
+      // guards format(), which is not the same as m_in_message_seq being
+      // non-zero once that counter wraps.
+      std::optional<uint16_t> m_first_delivered_epoch;
+
+      // Set once m_in_message_seq wraps, after which all handshake input is
+      // refused; see process_handshake_fragment.
+      bool m_in_message_seq_wrapped = false;
+
       writer_fn m_send_hs;
       steady_clock_fn m_steady_clock_ms;
       uint16_t m_mtu;
       size_t m_max_handshake_msg_size;
+      size_t m_max_pending_reassembly;
 };
 
 }  // namespace Botan::TLS

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -8,13 +8,19 @@
 
 #if defined(BOTAN_HAS_TLS_12)
 
+   #include <botan/rng.h>
+   #include <botan/tls_exceptn.h>
    #include <botan/tls_handshake_msg.h>
    #include <botan/tls_magic.h>
+   #include <botan/tls_policy.h>
+   #include <botan/internal/concat_util.h>
    #include <botan/internal/fmt.h>
+   #include <botan/internal/loadstor.h>
    #include <botan/internal/tls_handshake_io.h>
    #include <botan/internal/tls_seq_numbers.h>
 
    #include <algorithm>
+   #include <cstring>
    #include <vector>
 
 namespace Botan_Tests {
@@ -23,12 +29,35 @@ namespace {
 
 using namespace Botan::TLS;
 
+// Build a DTLS handshake record (12-byte header + payload). This is the
+// stream-of-bytes that Datagram_Handshake_IO::add_record consumes; the
+// outer DTLS record-layer header is stripped before this call.
+std::vector<uint8_t> dtls_hs_record(Handshake_Type msg_type,
+                                    uint32_t msg_len,
+                                    uint16_t message_seq,
+                                    uint32_t fragment_offset,
+                                    std::span<const uint8_t> fragment_bytes) {
+   const auto msg_len_bytes = Botan::store_be(msg_len);
+   const auto fragment_offset_bytes = Botan::store_be(fragment_offset);
+   const auto fragment_length_bytes = Botan::store_be(fragment_bytes.size());
+
+   return Botan::concat<std::vector<uint8_t>>(Botan::store_be(msg_type),
+                                              std::span{msg_len_bytes}.last<3>(),
+                                              Botan::store_be(message_seq),
+                                              std::span{fragment_offset_bytes}.last<3>(),
+                                              std::span{fragment_length_bytes}.last<3>(),
+                                              fragment_bytes);
+}
+
 class Datagram_IO_Fixture {
    public:
+      static constexpr size_t k_max_handshake_msg_size = 65536;  // default TLS::Policy value
+
       explicit Datagram_IO_Fixture(uint64_t initial_timeout_ms = 1000,
                                    uint64_t max_timeout_ms = 60000,
                                    std::optional<size_t> max_retransmissions = std::nullopt,
-                                   uint16_t mtu = 1500) :
+                                   uint16_t mtu = 1500,
+                                   size_t max_handshake_msg_size = k_max_handshake_msg_size) :
             m_io(
                [this](uint16_t, Record_Type type, const std::vector<uint8_t>& record) {
                   if(type == Record_Type::Handshake) {
@@ -42,7 +71,16 @@ class Datagram_IO_Fixture {
                initial_timeout_ms,
                max_timeout_ms,
                max_retransmissions,
-               65536) {}
+               max_handshake_msg_size) {}
+
+      void feed(std::span<const uint8_t> record, uint16_t epoch = 0) {
+         const uint64_t record_seq = static_cast<uint64_t>(epoch) << 48;
+         m_io.add_record(record.data(), record.size(), Record_Type::Handshake, record_seq);
+      }
+
+      std::pair<Handshake_Type, std::vector<uint8_t>> next_message() {
+         return m_io.get_next_record(false, k_max_handshake_msg_size);
+      }
 
       Datagram_Handshake_IO& io() { return m_io; }
 
@@ -69,6 +107,8 @@ class Datagram_IO_Fixture {
       Datagram_Handshake_IO m_io;
 };
 
+// Minimal Handshake_Message stub for tests that need to drive sends through
+// Datagram_Handshake_IO::send (and therefore exercise the timer state).
 class Stub_Handshake_Message final : public Botan::TLS::Handshake_Message {
    public:
       Stub_Handshake_Message(Handshake_Type type, std::vector<uint8_t> bytes) :
@@ -84,6 +124,10 @@ class Stub_Handshake_Message final : public Botan::TLS::Handshake_Message {
 };
 
 std::vector<Test::Result> dtls12_handshake_io_tests() {
+   const auto rng = Test::new_rng("dtls12_handshake_io_tests");
+
+   auto make_payload = [&rng](size_t len) { return rng->random_vec<std::vector<uint8_t>>(len); };
+
    return {
       CHECK(
          "protected handshake records respect MTU",
@@ -124,6 +168,319 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
             result.test_sz_eq(
                "unprotected message of that size is not fragmented", plaintext.sent_record_sizes().size(), size_t(1));
          }),
+
+      CHECK("single in-order ClientHello is delivered",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto payload = make_payload(64);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, payload));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered ClientHello", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload matches", bytes, payload);
+            }),
+
+      CHECK("multi-fragment reassembly in order",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto payload = make_payload(100);
+
+               const std::vector<uint8_t> p1(payload.begin(), payload.begin() + 40);
+               const std::vector<uint8_t> p2(payload.begin() + 40, payload.begin() + 75);
+               const std::vector<uint8_t> p3(payload.begin() + 75, payload.end());
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, p1));
+               result.test_is_true("not yet complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 40, p2));
+               result.test_is_true("still not complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 75, p3));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after final fragment", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("reassembled payload", bytes, payload);
+            }),
+
+      CHECK("out-of-order msg_seq waits for in-sequence message",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto p_seq0 = make_payload(50);
+               const auto p_seq1 = make_payload(60);
+
+               // Deliver message_seq=1 first
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 60, 1, 0, p_seq1));
+               result.test_is_true("seq=1 not delivered while waiting for seq=0",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // Now deliver message_seq=0; both should come out in order.
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, p_seq0));
+               auto [t0, b0] = fix.next_message();
+               result.test_enum_eq("first delivery is seq=0", t0, Handshake_Type::ClientHello);
+               result.test_bin_eq("seq=0 payload", b0, p_seq0);
+
+               auto [t1, b1] = fix.next_message();
+               result.test_enum_eq("second delivery is seq=1", t1, Handshake_Type::Certificate);
+               result.test_bin_eq("seq=1 payload", b1, p_seq1);
+            }),
+
+      // Regression test for the asymmetric DoS reported against the
+      // claim-based reassembly budget: an attacker sends header-only records
+      // for future message_seq values with a large declared msg_len. Before
+      // the fix, those records reserved the entire claimed msg_len against
+      // m_pending_reassembly_bytes and starved the legitimate ClientHello
+      // arriving at message_seq=0.
+      CHECK("header-only future-seq records do not block legit ClientHello",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               // Enough claims to exhaust the cap: 4 * 65536 == max_pending.
+               for(uint16_t seq = 1; seq <= 4; ++seq) {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size, seq, 0, {}));
+               }
+               result.test_is_true("attacker records yield no in-sequence message",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // The legit ClientHello must still get through.
+               const auto payload = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, payload));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit ClientHello delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("legit payload intact", bytes, payload);
+            }),
+
+      // A slot's charge is fixed by its claimed msg_length no matter how few of
+      // its bytes actually arrive. These fragments also arrive out of sequence,
+      // and out-of-sequence slots may only use part of the budget, so however
+      // many are sent the message actually being waited on still gets through.
+      CHECK("sparse one-byte segments cannot starve the expected message",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> one_byte = {0x42};
+               const uint32_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+
+               for(uint32_t offset = 0; offset < 40000; offset += 2) {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, big, 1, offset, one_byte));
+               }
+
+               const auto payload = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, payload));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("expected message still delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("its body is intact", bytes, payload);
+            }),
+
+      CHECK("tiny future-seq fragments do not exhaust the reassembly budget",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> fragment = {0x42};
+
+               // Saturate the reassembly window with 1-byte fragments
+               // claiming max msg_len at out-of-order msg_seq values.
+               for(uint16_t seq = 1; seq <= 8; ++seq) {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size, seq, 0, fragment));
+               }
+               result.test_is_true("no in-sequence delivery yet", fix.next_message().first == Handshake_Type::None);
+
+               // The legit msg_seq=0 ClientHello must still go through.
+               const std::vector<uint8_t> legit = make_payload(40);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 40, 0, 0, legit));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit msg_seq=0 delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("legit body intact", bytes, legit);
+            }),
+
+      // A fragment at the far end of the message can arrive before the start;
+      // filling the gap afterwards still completes the message.
+      CHECK("reassembly tolerates fragments at high offset",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const size_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+               const auto payload = make_payload(big);
+
+               // First the trailing 1 byte at offset big-1, then the
+               // leading big-1 bytes at offset 0.
+               const std::vector<uint8_t> tail(payload.end() - 1, payload.end());
+               const std::vector<uint8_t> head(payload.begin(), payload.end() - 1);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, static_cast<uint32_t>(big), 0, big - 1, tail));
+               result.test_is_true("not yet complete", fix.next_message().first == Handshake_Type::None);
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, static_cast<uint32_t>(big), 0, 0, head));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after gap fill", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("reassembled payload intact", bytes, payload);
+            }),
+
+      // Sibling check to the "tiny future-seq" test above using fully
+      // delivered payloads instead of one-byte fragments; confirms the cap
+      // is enforced symmetrically regardless of how much of each message
+      // the attacker actually sends.
+      CHECK("legitimately-large future-seq fragments are capped",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const size_t big = Datagram_IO_Fixture::k_max_handshake_msg_size;
+
+               // max_pending = min(4 * 65536, 16 MiB) = 256 KiB with half of it
+               // available to future-seq slots, and each of these is charged
+               // its claimed 64 KiB, so only two fit. Whichever exceeds the cap
+               // must be dropped silently rather than throwing.
+               for(uint16_t seq = 1; seq <= 5; ++seq) {
+                  result.test_no_throw("oversize future-seq fragment dropped without exception", [&] {
+                     fix.feed(dtls_hs_record(
+                        Handshake_Type::ClientHello, static_cast<uint32_t>(big), seq, 0, make_payload(big)));
+                  });
+               }
+
+               // The future-seq half of the budget is already full, so one-byte
+               // fragments claiming yet another large message are refused
+               // outright.
+               const std::vector<uint8_t> one_byte = {0x42};
+               for(uint32_t offset = 0; offset < 4000; offset += 2) {
+                  fix.feed(
+                     dtls_hs_record(Handshake_Type::Certificate, static_cast<uint32_t>(big), 6, offset, one_byte));
+               }
+
+               // Whatever those slots consumed, the message being waited on keeps
+               // its own share of the budget.
+               const auto expected = make_payload(16);
+               result.test_no_throw("expected msg_seq=0 is still admitted",
+                                    [&] { fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 16, 0, 0, expected)); });
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("expected message delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("its body is intact", bytes, expected);
+            }),
+
+      // A whole-message retransmission overlapping an already-buffered partial
+      // copy adds nothing to the slot's charge, which its claimed length fixed
+      // at the first fragment. Charging retransmitted bytes as new would drop,
+      // near the budget ceiling, the one fragment able to complete the message,
+      // stalling reassembly permanently.
+      CHECK("overlapping retransmission is admitted near the budget ceiling",
+            [&](Test::Result& result) {
+               // max_pending = 4 * 512 = 2048, future-seq slots limited to half
+               Datagram_IO_Fixture fix(1000, 60000, std::nullopt, 1500, 512);
+
+               const auto msg = make_payload(512);
+
+               // Consume most of the out-of-sequence half of the budget
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 1, 0, make_payload(300)));
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 2, 0, make_payload(300)));
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 3, 0, make_payload(100)));
+
+               // All but the tail of the awaited message
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 0, 0, std::span(msg).first(500)));
+               result.test_is_true("partial message not yet complete",
+                                   fix.next_message().first == Handshake_Type::None);
+
+               // The peer retransmits the message unfragmented. Were its bytes
+               // charged as new this would exceed the ceiling; the slot's fixed
+               // charge admits it.
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 512, 0, 0, msg));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("retransmitted message delivered", type, Handshake_Type::Certificate);
+               result.test_bin_eq("its body is intact", bytes, msg);
+            }),
+
+      // Empty handshake messages (msg_len == 0, e.g. ServerHelloDone) use a
+      // single record with fragment_length == 0; the zero-length filter must
+      // not eat them.
+      CHECK("empty handshake message is delivered",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               fix.feed(dtls_hs_record(Handshake_Type::ServerHelloDone, 0, 0, 0, {}));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered ServerHelloDone", type, Handshake_Type::ServerHelloDone);
+               result.test_sz_eq("no payload bytes", bytes.size(), size_t(0));
+            }),
+
+      CHECK("fragment past end of message is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // msg_len=10 but fragment claims offset=0, length=20.
+               result.template test_throws<Botan::Decoding_Error>("overflow rejected", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 10, 0, 0, make_payload(20)));
+               });
+            }),
+
+      CHECK("inconsistent fragment metadata is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 50, 0, 0, make_payload(20)));
+               result.template test_throws<Botan::Decoding_Error>("metadata mismatch rejected", [&] {
+                  // Same message_seq but advertise a different msg_type.
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 20, make_payload(10)));
+               });
+            }),
+
+      // RFC 6347 4.2.3 permits overlapping retransmissions, and overlapping bytes
+      // that disagree are a protocol error. For anything other than a
+      // ClientHello that stays an error.
+      CHECK("inconsistent overlapping bytes are rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // Partial first fragment so the slot is not yet complete; a
+               // completed slot silently ignores retransmissions.
+               const auto base = make_payload(50);
+               const std::vector<uint8_t> first(base.begin(), base.begin() + 30);
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 0, first));
+
+               auto bad = first;
+               bad[10] ^= 0xFF;
+               result.template test_throws<Botan::Decoding_Error>("overlap mismatch rejected", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 50, 0, 0, bad));
+               });
+            }),
+
+      CHECK("consistent retransmits are tolerated",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               const auto p = make_payload(100);
+               const std::vector<uint8_t> half1(p.begin(), p.begin() + 50);
+               const std::vector<uint8_t> half2(p.begin() + 50, p.end());
+
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, half1));
+               // Same first half, repeated. Must not throw or alter state.
+               result.test_no_throw("retransmit accepted",
+                                    [&] { fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 0, half1)); });
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 100, 0, 50, half2));
+
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("delivered after retransmit", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload unchanged by retransmit", bytes, p);
+            }),
+
+      CHECK("msg_len above policy max is rejected",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               result.template test_throws<TLS_Exception>("oversize msg_len rejected", [&] {
+                  fix.feed(dtls_hs_record(
+                     Handshake_Type::ClientHello, Datagram_IO_Fixture::k_max_handshake_msg_size + 1, 0, 0, {}));
+               });
+            }),
+
+      CHECK("message_seq beyond reassembly window is dropped",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+               // Window is 16 starting at m_in_message_seq=0, so seq=16 is
+               // out of window and should be silently ignored.
+               result.test_no_throw("out-of-window seq is silently dropped", [&] {
+                  fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 32, 16, 0, make_payload(32)));
+               });
+               // The legit in-sequence message still works.
+               const auto p = make_payload(20);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 20, 0, 0, p));
+               auto [type, bytes] = fix.next_message();
+               result.test_enum_eq("legit message delivered", type, Handshake_Type::ClientHello);
+               result.test_bin_eq("payload intact", bytes, p);
+            }),
 
       // Once the backoff saturates at m_max_timeout, the elapsed time since the
       // last write keeps growing, so a retransmit must re-anchor it. Otherwise
@@ -248,6 +605,44 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                fix.advance_clock_ms(next);
                result.test_throws("give-up only after the reset budget is exhausted",
                                   [&] { fix.io().timeout_check(); });
+            }),
+
+      // message_seq is 16 bits, and no legitimate handshake delivers 65536
+      // messages. Once the counter wraps all further handshake input is
+      // refused: a fresh message at a wrapped sequence number must not be
+      // mistaken for one of the long-delivered ones.
+      CHECK("message_seq wrapping onto a delivered slot does not assert",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix;
+
+               const std::vector<uint8_t> body(4, 0x5A);
+               bool all_delivered = true;
+               for(size_t i = 0; i <= 0xFFFF && all_delivered; ++i) {
+                  fix.feed(dtls_hs_record(Handshake_Type::Certificate, 4, static_cast<uint16_t>(i), 0, body));
+                  all_delivered = (fix.next_message().first == Handshake_Type::Certificate);
+               }
+               result.test_is_true("every message_seq up to the wrap was delivered", all_delivered);
+
+               // m_in_message_seq is back at 0, but the wrap refuses the record.
+               fix.feed(dtls_hs_record(Handshake_Type::Certificate, 4, 0, 0, body));
+
+               std::pair<Handshake_Type, std::vector<uint8_t>> after;
+               result.test_no_throw("wrapped slot is not mistaken for a complete message",
+                                    [&] { after = fix.next_message(); });
+               result.test_is_true("nothing is delivered from the released slot", after.first == Handshake_Type::None);
+
+               // format() names the message just delivered, so its guard is
+               // that one exists rather than that the counter is non-zero.
+               // Those differ here, and the difference used to be a reachable
+               // assertion. The subtraction wraps to 65535 of its own accord,
+               // which is the right sequence number for that message.
+               std::vector<uint8_t> formatted;
+               result.test_no_throw("format does not assert after the wrap",
+                                    [&] { formatted = fix.io().format(body, Handshake_Type::Certificate); });
+               if(result.test_is_true("format produced a header", formatted.size() >= 12)) {
+                  const uint16_t msg_seq = (static_cast<uint16_t>(formatted[4]) << 8) | formatted[5];
+                  result.test_sz_eq("it names the wrapped sequence number", msg_seq, size_t(0xFFFF));
+               }
             }),
 
       // A caller's monotonic clock may legitimately read zero, so sending the


### PR DESCRIPTION
The total memory limit for handshake reassembly caps at either 4x the policy per-handshake message maximum, or a overall cap of 16 Mb as a safety bound (this last applies even if the policy disables the per-handshake size limit).

Limit the amount of memory that out-of-sequence messages can consume to at most half the budget; otherwise random unauthenticated fragements could starve the handshake.

Erase complete handshake messages after delivering them up to the state machine.

Handle message sequence wraparound. Previously if this happened we could end up examining previously delivered sequences.

Drop fragments beyond the reassembly window silently rather than letting them cue a flight retransmission.

Ignore stray retransmissions that disagree with an already-complete message instead of tearing down the connection.

Extracted from #5783 