### PR TITLE
Use the encoded byte length in Python PKSign.update

### DIFF
--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -2224,7 +2224,8 @@ class PKSign: # pylint: disable=invalid-name
 
     def update(self, msg: str | bytes):
         """Add more data to be signed"""
-        _DLL.botan_pk_op_sign_update(self.__obj, _ctype_bits(msg), len(msg))
+        bits = _ctype_bits(msg)
+        _DLL.botan_pk_op_sign_update(self.__obj, bits, len(bits))
 
     def finish(self, rng_obj: RandomNumberGenerator) -> bytes:
         """Returns the signature of the message provided so far, and resets for another message"""

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -706,6 +706,26 @@ ofvkP1EDmpx50fHLawIDAQAB
         verify = botan.PKVerify(pk, param_str)
         verify_positive_and_negative(verify, sig)
 
+    def test_pksign_utf8_input(self):
+        # A Python str's character count can be shorter than the length of its
+        # UTF-8 encoding. PKSign must pass the encoded byte length to the FFI,
+        # both for a single update and when the message is split across calls.
+        rng = botan.RandomNumberGenerator()
+        private_key = botan.PrivateKey.create('RSA', '1024', rng)
+        public_key = private_key.get_public_key()
+        unicode_msg = "sign this: café € 😀"
+
+        for updates in [[unicode_msg], ["sign this: ", "café ", "€ ", "😀"]]:
+            with self.subTest(updates=updates):
+                signer = botan.PKSign(private_key, 'PKCS1v15(SHA-256)')
+                for update in updates:
+                    signer.update(update)
+                signature = signer.finish(rng)
+
+                verifier = botan.PKVerify(public_key, 'PKCS1v15(SHA-256)')
+                verifier.update(unicode_msg.encode('utf-8'))
+                self.assertTrue(verifier.check_signature(signature))
+
     @staticmethod
     def _ecc_sec1_convert_to_compressed(uncompressed_sec1):
         assert uncompressed_sec1[0] == 0x04


### PR DESCRIPTION
## Summary

`PKSign.update(str)` converts its input to UTF-8 but currently passes the
Unicode code-point count to `botan_pk_op_sign_update()`, whose length argument
is measured in bytes. As a result, non-ASCII strings are signed only up to the
shorter character count.

Encode the input once and pass `len(bits)`, matching `PKVerify.update()` and
the FFI contract.

Fixes #5806.

## Tests

Add `BotanPythonTests.test_pksign_utf8_input` covering:

- a one-shot message containing two-, three-, and four-byte UTF-8 characters;
- the same message divided across multiple `update()` calls.

The regression-only commit fails both cases against current master. The fix
commit passes both cases.

```text
Regression-only 76e7f33a8: FAILED (failures=2)
Fixed           7df88179b: OK
```

Focused command:

```sh
python3 src/scripts/test_python.py BotanPythonTests.test_pksign_utf8_input
```
