### PR TITLE
Propagate Threaded_Fork branch exceptions

### DIFF
--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -13,6 +13,9 @@
    #include <botan/internal/barrier.h>
    #include <botan/internal/semaphore.h>
 
+   #include <exception>
+   #include <mutex>
+
 namespace Botan {
 
 struct Threaded_Fork_Data {
@@ -38,6 +41,27 @@ struct Threaded_Fork_Data {
       * The length of the work that needs to be done.
       */
       size_t m_input_length = 0;
+
+      void clear_exception() {
+         std::lock_guard lock(m_exception_mutex);
+         m_exception = nullptr;
+      }
+
+      void capture_exception() {
+         std::lock_guard lock(m_exception_mutex);
+         if(!m_exception) {
+            m_exception = std::current_exception();
+         }
+      }
+
+      std::exception_ptr exception() {
+         std::lock_guard lock(m_exception_mutex);
+         return m_exception;
+      }
+
+   private:
+      std::mutex m_exception_mutex;
+      std::exception_ptr m_exception;
 };
 
 /*
@@ -116,6 +140,7 @@ void Threaded_Fork::send(const uint8_t input[], size_t length) {
 
 void Threaded_Fork::thread_delegate_work(const uint8_t input[], size_t length) {
    //Set the data to do.
+   m_thread_data->clear_exception();
    m_thread_data->m_input = input;
    m_thread_data->m_input_length = length;
 
@@ -126,9 +151,15 @@ void Threaded_Fork::thread_delegate_work(const uint8_t input[], size_t length) {
    //Wait for all the filters to finish processing.
    m_thread_data->m_input_complete_barrier.sync();
 
+   const auto exception = m_thread_data->exception();
+
    //Reset the thread data
    m_thread_data->m_input = nullptr;
    m_thread_data->m_input_length = 0;
+
+   if(exception) {
+      std::rethrow_exception(exception);
+   }
 }
 
 void Threaded_Fork::thread_entry(Filter* filter) {
@@ -141,7 +172,11 @@ void Threaded_Fork::thread_entry(Filter* filter) {
 
       // Plain Fork skips null ports the same way
       if(filter != nullptr) {
-         filter->write(m_thread_data->m_input, m_thread_data->m_input_length);
+         try {
+            filter->write(m_thread_data->m_input, m_thread_data->m_input_length);
+         } catch(...) {
+            m_thread_data->capture_exception();
+         }
       }
       m_thread_data->m_input_complete_barrier.sync();
    }

--- a/src/lib/filters/threaded_fork.cpp
+++ b/src/lib/filters/threaded_fork.cpp
@@ -19,6 +19,7 @@
 namespace Botan {
 
 struct Threaded_Fork_Data {
+      // NOLINTBEGIN(*-non-private-member-variables-in-classes)
       /*
       * Semaphore for indicating that there is work to be done (or to
       * quit)
@@ -42,20 +43,22 @@ struct Threaded_Fork_Data {
       */
       size_t m_input_length = 0;
 
+      // NOLINTEND(*-non-private-member-variables-in-classes)
+
       void clear_exception() {
-         std::lock_guard lock(m_exception_mutex);
+         const std::lock_guard lock(m_exception_mutex);
          m_exception = nullptr;
       }
 
       void capture_exception() {
-         std::lock_guard lock(m_exception_mutex);
+         const std::lock_guard lock(m_exception_mutex);
          if(!m_exception) {
             m_exception = std::current_exception();
          }
       }
 
       std::exception_ptr exception() {
-         std::lock_guard lock(m_exception_mutex);
+         const std::lock_guard lock(m_exception_mutex);
          return m_exception;
       }
 

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -745,6 +745,12 @@ class Filter_Tests final : public Test {
             result.test_bin_eq(
                "Output", pipe.read_all(2 + i), "327AD8055223F5926693D8BEA40F7B35BDEEB535647DFB93F464E40EA01939A9");
          }
+
+         Botan::Pipe rejecting_pipe(
+            new Botan::Threaded_Fork(new Botan::Base64_Decoder(Botan::FULL_CHECK), new Botan::Hex_Encoder));
+         result.test_throws<Botan::Invalid_Argument>("Threaded_Fork propagates branch exceptions", [&] {
+            rejecting_pipe.process_msg("@@@@");
+         });
    #endif
          return result;
       }

--- a/src/tests/test_filters.cpp
+++ b/src/tests/test_filters.cpp
@@ -748,9 +748,8 @@ class Filter_Tests final : public Test {
 
          Botan::Pipe rejecting_pipe(
             new Botan::Threaded_Fork(new Botan::Base64_Decoder(Botan::FULL_CHECK), new Botan::Hex_Encoder));
-         result.test_throws<Botan::Invalid_Argument>("Threaded_Fork propagates branch exceptions", [&] {
-            rejecting_pipe.process_msg("@@@@");
-         });
+         result.test_throws<Botan::Invalid_Argument>("Threaded_Fork propagates branch exceptions",
+                                                     [&] { rejecting_pipe.process_msg("@@@@"); });
    #endif
          return result;
       }


### PR DESCRIPTION
## Summary

- Catch exceptions thrown by `Threaded_Fork` branch filters.
- Preserve the first worker exception and rethrow it on the calling thread after all workers reach the completion barrier.
- Clear saved exception state before each dispatch.
- Add a regression test using strict Base64 rejection through the public Pipe API.

Without this boundary, a branch exception escapes `std::thread` and invokes `std::terminate`, so input that plain `Fork` reports as a catchable Botan exception aborts the process.

Fixes #5808.

## Testing

At the regression-only commit, `botan-test filter` aborts with exit 134 on the new test. With the fix:

```text
Threaded_Fork ran 12 tests all ok
Tests complete ran 68 tests in 21.12 msec all tests ok
```

`run_clang_format.py --check --skip-version-check -j 1 src/lib/filters/threaded_fork.cpp src/tests/test_filters.cpp` passes, as does `git diff --check`.
