### PR TITLE
In TLS 1.2 ensure sensitive state is cleared after a fatal alert

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -118,9 +118,52 @@ void Channel_Impl_12::reset_state() {
    m_active_state.reset();
    m_pending_state.reset();
    m_epochs_before_latest_renegotiation.reset();
+   m_resumption_handle.reset();
    m_readbuf.clear();
    m_write_cipher_states.clear();
    m_read_cipher_states.clear();
+}
+
+void Channel_Impl_12::note_resumption_handle(std::optional<Session_Handle> handle) {
+   m_resumption_handle = std::move(handle);
+}
+
+std::vector<Session_Handle> Channel_Impl_12::take_sessions_to_invalidate() {
+   // A ticket-backed session is not cached under the ServerHello session ID, so
+   // both handles have to be collected.
+   std::vector<Session_Handle> handles;
+
+   if(m_resumption_handle.has_value()) {
+      handles.push_back(m_resumption_handle.value());
+      m_resumption_handle.reset();
+   }
+
+   if(m_active_state.has_value()) {
+      const auto& sid = m_active_state->session_id();
+      if(!sid.empty()) {
+         handles.emplace_back(sid);
+      }
+   }
+
+   return handles;
+}
+
+void Channel_Impl_12::invalidate_sessions(const std::vector<Session_Handle>& handles) {
+   // RFC 5246 7.2.2: "Servers and clients MUST forget any session-identifiers,
+   // keys, and secrets associated with a failed connection.  Thus, any
+   // connection terminated with a fatal alert MUST NOT be resumed."
+   //
+   // Best effort, and deliberately last: remove() reaches application-supplied
+   // storage and can throw, and by then the keys are already gone. Letting a
+   // failed cache eviction abort the teardown would leave the channel usable
+   // after a security-fatal event, which is the worse of the two outcomes. A
+   // stateless ticket issuer has nothing to remove and cannot revoke what it
+   // already handed out.
+   for(const auto& handle : handles) {
+      try {
+         session_manager().remove(handle);
+      } catch(...) {}
+   }
 }
 
 void Channel_Impl_12::reset_active_association_state() {
@@ -468,6 +511,14 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
 
    try {
       while(input_size > 0) {
+         // A fatal alert destroys the cipher states, so nothing further can even
+         // be decrypted. Closure by close_notify is different: the responding
+         // close_notify still has to be read, so those records keep flowing
+         // through the loop and are filtered per record type below.
+         if(m_had_fatal_alert) {
+            return 0;
+         }
+
          size_t consumed = 0;
 
          auto get_epoch = [this](uint16_t epoch) { return read_cipher_state_epoch(epoch); };
@@ -547,6 +598,14 @@ size_t Channel_Impl_12::from_peer(std::span<const uint8_t> data) {
                   throw TLS_Exception(Alert::ProtocolVersion, "Received unexpected record version");
                }
             }
+         }
+
+         // RFC 5246 7.2.1: "Any data received after a closure alert is ignored."
+         // This is about a closure alert the peer sent us. A peer that keeps
+         // talking after *our* close_notify is a different case, kept as an
+         // error below; BoGo's Shutdown-Shim-ApplicationData requires it.
+         if(m_peer_closed_connection && record.type() != Record_Type::Alert) {
+            continue;
          }
 
          if(record.type() == Record_Type::Handshake || record.type() == Record_Type::ChangeCipherSpec) {
@@ -706,17 +765,25 @@ void Channel_Impl_12::process_alert(const secure_vector<uint8_t>& record) {
       m_pending_state.reset();
    }
 
-   callbacks().tls_alert(alert_msg);
-
-   // If the alert is fatal on an active session, prevent later resumptions
-   if(alert_msg.is_fatal() && m_active_state.has_value()) {
-      const auto& sid = m_active_state->session_id();
-      if(!sid.empty()) {
-         session_manager().remove(Session_Handle(sid));
-      }
+   if(alert_msg.is_fatal()) {
+      // RFC 5246 7.2.2: "Upon transmission or receipt of a fatal alert message,
+      // both parties immediately close the connection."
+      //
+      // The teardown completes before the application hears about the alert, so
+      // the callback cannot reach the connection or its secrets. Same order as
+      // the TLS 1.3 channel.
+      m_has_been_closed = true;
+      m_had_fatal_alert = true;
+      const auto invalidated = take_sessions_to_invalidate();
+      reset_state();
+      invalidate_sessions(invalidated);
    }
 
+   callbacks().tls_alert(alert_msg);
+
    if(alert_msg.type() == Alert::CloseNotify) {
+      m_peer_closed_connection = true;
+
       // TLS 1.2 requires us to immediately react with our "close_notify",
       // the return value of the application's callback has no effect on that.
       callbacks().tls_peer_closed_connection();
@@ -796,13 +863,22 @@ void Channel_Impl_12::send_alert(const Alert& alert) {
    }
 
    if(alert.is_fatal()) {
-      if(m_active_state.has_value()) {
-         const auto& sid = m_active_state->session_id();
-         if(!sid.empty()) {
-            session_manager().remove(Session_Handle(sid));
-         }
-      }
+      // Order matters: the channel is made unusable and its secrets destroyed
+      // before any application-supplied storage is touched, so a throwing
+      // session manager cannot leave is_active() true with live keys.
+      m_had_fatal_alert = true;
+      m_has_been_closed = true;
+
+      // Alert::None is the local teardown that is never sent to the peer, used
+      // where the trigger was unauthenticated input or a local timeout. Evicting
+      // the resumption state on that basis would hand anyone able to reach the
+      // address the ability to destroy it, which is what keeping the teardown
+      // local exists to prevent.
+      const auto invalidated =
+         (alert.type() == Alert::None) ? std::vector<Session_Handle>() : take_sessions_to_invalidate();
+
       reset_state();
+      invalidate_sessions(invalidated);
    }
 
    if(alert.type() == Alert::CloseNotify || alert.is_fatal()) {
@@ -881,6 +957,9 @@ SymmetricKey Channel_Impl_12::key_material_export(std::string_view label,
    if(!m_active_state.has_value()) {
       throw Invalid_State("Channel_Impl_12::key_material_export connection not active");
    }
+
+   // A fatal alert should have already cleared the active state:
+   BOTAN_ASSERT_NOMSG(!m_had_fatal_alert);
 
    if(pending_state() != nullptr) {
       throw Invalid_State("Channel_Impl_12::key_material_export cannot export during renegotiation");

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -187,6 +187,13 @@ class Channel_Impl_12 : public Channel_Impl {
 
       void reset_active_association_state();
 
+      /**
+      * Record the resumption handle this connection was established or resumed
+      * under, so that a fatal alert can invalidate it. The ServerHello session
+      * ID does not identify a ticket-backed session.
+      */
+      void note_resumption_handle(std::optional<Session_Handle> handle);
+
       virtual void initiate_handshake(Handshake_State& state, bool force_full_renegotiation) = 0;
 
    private:
@@ -200,6 +207,13 @@ class Channel_Impl_12 : public Channel_Impl {
          Connection_Cipher_State* cipher_state, uint16_t epoch, Record_Type type, const uint8_t input[], size_t length);
 
       void reset_state();
+
+      // Collect the handles this connection's session is cached under, clearing
+      // the tracked one. Separate from the removal so that the caller can
+      // destroy the connection state first; see invalidate_sessions.
+      std::vector<Session_Handle> take_sessions_to_invalidate();
+
+      void invalidate_sessions(const std::vector<Session_Handle>& handles);
 
       Connection_Sequence_Numbers& sequence_numbers() const;
 
@@ -236,6 +250,9 @@ class Channel_Impl_12 : public Channel_Impl {
 
       /* pending handshake state (null when no handshake is in progress) */
       std::unique_ptr<Handshake_State> m_pending_state;
+
+      /* handle under which this connection's session is cached, if any */
+      std::optional<Session_Handle> m_resumption_handle;
 
       // Epochs in force when the pending handshake began. Whether either has
       // moved decides if an abandoned handshake can be discarded or has to
@@ -276,6 +293,14 @@ class Channel_Impl_12 : public Channel_Impl {
       secure_vector<uint8_t> m_record_buf;
 
       bool m_has_been_closed;
+
+      // Set when a fatal alert was sent or received, which unlike close_notify
+      // destroys the connection state outright.
+      bool m_had_fatal_alert = false;
+
+      // Set when the peer sent close_notify, as opposed to us closing. Only
+      // then is later data from the peer something to ignore rather than reject.
+      bool m_peer_closed_connection = false;
 
       std::optional<Active_Connection_State_12> m_active_state;
       // TODO(Botan4) remember to remove this when renegotiation support is dropped

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -780,6 +780,8 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
          }
       }
 
+      note_resumption_handle(handle);
+
       activate_session();
    } else {
       throw Unexpected_Message("Unknown handshake message received");

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -682,6 +682,8 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
                handle->ticket().value(),
                static_cast<uint32_t>(policy().session_ticket_lifetime().count())));
          }
+
+         note_resumption_handle(handle);
       }
 
       if(pending_state.new_session_ticket() == nullptr && pending_state.server_hello()->supports_session_ticket()) {
@@ -798,6 +800,8 @@ void Server_Impl_12::session_resume(Server_Handshake_State& pending_state, const
          return session_manager().establish(session.session, session.handle.id());
       }
    }();
+
+   note_resumption_handle(new_handle);
 
    if(pending_state.server_hello()->supports_session_ticket()) {
       if(new_handle.has_value() && new_handle->is_ticket()) {

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -217,6 +217,14 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_without_epoch0_restart() {
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
+// So that a test's own find() call does not consume the ticket it is checking
+// for.
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_reusing_session_tickets() {
+   DTLS_Policy_Options opts;
+   opts.reuse_session_tickets = true;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
 std::unique_ptr<Botan::TLS::Client> make_dtls_client(const std::shared_ptr<Botan::TLS::Callbacks>& callbacks,
                                                      const std::shared_ptr<Botan::TLS::Session_Manager>& sessions,
                                                      const std::shared_ptr<Botan::Credentials_Manager>& creds,
@@ -1997,6 +2005,241 @@ class DTLS_Epoch0_Window_Tampering_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_window_tamper", DTLS_Epoch0_Window_Tampering_Test);
+
+/*
+* RFC 5246 7.2.2 requires a fatally terminated connection to forget its keys and
+* to become unresumable, and 7.2.1 says data arriving after a closure alert is
+* ignored. These check the receive side of both, which previously only tore down
+* on locally generated alerts.
+*/
+class TLS_Closure_Teardown_Test : public Test {
+   private:
+      // Session_Manager::remove() reaches application storage and is not
+      // noexcept. A failure there must not be able to abort a fatal-alert
+      // teardown partway through.
+      class Throwing_Session_Manager final : public Botan::TLS::Session_Manager {
+         public:
+            explicit Throwing_Session_Manager(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) :
+                  Session_Manager(rng) {}
+
+            void store(const Botan::TLS::Session& /*session*/, const Botan::TLS::Session_Handle& /*handle*/) override {}
+
+            size_t remove(const Botan::TLS::Session_Handle& /*handle*/) override {
+               throw Botan::Invalid_State("session storage is unavailable");
+            }
+
+            size_t remove_all() override { return 0; }
+
+         protected:
+            std::optional<Botan::TLS::Session> retrieve_one(const Botan::TLS::Session_Handle& /*handle*/) override {
+               return std::nullopt;
+            }
+
+            std::vector<Botan::TLS::Session_with_Handle> find_some(const Botan::TLS::Server_Information& /*info*/,
+                                                                   size_t /*max_sessions_hint*/) override {
+               return {};
+            }
+      };
+
+      Test::Result fatal_alert_teardown(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("received fatal alert destroys connection state");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         result.test_no_throw("exporter works while active",
+                              [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         assoc->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         result.test_is_true("server emitted the alert", !assoc->s2c.empty());
+
+         std::vector<uint8_t> alert;
+         std::swap(assoc->s2c, alert);
+         result.test_no_throw("client accepts the alert record",
+                              [&] { assoc->client->received_data(alert.data(), alert.size()); });
+
+         result.test_sz_eq("the application saw the alert", assoc->client_cb->alerts_received(), size_t(1));
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_is_true("client is no longer active", !assoc->client->is_active());
+         result.test_is_true("handshake state is gone", !assoc->client->is_handshake_complete());
+
+         result.test_throws("exporter is refused after a fatal alert",
+                            [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         return result;
+      }
+
+      // RFC 5246 7.2.2 makes a fatally terminated connection's secrets unusable,
+      // but a clean close_notify does not, and TLS 1.3 keeps its exporter
+      // working across one. Keying the refusal on is_closed() broke both.
+      Test::Result exporter_after_clean_close(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("exporter survives close_notify but not a fatal alert");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         assoc->client->close();
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_no_throw("exporter still works after close_notify",
+                              [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         // A fatal alert is different: the teardown clears the active state, so
+         // the exporter refuses on that ground too.
+         auto fatal = make_association(result, rng, opts);
+         if(!result.test_is_true("second handshake completed", fatal->pump())) {
+            return result;
+         }
+         fatal->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(fatal->s2c, alert);
+         fatal->client->received_data(alert.data(), alert.size());
+         result.test_throws("exporter refuses after a fatal alert",
+                            [&] { fatal->client->key_material_export("test label", "", 32); });
+
+         return result;
+      }
+
+      // The teardown touches application storage. If that throws before the
+      // keys are destroyed, the channel is left half closed: inbound records
+      // dropped, but is_active() still true and the write side still usable.
+      Test::Result teardown_survives_a_throwing_session_manager(
+         const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("fatal teardown completes despite a throwing session manager");
+
+         DTLS_Association_Options opts;
+         opts.client_sessions = std::make_shared<Throwing_Session_Manager>(rng);
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         // Locally generated fatal alert, which invalidates cached sessions
+         // before the channel state is torn down.
+         result.test_no_throw("local fatal alert does not surface the storage failure",
+                              [&] { assoc->client->send_fatal_alert(Botan::TLS::Alert::InternalError); });
+
+         result.test_is_true("client is closed", assoc->client->is_closed());
+         result.test_is_true("client is not active", !assoc->client->is_active());
+         result.test_is_true("connection state is gone", !assoc->client->is_handshake_complete());
+         result.test_throws("writes are refused", [&] { assoc->client->send("nope"); });
+         result.test_throws("exporter is refused", [&] { assoc->client->key_material_export("test label", "", 32); });
+
+         // And the receive side, where the callback also runs before teardown.
+         DTLS_Association_Options received_opts;
+         received_opts.client_sessions = std::make_shared<Throwing_Session_Manager>(rng);
+         received_opts.tolerate_fatal_alerts = true;
+         auto received = make_association(result, rng, received_opts);
+         if(!result.test_is_true("second handshake completed", received->pump())) {
+            return result;
+         }
+         received->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(received->s2c, alert);
+         result.test_no_throw("received fatal alert does not surface the storage failure",
+                              [&] { received->client->received_data(alert.data(), alert.size()); });
+         result.test_is_true("client is closed", received->client->is_closed());
+         result.test_is_true("connection state is gone", !received->client->is_handshake_complete());
+
+         return result;
+      }
+
+      Test::Result ticket_invalidated(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("received fatal alert invalidates a ticket-backed session");
+
+         DTLS_Association_Options opts;
+         opts.policy = dtls_policy_reusing_session_tickets();
+         opts.stateless_tickets = true;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         // Without reuse allowed, find() itself consumes the ticket and the
+         // final check below would pass vacuously.
+         const auto policy = dtls_policy_reusing_session_tickets();
+         const auto cached =
+            assoc->client_sessions->find(Botan::TLS::Server_Information("localhost"), *assoc->client_cb, *policy);
+         if(!result.test_is_true("client cached a resumable session", !cached.empty())) {
+            return result;
+         }
+         // The ServerHello session ID, which is all the channel used to track,
+         // does not identify this session.
+         result.test_is_true("the session is ticket-backed, not ID-backed", cached[0].handle.is_ticket());
+
+         const auto recheck =
+            assoc->client_sessions->find(Botan::TLS::Server_Information("localhost"), *assoc->client_cb, *policy);
+         result.test_is_true("find() did not consume the ticket", !recheck.empty());
+
+         assoc->server->send_fatal_alert(Botan::TLS::Alert::InternalError);
+         std::vector<uint8_t> alert;
+         std::swap(assoc->s2c, alert);
+         assoc->client->received_data(alert.data(), alert.size());
+
+         const auto after =
+            assoc->client_sessions->find(Botan::TLS::Server_Information("localhost"), *assoc->client_cb, *policy);
+         result.test_is_true("the ticket was removed from the client cache", after.empty());
+
+         return result;
+      }
+
+      Test::Result data_after_close_notify(const std::shared_ptr<Botan::RandomNumberGenerator>& rng) {
+         Test::Result result("data reordered behind a close_notify is ignored");
+
+         DTLS_Association_Options opts;
+         opts.tolerate_fatal_alerts = true;
+         auto assoc = make_association(result, rng, opts);
+         if(!result.test_is_true("handshake completed", assoc->pump())) {
+            return result;
+         }
+
+         // Send application data and then close, but hand the client the
+         // close_notify first. Reordering is ordinary for DTLS, and it must not
+         // turn a clean shutdown into a fatal error.
+         const std::string payload = "reordered";
+         assoc->server->send(payload);
+         std::vector<uint8_t> app_data;
+         std::swap(assoc->s2c, app_data);
+         result.test_is_true("app data record captured", !app_data.empty());
+
+         assoc->server->close();
+         std::vector<uint8_t> close_notify;
+         std::swap(assoc->s2c, close_notify);
+         result.test_is_true("close_notify record captured", !close_notify.empty());
+
+         result.test_no_throw("client accepts the close_notify",
+                              [&] { assoc->client->received_data(close_notify.data(), close_notify.size()); });
+         result.test_is_true("client is closed", assoc->client->is_closed());
+
+         result.test_no_throw("late application data is ignored, not rejected",
+                              [&] { assoc->client->received_data(app_data.data(), app_data.size()); });
+         result.test_is_true("the ignored data was not delivered", assoc->client_recv.empty());
+
+         return result;
+      }
+
+   public:
+      std::vector<Test::Result> run() override {
+         auto rng = Test::new_shared_rng(this->test_name());
+
+         return {fatal_alert_teardown(rng),
+                 ticket_invalidated(rng),
+                 data_after_close_notify(rng),
+                 exporter_after_clean_close(rng),
+                 teardown_survives_a_throwing_session_manager(rng)};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_closure_teardown", TLS_Closure_Teardown_Test);
 
 #endif
 


### PR DESCRIPTION
Extracted from #5783 