### PR TITLE
Ignore unauthenticated epoch-zero input in active DTLS associations

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -64,6 +64,27 @@ void prune_old_cipher_states(std::map<uint16_t, T>& states) {
    }
 }
 
+// Run fn, absorbing the exceptions that report malformed input when `absorb`
+// is set. Used where the input is unauthenticated epoch-zero data that must
+// not be able to tear down an established association. Only TLS_Exception and
+// Decoding_Error are absorbed: an Internal_Error from one of the reassembly
+// accounting assertions, or a failed allocation, still propagates rather than
+// leaving the association running on state those assertions exist to protect.
+template <typename F>
+void absorb_malformed_input_errors(bool absorb, F fn) {
+   try {
+      fn();
+   } catch(const TLS_Exception&) {
+      if(!absorb) {
+         throw;
+      }
+   } catch(const Decoding_Error&) {
+      if(!absorb) {
+         throw;
+      }
+   }
+}
+
 }  // namespace
 
 Channel_Impl_12::Channel_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
@@ -573,16 +594,14 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
    const auto process_retransmitted_record = [&] {
       BOTAN_ASSERT(m_active_state.has_value(), "Have active DTLS association for retransmission");
       BOTAN_ASSERT_NONNULL(m_active_state->dtls_handshake_io());
-      try {
+      // Epoch-zero records are unauthenticated and may be spoofed, so a
+      // malformed one must not tear down an established association.
+      const bool unauthenticated = (record_sequence >> 48) == 0;
+
+      absorb_malformed_input_errors(unauthenticated, [&] {
          m_active_state->dtls_handshake_io()->add_retransmitted_record(
             record.data(), record.size(), record_type, record_sequence);
-      } catch(...) {
-         // Epoch-zero records are unauthenticated and may be spoofed. Invalid
-         // retransmissions must not tear down an established association.
-         if((record_sequence >> 48) > 0) {
-            throw;
-         }
-      }
+      });
    };
 
    if(!m_pending_state) {
@@ -601,7 +620,6 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
       if(m_is_datagram && !epoch0_restart) {
          if(m_sequence_numbers) {
             const uint16_t epoch = record_sequence >> 48;
-
             const uint16_t current_epoch = sequence_numbers().current_read_epoch();
             if(epoch == current_epoch) {
                // Either endpoint can initiate renegotiation from FINISHED:
@@ -629,21 +647,36 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
 
    // May have been created in above conditional
    if(m_pending_state) {
-      m_pending_state->handshake_io().add_record(record.data(), record.size(), record_type, record_sequence);
+      // An epoch-zero record is unauthenticated. Once an association is
+      // established, one arriving during a pending renegotiation must not be
+      // able to destroy it, exactly as for the no-pending-handshake path above.
+      // Without this a single forged CCS or handshake fragment tore down the
+      // active association and the renegotiation along with it.
+      //
+      // Delivery is inside the guard as well as reassembly. A bare 12-byte
+      // header declaring a zero-length message reassembles cleanly and only
+      // fails when the message itself is parsed or dispatched, which reaches
+      // the same teardown by a later route.
+      const bool unauthenticated_against_active_association =
+         m_is_datagram && (record_sequence >> 48) == 0 && m_active_state.has_value();
 
-      while(auto* pending = m_pending_state.get()) {
-         auto msg = pending->get_next_handshake_msg(policy().maximum_handshake_message_size());
+      absorb_malformed_input_errors(unauthenticated_against_active_association, [&] {
+         m_pending_state->handshake_io().add_record(record.data(), record.size(), record_type, record_sequence);
 
-         if(msg.first == Handshake_Type::None) {  // no full handshake yet
-            break;
+         while(auto* pending = m_pending_state.get()) {
+            auto msg = pending->get_next_handshake_msg(policy().maximum_handshake_message_size());
+
+            if(msg.first == Handshake_Type::None) {  // no full handshake yet
+               break;
+            }
+
+            process_handshake_msg(*pending, msg.first, msg.second, epoch0_restart);
+
+            if(!m_pending_state) {
+               break;
+            }
          }
-
-         process_handshake_msg(*pending, msg.first, msg.second, epoch0_restart);
-
-         if(!m_pending_state) {
-            break;
-         }
-      }
+      });
    }
 }
 

--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -476,12 +476,12 @@ Record_Header read_dtls_record(secure_vector<uint8_t>& readbuf,
    }
 
    if(epoch == 0) {
-      // Unencrypted initial handshake
+      // Unencrypted initial handshake. Epoch-0 records are unauthenticated and
+      // deliberately do not advance the replay window: one spoofed record with a
+      // high sequence number would otherwise silently drop every later record
+      // from the real peer. Duplicates are filtered by handshake reassembly.
       recbuf.assign(readbuf.begin() + DTLS_HEADER_SIZE, readbuf.begin() + DTLS_HEADER_SIZE + record_size);
       readbuf.clear();
-      if(sequence_numbers != nullptr && sequence_numbers->current_read_epoch() == 0) {
-         sequence_numbers->read_accept(sequence);
-      }
       return Record_Header(sequence, version, type);
    }
 

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -209,6 +209,14 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_max_retransmissions(size_t lim
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
+// allow_dtls_epoch0_restart() off, which is the Policy default and the
+// configuration every DTLS client runs in.
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_without_epoch0_restart() {
+   DTLS_Policy_Options opts;
+   opts.allow_epoch0_restart = false;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
 std::unique_ptr<Botan::TLS::Client> make_dtls_client(const std::shared_ptr<Botan::TLS::Callbacks>& callbacks,
                                                      const std::shared_ptr<Botan::TLS::Session_Manager>& sessions,
                                                      const std::shared_ptr<Botan::Credentials_Manager>& creds,
@@ -1074,6 +1082,115 @@ class DTLS_Core_Regression_Tests final : public Test {
          return result;
       }
 
+      // A bare handshake header declaring a zero-length message reassembles
+      // completely, so it is not rejected by add_record; it fails later, when
+      // the message is parsed or offered to the state machine. That route
+      // reached the same teardown until the guard was widened to cover
+      // delivery. The client is the exposed side: its pending IO has received
+      // nothing, so the stale-epoch check cannot help it.
+      static Test::Result test_forged_epoch0_message_during_renegotiation() {
+         Test::Result result("DTLS forged epoch-zero message during renegotiation");
+
+         auto rng = Test::new_shared_rng("dtls-core-forged-epoch0-message");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& server_recv = assoc->server_recv;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         result.test_no_throw("client starts renegotiation", [&] { client.renegotiate(true); });
+
+         // Drop the ClientHello. The client's pending IO has now received
+         // nothing at all, which is the state it spends the renegotiation in.
+         c2s.clear();
+
+         // ServerHello and Certificate: the first fails in the message parser,
+         // the second in the state machine. Each carries the message_seq the
+         // pending IO is waiting for, so each reaches dispatch.
+         const std::array<uint8_t, 2> forged_types = {0x02, 0x0B};
+
+         for(size_t i = 0; i != forged_types.size(); ++i) {
+            std::array<uint8_t, 12> header = {};
+            header[0] = forged_types[i];          // msg_type
+            header[5] = static_cast<uint8_t>(i);  // message_seq, in sequence
+                                                  // msg_len, fragment_offset, fragment_length all zero
+            const auto forged = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 9 + i, header);
+
+            result.test_no_throw("forged epoch-zero message is absorbed",
+                                 [&] { client.received_data(forged.data(), forged.size()); });
+            result.test_is_true("client remains active", client.is_active());
+            result.test_is_false("client did not close", client.is_closed());
+            result.test_is_true("client said nothing in reply", c2s.empty());
+         }
+
+         // The association still carries data under the established epoch. The
+         // pending renegotiation may not survive being desynchronized this way,
+         // but nothing unauthenticated may destroy what is already running.
+         client.send("still alive");
+         result.test_is_true("client can still write", !c2s.empty());
+         deliver(result, "application data after the forgery", c2s, server);
+         result.test_is_true("server received it", server_recv.size() == 11);
+
+         return result;
+      }
+
+      // A single forged epoch-zero record must not tear down an established
+      // association while a handshake is pending, whether it is malformed at the
+      // record layer or only once the new handshake IO reassembles it.
+      static Test::Result test_forged_epoch0_record_during_renegotiation() {
+         Test::Result result("DTLS forged epoch-zero record during renegotiation");
+
+         auto rng = Test::new_shared_rng("dtls-core-forged-epoch0-reneg");
+         auto assoc = make_association(result, rng);
+         auto& client = *assoc->client;
+         auto& server = *assoc->server;
+         auto& c2s = assoc->c2s;
+         auto& s2c = assoc->s2c;
+
+         if(!complete_dtls_handshake(result, *assoc)) {
+            return result;
+         }
+
+         result.test_no_throw("client starts renegotiation", [&] { client.renegotiate(true); });
+         deliver(result, "renegotiation client hello", c2s, server);
+
+         // Hold the server's renegotiation flight back so that anything it emits
+         // in response to the forged records below is visible on its own.
+         std::vector<uint8_t> renegotiation_flight;
+         std::swap(renegotiation_flight, s2c);
+         result.test_is_true("server produced a renegotiation flight", !renegotiation_flight.empty());
+
+         // A ChangeCipherSpec payload must be 0x01, so this one is malformed.
+         const std::vector<uint8_t> bad_ccs_body = {0x02};
+         const auto bad_ccs = unprotected_dtls_record(Botan::TLS::Record_Type::ChangeCipherSpec, 7, bad_ccs_body);
+         result.test_no_throw("forged epoch-zero CCS is ignored",
+                              [&] { server.received_data(bad_ccs.data(), bad_ccs.size()); });
+         result.test_is_true("server remains active", server.is_active());
+         result.test_is_false("server did not close", server.is_closed());
+         result.test_is_true("server said nothing in reply", s2c.empty());
+
+         // A malformed handshake fragment must be equally harmless.
+         std::array<uint8_t, 12> bogus_handshake = {};
+         bogus_handshake[0] = 0xFF;
+         const auto forged_handshake = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, 8, bogus_handshake);
+         result.test_no_throw("forged epoch-zero handshake record is ignored",
+                              [&] { server.received_data(forged_handshake.data(), forged_handshake.size()); });
+         result.test_is_true("server still active", server.is_active());
+
+         // The renegotiation itself survived and can still complete.
+         deliver_copy(result, "renegotiation server flight", renegotiation_flight, client);
+         deliver(result, "renegotiation client final flight", c2s, server);
+         deliver(result, "renegotiation server final flight", s2c, client);
+         result.test_is_true("client active after renegotiation", client.is_active());
+         result.test_is_true("server active after renegotiation", server.is_active());
+
+         return result;
+      }
+
       static Test::Result test_duplicate_server_flight_defers_to_timer() {
          Test::Result result("DTLS duplicate server flight defers replay to timer");
 
@@ -1675,6 +1792,8 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_lost_server_flight_retransmits(),
                  test_duplicate_server_flight_defers_to_timer(),
                  test_hello_request_during_handshake_is_ignored(),
+                 test_forged_epoch0_record_during_renegotiation(),
+                 test_forged_epoch0_message_during_renegotiation(),
                  test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),
@@ -1781,6 +1900,103 @@ class DTLS_Reconnection_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_reconnect", DTLS_Reconnection_Test);
+
+// One unauthenticated epoch-0 record, from anyone able to target the
+// connection's 5-tuple, must not be able to end an established association.
+class DTLS_Epoch0_Inject_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+         results.push_back(run_one("server target", true));
+         results.push_back(run_one("client target", false));
+         return results;
+      }
+
+   private:
+      Test::Result run_one(const std::string& subtest, bool target_server) {
+         Test::Result result("DTLS epoch-0 inject: " + subtest);
+
+         auto rng = Test::new_shared_rng(this->test_name() + "/" + subtest);
+
+         // allow_dtls_epoch0_restart() is off, which is the vulnerable
+         // configuration and the default for every DTLS endpoint.
+         auto assoc = make_association(result, rng, dtls_policy_without_epoch0_restart());
+
+         result.test_is_true("DTLS handshake completed", assoc->pump());
+
+         // The sequence number is chosen so that, immediately after handshake
+         // completion, the bit at (m_window_highest - sequence) is unset and
+         // already_seen() returns false. With m_window_highest = 2^48 and
+         // m_window_bits = 0b1, sequence = 2^48 - 1 lands at offset 1 in the
+         // window, where the bit is zero.
+         const std::vector<uint8_t> body = {0xAA};
+         const auto attack = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, (uint64_t(1) << 48) - 1, body);
+
+         auto& target = target_server ? static_cast<Botan::TLS::Channel&>(*assoc->server)
+                                      : static_cast<Botan::TLS::Channel&>(*assoc->client);
+         result.test_no_throw("epoch-0 inject does not throw",
+                              [&] { target.received_data(attack.data(), attack.size()); });
+
+         result.test_is_true("target still active after inject", target.is_active());
+         result.test_is_false("target not closed after inject", target.is_closed());
+
+         // App data must still flow on the live keys.
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+         assoc->server_recv.clear();
+         assoc->client_recv.clear();
+         assoc->client->send(ping);
+         assoc->server->send(pong);
+         result.test_is_true("app data still flows after inject", assoc->pump_until([&] {
+            return assoc->server_recv == ping && assoc->client_recv == pong;
+         }));
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_inject", DTLS_Epoch0_Inject_Test);
+
+// A spoofed epoch-0 record at the top of the 48-bit sequence space must not
+// advance the read replay window past anything the legitimate peer can still
+// reach, which would silently drop every later record of its handshake.
+class DTLS_Epoch0_Window_Tampering_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("DTLS epoch-0 window tampering");
+
+         auto rng = Test::new_shared_rng(this->test_name());
+         auto assoc = make_association(result, rng, dtls_policy_without_epoch0_restart());
+
+         // One round-trip so the server has processed the first ClientHello and
+         // its sequence numbers exist with the window highest at 0.
+         result.test_is_true("client produced initial CH", !assoc->c2s.empty());
+         assoc->pump_one();
+
+         // Recentering the replay window here would drop every later
+         // ClientHello and key exchange from the legitimate client.
+         const std::vector<uint8_t> body = {0xAA};
+         const auto attack = unprotected_dtls_record(Botan::TLS::Record_Type::Handshake, (uint64_t(1) << 48) - 1, body);
+         result.test_no_throw("epoch-0 inject does not throw",
+                              [&] { assoc->server->received_data(attack.data(), attack.size()); });
+
+         result.test_is_true("handshake completed despite epoch-0 inject", assoc->pump());
+
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+         assoc->server_recv.clear();
+         assoc->client_recv.clear();
+         assoc->client->send(ping);
+         assoc->server->send(pong);
+         result.test_is_true("app data flows after recovery", assoc->pump_until([&] {
+            return assoc->server_recv == ping && assoc->client_recv == pong;
+         }));
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_epoch0_window_tamper", DTLS_Epoch0_Window_Tampering_Test);
 
 #endif
 


### PR DESCRIPTION
Extracted from #5783 