### PR TITLE
Refactor: TLS downgrade does not re-parse Client Hello

### DIFF
--- a/src/lib/tls/tls12/msg_client_hello_12.cpp
+++ b/src/lib/tls/tls12/msg_client_hello_12.cpp
@@ -267,6 +267,15 @@ Client_Hello_12::Client_Hello_12(Handshake_IO& io,
 Client_Hello_12::Client_Hello_12(std::span<const uint8_t> buf) :
       Client_Hello_12(std::make_unique<Client_Hello_Internal>(buf)) {}
 
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+
+Client_Hello_12::Client_Hello_12(Client_Hello_13 client_hello, Handshake_IO& io, Handshake_Hash& hash) :
+      Client_Hello_12(std::move(client_hello.m_data)) {
+   hash.update(io.start_with_client_hello_from_downgrade(*this));
+}
+
+#endif
+
 Client_Hello_12::Client_Hello_12(std::unique_ptr<Client_Hello_Internal> data) : Client_Hello_12_Shim(std::move(data)) {
    const uint16_t TLS_EMPTY_RENEGOTIATION_INFO_SCSV = 0x00FF;
 

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -117,7 +117,7 @@ Client_Impl_12::Client_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
 
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
 
-Client_Impl_12::Client_Impl_12(const Channel_Impl::Downgrade_Information& downgrade_info) :
+Client_Impl_12::Client_Impl_12(Channel_Impl::Downgrade_Information& downgrade_info) :
       Channel_Impl_12(downgrade_info.callbacks,
                       downgrade_info.session_manager,
                       downgrade_info.rng,
@@ -129,15 +129,12 @@ Client_Impl_12::Client_Impl_12(const Channel_Impl::Downgrade_Information& downgr
       m_info(downgrade_info.server_info) {
    Handshake_State& state = create_handshake_state(Protocol_Version::TLS_V12);
 
-   if(!downgrade_info.client_hello_message.empty()) {
+   if(downgrade_info.client_hello.has_value()) {
       // Downgrade detected after receiving a TLS 1.2 server hello. We need to
       // recreate the state as if this implementation issued the client hello.
-      const std::vector<uint8_t> client_hello_msg(
-         downgrade_info.client_hello_message.begin() + 4 /* handshake header length */,
-         downgrade_info.client_hello_message.end());
 
-      state.client_hello(std::make_unique<Client_Hello_12>(client_hello_msg));
-      state.hash().update(downgrade_info.client_hello_message);
+      state.client_hello(std::make_unique<Client_Hello_12>(
+         std::exchange(downgrade_info.client_hello, {}).value(), state.handshake_io(), state.hash()));
 
       secure_renegotiation_check(state.client_hello());
       state.set_expected_next(Handshake_Type::ServerHello);

--- a/src/lib/tls/tls12/tls_client_impl_12.h
+++ b/src/lib/tls/tls12/tls_client_impl_12.h
@@ -58,7 +58,7 @@ class Client_Impl_12 final : public Channel_Impl_12 {
 
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
 
-      explicit Client_Impl_12(const Channel_Impl::Downgrade_Information& downgrade_info);
+      explicit Client_Impl_12(Channel_Impl::Downgrade_Information& downgrade_info);
 
 #endif
 

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/tls_handshake_io.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/tls_exceptn.h>
 #include <botan/tls_handshake_msg.h>
@@ -141,6 +142,20 @@ std::vector<uint8_t> Stream_Handshake_IO::send(const Handshake_Message& msg) {
    m_send_hs(Record_Type::Handshake, buf);
    return buf;
 }
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+
+std::vector<uint8_t> Stream_Handshake_IO::start_with_client_hello_from_downgrade(
+   const Handshake_Message& client_hello) {
+   BOTAN_ARG_CHECK(client_hello.type() == Handshake_Type::ClientHello,
+                   "Expected ClientHello message for TLS downgrade");
+
+   // In TLS we don't have to update any internal state, we just need to
+   // format the Client Hello message for absorption into the handshake hash.
+   return format(client_hello.serialize(), client_hello.wire_type());
+}
+
+#endif
 
 Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              steady_clock_fn steady_clock_ms,
@@ -687,6 +702,19 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
 
    return send_message(m_out_message_seq - 1, epoch, msg_type, msg_bits);
 }
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+
+std::vector<uint8_t> Datagram_Handshake_IO::start_with_client_hello_from_downgrade(
+   const Handshake_Message& client_hello) {
+   BOTAN_ARG_CHECK(client_hello.type() == Handshake_Type::ClientHello,
+                   "Expected ClientHello message for DTLS downgrade");
+   BOTAN_STATE_CHECK(m_out_message_seq == 0);
+   BOTAN_STATE_CHECK(m_seqs.current_write_epoch() == 0);
+   return format_w_seq(client_hello.serialize(), client_hello.wire_type(), m_out_message_seq++);
+}
+
+#endif
 
 std::vector<uint8_t> Datagram_Handshake_IO::send_message(uint16_t msg_seq,
                                                          uint16_t epoch,

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -50,6 +50,10 @@ class Handshake_IO {
 
       virtual std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) = 0;
 
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      virtual std::vector<uint8_t> start_with_client_hello_from_downgrade(const Handshake_Message& client_hello) = 0;
+#endif
+
       virtual bool timeout_check() = 0;
 
       virtual std::optional<std::chrono::milliseconds> next_retransmission_timeout() const = 0;
@@ -101,6 +105,10 @@ class Stream_Handshake_IO final : public Handshake_IO {
 
       std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) override;
 
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      std::vector<uint8_t> start_with_client_hello_from_downgrade(const Handshake_Message& client_hello) override;
+#endif
+
       std::vector<uint8_t> format(const std::vector<uint8_t>& handshake_msg,
                                   Handshake_Type handshake_type) const override;
 
@@ -144,6 +152,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       std::vector<uint8_t> send(const Handshake_Message& msg) override;
 
       std::vector<uint8_t> send_under_epoch(const Handshake_Message& msg, uint16_t epoch) override;
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      std::vector<uint8_t> start_with_client_hello_from_downgrade(const Handshake_Message& client_hello) override;
+#endif
 
       std::vector<uint8_t> format(const std::vector<uint8_t>& handshake_msg,
                                   Handshake_Type handshake_type) const override;

--- a/src/lib/tls/tls12/tls_messages_12.h
+++ b/src/lib/tls/tls12/tls_messages_12.h
@@ -12,6 +12,10 @@
 #include <botan/secmem.h>
 #include <botan/tls_messages.h>
 
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+   #include <botan/tls_messages_13.h>
+#endif
+
 namespace Botan {
 
 class PK_Key_Agreement_Key;
@@ -54,6 +58,14 @@ class BOTAN_UNSTABLE_API Client_Hello_12 final : public Client_Hello_12_Shim {
                       std::vector<std::string> next_protocols);
 
       explicit Client_Hello_12(std::span<const uint8_t> buf);
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      /**
+       * This creates a TLS 1.2 Client Hello object from a TLS 1.3 Client Hello
+       * object. This is used for downgrades from TLS 1.3 to TLS 1.2.
+       */
+      Client_Hello_12(Client_Hello_13 client_hello, Handshake_IO& io, Handshake_Hash& hash);
+#endif
 
    private:
       explicit Client_Hello_12(std::unique_ptr<Client_Hello_Internal> data);

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -272,10 +272,9 @@ Channel_Impl_13::AggregatedPostHandshakeMessages& Channel_Impl_13::AggregatedPos
    return *this;
 }
 
-std::vector<uint8_t> Channel_Impl_13::AggregatedMessages::send() {
+void Channel_Impl_13::AggregatedMessages::send() const {
    BOTAN_STATE_CHECK(contains_messages());
    m_channel.send_record(Record_Type::Handshake, m_message_buffer);
-   return std::exchange(m_message_buffer, {});
 }
 
 void Channel_Impl_13::send_dummy_change_cipher_spec() {

--- a/src/lib/tls/tls13/tls_channel_impl_13.h
+++ b/src/lib/tls/tls13/tls_channel_impl_13.h
@@ -70,12 +70,9 @@ class Channel_Impl_13 : public Channel_Impl,
             ~AggregatedMessages() = default;
 
             /**
-             * Send the messages aggregated in the message buffer. The buffer
-             * is returned if the sender needs to also handle it somehow.
-             * Most notable use: book keeping for a potential protocol downgrade
-             * in the client implementation.
+             * Send the messages aggregated in the message buffer.
              */
-            std::vector<uint8_t> send();
+            void send() const;
 
             bool contains_messages() const { return !m_message_buffer.empty(); }
 
@@ -243,17 +240,17 @@ class Channel_Impl_13 : public Channel_Impl,
       void opportunistically_update_traffic_keys() { m_opportunistic_key_update = true; }
 
       template <typename... MsgTs>
-      std::vector<uint8_t> send_handshake_message(const std::variant<MsgTs...>& message) {
-         return aggregate_handshake_messages().add(generalize_to<Handshake_Message_13_Ref>(message)).send();
+      void send_handshake_message(const std::variant<MsgTs...>& message) {
+         aggregate_handshake_messages().add(generalize_to<Handshake_Message_13_Ref>(message)).send();
       }
 
       template <typename MsgT>
-      std::vector<uint8_t> send_handshake_message(std::reference_wrapper<MsgT> message) {
-         return send_handshake_message(generalize_to<Handshake_Message_13_Ref>(message));
+      void send_handshake_message(std::reference_wrapper<MsgT> message) {
+         send_handshake_message(generalize_to<Handshake_Message_13_Ref>(message));
       }
 
-      std::vector<uint8_t> send_post_handshake_message(Post_Handshake_Message_13 message) {
-         return aggregate_post_handshake_messages().add(std::move(message)).send();
+      void send_post_handshake_message(Post_Handshake_Message_13 message) {
+         aggregate_post_handshake_messages().add(std::move(message)).send();
       }
 
       void send_dummy_change_cipher_spec();

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -53,7 +53,7 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
 #endif
    }
 
-   auto msg = send_handshake_message(m_handshake->state.sending(
+   send_handshake_message(m_handshake->state.sending(
       Client_Hello_13(*policy,
                       *callbacks,
                       *rng,
@@ -61,12 +61,6 @@ Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
                       next_protocols,
                       m_handshake->resumed_session,
                       creds->find_preshared_keys(m_info.hostname(), Connection_Side::Client))));
-
-#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
-   if(expects_downgrade()) {
-      preserve_client_hello(msg);
-   }
-#endif
 
    maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingFirstClientHello);
 
@@ -216,6 +210,7 @@ void Client_Impl_13::handle(const Server_Hello_12_Shim& server_hello_msg) {
       throw TLS_Exception(Alert::IllegalParameter, "Unexpected session ID during downgrade");
    }
 
+   preserve_client_hello(m_handshake->state.take_client_hello());
    request_downgrade();
 
    // After this, no further messages are expected here because this instance will be replaced

--- a/src/lib/tls/tls13/tls_handshake_state_13.h
+++ b/src/lib/tls/tls13/tls_handshake_state_13.h
@@ -14,6 +14,7 @@
 #include <botan/tls_messages_13.h>
 #include <botan/internal/stl_util.h>
 #include <optional>
+#include <utility>
 #include <variant>
 
 namespace Botan::TLS {
@@ -71,6 +72,19 @@ class BOTAN_TEST_API Handshake_State_13_Base {
       const Finished_13& server_finished() const { return get(m_server_finished); }
 
       const Finished_13& client_finished() const { return get(m_client_finished); }
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      /**
+       * This extracts the Client Hello object from the handshake state. This is
+       * a destructive operation that should only be used for protocol
+       * downgrades, where the Client Hello is transferred to the other
+       * implementation.
+       */
+      Client_Hello_13 take_client_hello() {
+         BOTAN_STATE_CHECK(m_client_hello.has_value());
+         return std::exchange(m_client_hello, {}).value();
+      }
+#endif
 
    protected:
       explicit Handshake_State_13_Base(Connection_Side whoami) : m_side(whoami) {}

--- a/src/lib/tls/tls13/tls_messages_13.h
+++ b/src/lib/tls/tls13/tls_messages_13.h
@@ -25,6 +25,7 @@ class X509_Certificate;
 namespace Botan::TLS {
 
 class Transcript_Hash_State;
+class Client_Hello_12;
 
 class BOTAN_UNSTABLE_API Client_Hello_13 final : public Client_Hello {
    public:
@@ -64,6 +65,12 @@ class BOTAN_UNSTABLE_API Client_Hello_13 final : public Client_Hello {
 
    private:
       explicit Client_Hello_13(std::unique_ptr<Client_Hello_Internal> data);
+
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+      // This lets the TLS 1.2 implementation extract the internal data
+      // from this Client Hello object for downgrade purposes.
+      friend class Client_Hello_12;
+#endif
 
       /**
       * If the Client Hello contains a PSK extensions with identities this will

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -21,10 +21,6 @@
 #include <string_view>
 #include <vector>
 
-#if defined(BOTAN_HAS_TLS_13) && defined(BOTAN_HAS_TLS_12)
-   #define BOTAN_HAS_TLS_DOWNGRADE_SUPPORT
-#endif
-
 namespace Botan {
 
 class Public_Key;

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -21,6 +21,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
+   #include <botan/tls_messages_13.h>
+#endif
+
 namespace Botan {
 
 class Credentials_Manager;
@@ -198,7 +202,7 @@ class Channel_Impl {
        */
       struct Downgrade_Information {
             /// The client hello message including the handshake header bytes as transferred to the peer.
-            std::vector<uint8_t> client_hello_message;
+            std::optional<Client_Hello_13> client_hello;
 
             /// The full data transcript received from the peer. This will contain the server hello message that forced us to downgrade.
             std::vector<uint8_t> peer_transcript;
@@ -228,9 +232,9 @@ class Channel_Impl {
          m_downgrade_info->peer_transcript.insert(m_downgrade_info->peer_transcript.end(), input.begin(), input.end());
       }
 
-      void preserve_client_hello(std::span<const uint8_t> msg) {
+      void preserve_client_hello(Client_Hello_13 client_hello) {
          BOTAN_STATE_CHECK(m_downgrade_info);
-         m_downgrade_info->client_hello_message.assign(msg.begin(), msg.end());
+         m_downgrade_info->client_hello.emplace(std::move(client_hello));
       }
 
       friend class Client;
@@ -255,7 +259,7 @@ class Channel_Impl {
       }
 
       void request_downgrade_for_resumption(Session_with_Handle session) {
-         BOTAN_STATE_CHECK(m_downgrade_info && m_downgrade_info->client_hello_message.empty() &&
+         BOTAN_STATE_CHECK(m_downgrade_info && !m_downgrade_info->client_hello.has_value() &&
                            m_downgrade_info->peer_transcript.empty() && !m_downgrade_info->tls12_session.has_value());
          BOTAN_ASSERT_NOMSG(session.session.version().is_pre_tls_13());
          m_downgrade_info->tls12_session = std::move(session);

--- a/src/lib/tls/tls_magic.h
+++ b/src/lib/tls/tls_magic.h
@@ -15,6 +15,10 @@
 
 //BOTAN_FUTURE_INTERNAL_HEADER(tls_magic.h)
 
+#if defined(BOTAN_HAS_TLS_13) && defined(BOTAN_HAS_TLS_12)
+   #define BOTAN_HAS_TLS_DOWNGRADE_SUPPORT
+#endif
+
 namespace Botan::TLS {
 
 /**


### PR DESCRIPTION
Before, the ClientHello message was passed from the 1.3-implementation to the 1.2-implementation in marshalled form (with its header). This is fine for TLS, where the handshake message protocol header is equivalent across both versions.

However, DTLS is handling this protocol header differently. DTLS 1.2's transcript hash is calculated over a fictious unfragmented version of the marshalled message, whereas in DTLS 1.3 the transcript hash omits the fragmentation information in the message protocol headers.

Also, this prepares some new API in the TLS 1.2 `Handshake_IO` for DTLS where the `Datagram_Handshake_IO` needs some state set-up after downgrading.