### PR TITLE
Reject embedded NULs at the Python C-string boundary

### DIFF
--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -739,6 +739,8 @@ def _ctype_str(s: str | None) -> bytes | None:
     if s is None:
         return None
     assert isinstance(s, str)
+    if '\0' in s:
+        raise ValueError('Botan C string arguments cannot contain embedded NUL bytes')
     return s.encode('utf-8')
 
 def _ctype_to_str(s: bytes) -> str:

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -129,6 +129,12 @@ class BotanPythonTests(unittest.TestCase):
 
         self.assertTrue(botan.check_bcrypt('test', '$2a$04$wjen1fAA.UW6UxthpKK.huyOoxvCR7ATRCVC4CBIEGVDOCtr8Oj1C'))
 
+        with self.assertRaises(ValueError):
+            botan.bcrypt('x\0-Acceptable-Password-42!', r, 4)
+
+        with self.assertRaises(ValueError):
+            botan.check_bcrypt('testing\0ignored', phash)
+
     def test_password_utf8(self):
         # The password-based interfaces must consume the full UTF-8 encoding of
         # a non-ASCII password, not a truncated character-count prefix. The

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -1035,6 +1035,18 @@ ofvkP1EDmpx50fHLawIDAQAB
         self.assertFalse(int04_1.is_revoked(rootcrl))
         self.assertTrue(end21.is_revoked(int21crl))
 
+    def test_x509_rejects_embedded_nul_strings(self):
+        cert = botan.X509Cert(filename=test_data("src/tests/data/x509/ecc/isrg-root-x2.pem"))
+
+        with self.assertRaises(ValueError):
+            cert.hostname_match("example.com\0.attacker.invalid")
+
+        with self.assertRaises(ValueError):
+            cert.verify(hostname="example.com\0.attacker.invalid")
+
+        with self.assertRaises(ValueError):
+            cert.verify(trusted_path="/trusted/roots\0/attacker")
+
     def test_x509_extensions(self):
         no_ext_cert = botan.X509Cert(filename=test_data("src/tests/data/x509/x509test/root.pem"))
 


### PR DESCRIPTION
# Reject embedded NULs at the Python C-string boundary

Python strings can contain embedded NUL characters, while Botan's FFI string parameters are NUL-terminated. Reject these values centrally in `_ctype_str()` so native code cannot observe a different prefix from the value validated by Python application code.

Add regression coverage for bcrypt passwords, X.509 hostname matching, hostname verification, and trust-directory selection.

## Test plan

- Confirm the bcrypt regression fails against the original wrapper because no `ValueError` is raised.
- Confirm the bcrypt regression passes after `_ctype_str()` rejects the value.
- Confirm the X.509 hostname and trust-path regression tests reject embedded NULs.
