### PR TITLE
Disable implicit redirects in the internal HTTP client

### DIFF
--- a/src/lib/utils/http_util/http_util.h
+++ b/src/lib/utils/http_util/http_util.h
@@ -122,7 +122,7 @@ class RequestLimits final {
       }
 
    private:
-      size_t m_max_redirects = 1;
+      size_t m_max_redirects = 0;
       std::chrono::milliseconds m_timeout = std::chrono::milliseconds(3000);
       std::optional<size_t> m_max_body_size;
 };

--- a/src/tests/test_http.cpp
+++ b/src/tests/test_http.cpp
@@ -591,6 +591,26 @@ class HTTP_Redirect_Tests final : public Test {
    private:
       static std::string verb_of(std::string_view message) { return std::string(message.substr(0, message.find(' '))); }
 
+      static Test::Result test_redirects_disabled_by_default() {
+         Test::Result result("HTTP redirects are disabled by default");
+         MockServer mock({
+            make_response(303, "See Other", {{"Location", "http://127.0.0.1/private-control?operation=export"}}),
+            make_response(200, "OK"),
+         });
+         const auto uri = Botan::URI::from_string("http://ocsp.example/status").value();
+
+         result.test_throws<Botan::HTTP::HTTP_Error>("default redirect budget rejects redirect", [&] {
+            (void)Botan::HTTP::http_sync(mock.as_exch_fn(),
+                                         "POST",
+                                         uri,
+                                         "application/ocsp-request",
+                                         std::vector<uint8_t>{0x30, 0x00},
+                                         Botan::HTTP::RequestLimits());
+         });
+         result.test_sz_eq("only the configured origin was contacted", mock.calls(), 1);
+         return result;
+      }
+
       static Test::Result test_301_preserves_method_for_get() {
          Test::Result result("HTTP 301 with GET: re-issues GET to new URL");
          MockServer mock({
@@ -769,6 +789,7 @@ class HTTP_Redirect_Tests final : public Test {
    public:
       std::vector<Test::Result> run() override {
          return {
+            test_redirects_disabled_by_default(),
             test_301_preserves_method_for_get(),
             test_303_post_downgrades_to_get(),
             test_307_post_preserves_method_and_body(),


### PR DESCRIPTION
# Disable implicit redirects in the internal HTTP client

## Summary

- change `HTTP::RequestLimits` to allow zero redirects by default
- retain `set_max_redirects()` for callers that deliberately opt in
- add a regression test proving that a default 303 is rejected before a cross-origin request occurs

Botan's internal HTTP client is primarily used for OCSP and CRL fetching. Those URLs are certificate-supplied endpoints, and an unsigned HTTP redirect should not silently authorize a different origin. The HTTP CLI already supplies its redirect count explicitly, so its behavior is unchanged.

This intentionally starts with redirects disabled. If a concrete compatibility need arises, an affected caller can opt in explicitly and a narrower revocation-fetch policy can be considered with that deployment evidence.

## Testing

Before the fix, the new regression fails because no exception is thrown and the mock exchange is called twice. After the fix:

```text
HTTP redirects are disabled by default ran 2 tests all ok
Tests complete ran 110 tests in 1.21 msec all tests ok
```

The standalone OCSP reproducer also changes from `redirected_internal_GET=1` on the vulnerable commit to `redirected_internal_GET=0` after the fix.
