### PR TITLE
Align the cost limits on PBES2 and PKCS12 decryption

### DIFF
--- a/src/lib/pbkdf/scrypt/scrypt.cpp
+++ b/src/lib/pbkdf/scrypt/scrypt.cpp
@@ -16,6 +16,7 @@
 #include <botan/internal/mem_utils.h>
 #include <botan/internal/salsa20.h>
 #include <botan/internal/time_utils.h>
+#include <array>
 
 namespace Botan {
 
@@ -23,7 +24,7 @@ namespace {
 
 constexpr size_t MAX_SCRYPT_N = 4194304;
 constexpr size_t MAX_SCRYPT_MEMORY_GB = sizeof(size_t) == 4 ? 2 : 8;
-constexpr size_t MAX_SCRYPT_MEMORY_BYTES = MAX_SCRYPT_MEMORY_GB * 1024 * 1024 * 1024 + 65536;
+constexpr size_t MAX_SCRYPT_MEMORY_BYTES = MAX_SCRYPT_MEMORY_GB * 1024 * 1024 * 1024 + 2 * 1024 * 1024;
 
 std::optional<size_t> scrypt_memory_usage(size_t N, size_t r, size_t p) {
    // 128 * r * (N + p) rejecting on overflow
@@ -56,7 +57,7 @@ std::unique_ptr<PasswordHash> Scrypt_Family::tune_params(size_t /*output_length*
    *
    * Empirically for smaller sizes:
    * stime(N,8*r,p) / stime(N,r,p) is ~ 6-7
-   * stime(N,r,8*p) / stime(N,r,8*p) is ~ 7
+   * stime(N,r,8*p) / stime(N,r,p) is ~ 7
    * stime(2*N,r,p) / stime(N,r,p) is ~ 2
    *
    * Compute stime(8192,1,1) as baseline and extrapolate
@@ -191,7 +192,7 @@ namespace {
 
 void scryptBlockMix(size_t r, uint8_t* B, uint8_t* Y) {
    uint32_t B32[16];
-   secure_vector<uint8_t> X(64);
+   std::array<uint8_t, 64> X{};
    copy_mem(X.data(), &B[(2 * r - 1) * 64], 64);
 
    for(size_t i = 0; i != 2 * r; i++) {
@@ -242,10 +243,10 @@ void Scrypt::derive_key(uint8_t output[],
    const size_t p = parallelism();
    const size_t r = iterations();
 
-   const size_t S = 128 * r;
-   secure_vector<uint8_t> B(p * S);
+   const size_t S = mul_or_throw(size_t(128), r, "Scrypt S size overflow");
+   secure_vector<uint8_t> B(mul_or_throw(p, S, "Scrypt B size overflow"));
    // temp space
-   secure_vector<uint8_t> V((N + 1) * S);
+   secure_vector<uint8_t> V(mul_or_throw(N + 1, S, "Scrypt V size overflow"));
 
    auto hmac_sha256 = MessageAuthenticationCode::create_or_throw("HMAC(SHA-256)");
 

--- a/src/lib/pkcs12/pkcs12_pbe/pkcs12_pbe.h
+++ b/src/lib/pkcs12/pkcs12_pbe/pkcs12_pbe.h
@@ -20,7 +20,9 @@ namespace Botan {
 class RandomNumberGenerator;
 
 /// Maximum allowed iteration count for PKCS#12 KDF/PBE/MAC operations
-inline constexpr size_t PKCS12_MAX_ITERATIONS = 1'000'000;
+///
+/// This matches the limit used by NSS, AWS-LC and BoringSSL for PKCS12 files
+inline constexpr size_t PKCS12_MAX_ITERATIONS = 100'000'000;
 
 /**
 * Decrypt data protected by PKCS#12 PBE (RFC 7292 Appendix B) or PBES2.

--- a/src/lib/pubkey/pbes2/pbes2.cpp
+++ b/src/lib/pubkey/pbes2/pbes2.cpp
@@ -180,9 +180,10 @@ std::unique_ptr<Pbes2Pbkdf2Parameters> Pbes2Pbkdf2Parameters::tune(std::string_v
 
 //static
 void Pbes2Pbkdf2Parameters::validate_params(size_t iterations) {
-   // The upper bound corresponds to about 10 to 60 seconds of CPU time
-   // (depending on hash and hardware) which seems sufficient...
-   if(iterations == 0 || iterations > (1U << 26)) {
+   // NSS, AWS-LC, and BoringSSL all allow up to exactly 100 million for this operation
+   constexpr size_t MaximumPbes2Pbkdf2Iterations = 100'000'000;
+
+   if(iterations == 0 || iterations > MaximumPbes2Pbkdf2Iterations) {
       throw Decoding_Error(fmt("PBES2: Invalid or unacceptable PBKDF2 iteration count ({})", iterations));
    }
 }
@@ -274,6 +275,17 @@ void Pbes2ScryptParameters::validate_params(size_t N, size_t r, size_t p) {
    }
    if(p == 0 || p >= 1024) {
       throw Decoding_Error(fmt("PBES2: Invalid or unacceptable Scrypt parameter p ({})", p));
+   }
+
+   /*
+   * Practically speaking this work limit aligns relatively closely to the 100 million
+   * iteration limit applied in PBES2 and PKCS12
+   */
+   const uint64_t scrypt_work = uint64_t(N) * r * p;
+   constexpr uint64_t MaximumPbes2ScryptWork = (1 << 26);
+
+   if(scrypt_work > MaximumPbes2ScryptWork) {
+      throw Decoding_Error(fmt("PBES2: Invalid or unacceptable Scrypt parameters N={} r={} p={}", N, r, p));
    }
 }
 

--- a/src/tests/test_pkcs12.cpp
+++ b/src/tests/test_pkcs12.cpp
@@ -714,7 +714,7 @@ class PKCS12_Tests final : public Test {
          auto creds = generate_credentials(*rng);
 
          // PKCS12_MAX_ITERATIONS + 1
-         const auto opts = Botan::PKCS12_Export_Options("test").with_iterations(1'000'001);
+         const auto opts = Botan::PKCS12_Export_Options("test").with_iterations(100'000'001);
 
          result.test_throws<Botan::Invalid_Argument>("max iterations exceeded throws", [&]() {
             Botan::PKCS12 bundle;


### PR DESCRIPTION
Previously PBES2 PBKD5 limited to 2^26 (~67 million), while PKCS12 KDF limited to 1 million iterations. They cost roughly the same so the discrepency in limits wasn't sensible. NSS and BoringSSL both allow up to 100 million for both algorithms, so take that upper bound for both.

For scrypt, bound the overall work product N*r*p to 2^26 which approximately matches the computational cost of 100 million PBKDF2 iterations.