### PR TITLE
In ECIES require a fresh nonce be created for each message

### DIFF
--- a/doc/api_ref/pubkey.rst
+++ b/doc/api_ref/pubkey.rst
@@ -777,6 +777,12 @@ support it directly, such as RSA or ElGamal; these use the EME class:
 
       Creates an ephemeral private key which is used for the key agreement.
 
+   .. cpp:function:: void ECIES_Encryptor::set_initialization_vector(const InitializationVector& iv)
+
+      Set a new initialization vector for the encryptor. This must be called
+      before each message with a random nonce suitable for the chosen cipher. In
+      the ECIES message format the nonce is not conveyed with the produced
+      ciphertext, so it must be set separately.
 
 .. cpp:class:: PK_Decryptor
 

--- a/src/lib/pubkey/dlies/dlies.h
+++ b/src/lib/pubkey/dlies/dlies.h
@@ -35,6 +35,7 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Encryptor final : public PK_Encryptor {
       *
       * output = (ephemeral) public key + ciphertext + tag
       */
+      BOTAN_DEPRECATED("DLIES support is deprecated")
       DLIES_Encryptor(const DH_PrivateKey& own_priv_key,
                       RandomNumberGenerator& rng,
                       std::unique_ptr<KDF> kdf,
@@ -54,6 +55,7 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Encryptor final : public PK_Encryptor {
       *
       * output = (ephemeral) public key + ciphertext + tag
       */
+      BOTAN_DEPRECATED("DLIES support is deprecated")
       DLIES_Encryptor(const DH_PrivateKey& own_priv_key,
                       RandomNumberGenerator& rng,
                       std::unique_ptr<KDF> kdf,
@@ -66,6 +68,10 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Encryptor final : public PK_Encryptor {
       inline void set_other_key(const std::vector<uint8_t>& other_pub_key) { m_other_pub_key = other_pub_key; }
 
       /// Set the initialization vector for the data encryption method
+      ///
+      /// If DLIES is being used with a cipher, a fresh IV must be provided for
+      /// each message; it is not included in the serialized ciphertext and must
+      /// be conveyed separately.
       inline void set_initialization_vector(const InitializationVector& iv) { m_iv = iv; }
 
    private:
@@ -102,6 +108,7 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Decryptor final : public PK_Decryptor {
       *
       * input = (ephemeral) public key + ciphertext + tag
       */
+      BOTAN_DEPRECATED("DLIES support is deprecated")
       DLIES_Decryptor(const DH_PrivateKey& own_priv_key,
                       RandomNumberGenerator& rng,
                       std::unique_ptr<KDF> kdf,
@@ -121,6 +128,7 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Decryptor final : public PK_Decryptor {
       *
       * input = (ephemeral) public key + ciphertext + tag
       */
+      BOTAN_DEPRECATED("DLIES support is deprecated")
       DLIES_Decryptor(const DH_PrivateKey& own_priv_key,
                       RandomNumberGenerator& rng,
                       std::unique_ptr<KDF> kdf,
@@ -130,6 +138,10 @@ class BOTAN_PUBLIC_API(2, 0) DLIES_Decryptor final : public PK_Decryptor {
                       size_t mac_key_len = 20);
 
       /// Set the initialization vector for the data decryption method
+      ///
+      /// If DLIES is being used with a cipher, a fresh IV must be provided for
+      /// each message; it is not included in the serialized ciphertext and must
+      /// be conveyed separately.
       inline void set_initialization_vector(const InitializationVector& iv) { m_iv = iv; }
 
    private:

--- a/src/lib/pubkey/ecies/ecies.cpp
+++ b/src/lib/pubkey/ecies/ecies.cpp
@@ -322,17 +322,23 @@ std::vector<uint8_t> ECIES_Encryptor::enc(const uint8_t data[],
    if(!m_other_point.has_value()) {
       throw Invalid_State("ECIES_Encryptor: peer key invalid or not set");
    }
+   if(!m_iv.has_value()) {
+      throw Invalid_State("ECIES requires a fresh IV be provided for each message");
+   }
+   if(m_iv->empty() && !m_cipher->valid_nonce_length(m_iv->size())) {
+      throw Invalid_Argument("ECIES with " + m_cipher->name() + " requires an IV be set");
+   }
 
    const SymmetricKey secret_key = m_ka.derive_secret(m_eph_public_key_bin, m_other_point.value());
+
+   BOTAN_ASSERT_NOMSG(secret_key.size() == m_params.dem_keylen() + m_params.mac_keylen());
 
    // encryption
 
    m_cipher->set_key(SymmetricKey(secret_key.begin(), m_params.dem_keylen()));
-   if(m_iv.empty() && !m_cipher->valid_nonce_length(m_iv.size())) {
-      throw Invalid_Argument("ECIES with " + m_cipher->name() + " requires an IV be set");
-   }
 
-   m_cipher->start(m_iv.bits_of());
+   m_cipher->start(m_iv->bits_of());
+   m_iv.reset();
 
    secure_vector<uint8_t> encrypted_data(data, data + length);
    m_cipher->finish(encrypted_data);
@@ -415,6 +421,13 @@ secure_vector<uint8_t> ECIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
       throw Decoding_Error("ECIES decryption: ciphertext is too short");
    }
 
+   if(!m_iv.has_value()) {
+      throw Invalid_State("ECIES requires a fresh IV be provided for each message");
+   }
+   if(m_iv->empty() && !m_cipher->valid_nonce_length(m_iv->size())) {
+      throw Invalid_Argument("ECIES with " + m_cipher->name() + " requires an IV be set");
+   }
+
    // extract data
    const std::vector<uint8_t> other_public_key_bin(in, in + point_size);  // the received (ephemeral) public key
    const std::vector<uint8_t> encrypted_data(in + point_size, in + in_len - m_mac->output_length());
@@ -430,6 +443,8 @@ secure_vector<uint8_t> ECIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
    // throws Illegal_Transformation if the point is zero)
    const SymmetricKey secret_key = m_ka.derive_secret(other_public_key_bin, other_public_key);
 
+   BOTAN_ASSERT_NOMSG(secret_key.size() == m_params.dem_keylen() + m_params.mac_keylen());
+
    // validate mac
    m_mac->set_key(secret_key.begin() + m_params.dem_keylen(), m_params.mac_keylen());
    m_mac->update(encrypted_data);
@@ -439,14 +454,15 @@ secure_vector<uint8_t> ECIES_Decryptor::do_decrypt(uint8_t& valid_mask, const ui
    const secure_vector<uint8_t> calculated_mac = m_mac->final();
    valid_mask = CT::is_equal<uint8_t>(mac_data, calculated_mac).value();
 
+   // Consume the IV state even if the message is invalid
+   auto iv = m_iv->bits_of();
+   m_iv.reset();
+
    if(valid_mask == 0xFF) {
       // decrypt data
 
       m_cipher->set_key(SymmetricKey(secret_key.begin(), m_params.dem_keylen()));
-      if(m_iv.empty() && !m_cipher->valid_nonce_length(m_iv.size())) {
-         throw Invalid_Argument("ECIES with " + m_cipher->name() + " requires an IV be set");
-      }
-      m_cipher->start(m_iv.bits_of());
+      m_cipher->start(iv);
 
       try {
          // the decryption can fail:

--- a/src/lib/pubkey/ecies/ecies.h
+++ b/src/lib/pubkey/ecies/ecies.h
@@ -169,6 +169,9 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_System_Params final : public ECIES_KA_Params 
       *        only affects the secret derivation when single_hash_mode is false)
       * @param single_hash_mode if false, prefix the KDF input with the encoded
       *        ephemeral public key; if true, the KDF input is just the ECDH shared secret
+      *
+      * TODO(Botan4) split this constructor into two, one taking the point format (requesting
+      *   !single_hash_mode) and the other with no extra params (for single_hash_mode)
       */
       ECIES_System_Params(const EC_Group& group,
                           std::string_view kdf_spec,
@@ -273,6 +276,9 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_KA_Operation {
 
 /**
 * ECIES Encryption according to ISO 18033-2
+*
+* TODO(Botan4) remove derivation on PK_Encryptor and provide a direct API
+* for encryption taking all relevant params, avoiding setters/implicit state
 */
 class BOTAN_PUBLIC_API(2, 0) ECIES_Encryptor final : public PK_Encryptor {
    public:
@@ -303,6 +309,9 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_Encryptor final : public PK_Encryptor {
       void set_other_key(const EC_AffinePoint& pt) { m_other_point = pt; }
 
       /// Set the initialization vector for the data encryption method
+      ///
+      /// A new IV must be provided for each message; it is not included
+      /// in the serialized ciphertext and must be conveyed separately
       void set_initialization_vector(const InitializationVector& iv) { m_iv = iv; }
 
       /// Set the label which is appended to the input for the message authentication code
@@ -320,13 +329,16 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_Encryptor final : public PK_Encryptor {
       std::unique_ptr<MessageAuthenticationCode> m_mac;
       std::unique_ptr<Cipher_Mode> m_cipher;
       std::vector<uint8_t> m_eph_public_key_bin;
-      InitializationVector m_iv;
+      mutable std::optional<InitializationVector> m_iv;
       std::optional<EC_AffinePoint> m_other_point;
       std::vector<uint8_t> m_label;
 };
 
 /**
 * ECIES Decryption according to ISO 18033-2
+*
+* TODO(Botan4) remove derivation on PK_Decryptor and provide a direct API
+* for decryption taking all relevant params, avoiding setters/implicit state
 */
 class BOTAN_PUBLIC_API(2, 0) ECIES_Decryptor final : public PK_Decryptor {
    public:
@@ -340,6 +352,9 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_Decryptor final : public PK_Decryptor {
                       RandomNumberGenerator& rng);
 
       /// Set the initialization vector for the data encryption method
+      ///
+      /// A new IV must be provided for each message; it is not included
+      /// in the serialized ciphertext and must be conveyed separately
       void set_initialization_vector(const InitializationVector& iv) { m_iv = iv; }
 
       /// Set the label which is appended to the input for the message authentication code
@@ -356,7 +371,7 @@ class BOTAN_PUBLIC_API(2, 0) ECIES_Decryptor final : public PK_Decryptor {
       const ECIES_System_Params m_params;
       std::unique_ptr<MessageAuthenticationCode> m_mac;
       std::unique_ptr<Cipher_Mode> m_cipher;
-      InitializationVector m_iv;
+      mutable std::optional<InitializationVector> m_iv;
       std::vector<uint8_t> m_label;
 };
 

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -53,10 +53,8 @@ void check_encrypt_decrypt(Test::Result& result,
       ecies_enc.set_other_key(
          Botan::EC_AffinePoint(other_private_key.domain(), other_private_key.raw_public_key_bits()));
       Botan::ECIES_Decryptor ecies_dec(other_private_key, ecies_params, rng);
-      if(!iv.bits_of().empty()) {
-         ecies_enc.set_initialization_vector(iv);
-         ecies_dec.set_initialization_vector(iv);
-      }
+      ecies_enc.set_initialization_vector(iv);
+      ecies_dec.set_initialization_vector(iv);
       if(!label.empty()) {
          ecies_enc.set_label(label);
          ecies_dec.set_label(label);
@@ -82,6 +80,9 @@ void check_encrypt_decrypt(Test::Result& result,
       std::vector<uint8_t> invalid_encrypted = encrypted;
       uint8_t& last_byte = invalid_encrypted[invalid_encrypted.size() - 1];
       last_byte = ~last_byte;
+
+      ecies_dec.set_initialization_vector(iv);
+
       result.test_throws("throw on invalid ciphertext",
                          [&ecies_dec, &invalid_encrypted] { ecies_dec.decrypt(invalid_encrypted); });
    } catch(Botan::Lookup_Error& e) {


### PR DESCRIPTION
This limitation also applies to DLIES when a cipher is being used. This is addressed only with a warning in the header since DLIES is anyway deprecated and likely very rarely used.