### PR TITLE
In the bitsliced AES use the native word size instead of always 32-bit

### DIFF
--- a/src/lib/block/aes/aes.cpp
+++ b/src/lib/block/aes/aes.cpp
@@ -1,5 +1,5 @@
 /*
-* (C) 1999-2010,2015,2017,2018,2020 Jack Lloyd
+* (C) 1999-2010,2015,2017,2018,2020,2026 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -11,6 +11,7 @@
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <concepts>
 
 #if defined(BOTAN_HAS_CPUID)
    #include <botan/internal/cpuid.h>
@@ -36,15 +37,10 @@ namespace Botan {
 *   use the vperm technique published by Mike Hamburg at CHES 2009.
 *
 * - If no hardware or SIMD support, fall back to a constant time bitsliced
-*   implementation. This uses 32-bit words resulting in 2 blocks being processed
-*   in parallel. Moving to 4 blocks (with 64-bit words) would approximately
-*   double performance on 64-bit CPUs. Likewise moving to 128 bit SIMD would
-*   again approximately double performance vs 64-bit. However the assumption is
-*   that most 64-bit CPUs either have hardware AES or SIMD shuffle support and
-*   that the majority of users falling back to this code will be 32-bit cores.
-*   If this assumption proves to be unsound, the bitsliced code can easily be
-*   extended to operate on either 32 or 64 bit words depending on the native
-*   wordsize of the target processor.
+*   implementation. This uses the native word size: 32-bit words process 2
+*   blocks in parallel, 64-bit words process 4 blocks. Each 64-bit word is
+*   treated as two independent 32-bit halves (one pair of blocks each), so
+*   the bitsliced layout within each half is identical to the 32-bit case.
 *
 * Useful references
 *
@@ -68,6 +64,48 @@ namespace Botan {
 namespace {
 
 /*
+* The word type used for bitsliced AES operations.
+*
+* On 64-bit platforms each word holds two independent 32-bit halves,
+* each encoding one pair of AES blocks, for 4 blocks total.
+* On 32-bit platforms each word encodes one pair of blocks (2 total).
+*/
+using aes_bs_word = word;
+static_assert(std::same_as<aes_bs_word, uint32_t> || std::same_as<aes_bs_word, uint64_t>);
+
+constexpr size_t AES_BITSLICED_BLOCKS = 8 * sizeof(aes_bs_word) / 16;
+
+/**
+* Replicate a 32-bit pattern into each 32-bit half of a wider word
+*/
+template <std::unsigned_integral W>
+constexpr inline W rep32(uint32_t x) {
+   if constexpr(std::same_as<W, uint32_t>) {
+      return x;
+   } else {
+      return (static_cast<W>(x) << 32) | x;
+   }
+}
+
+/**
+* Rotate right within each 32-bit half of a word.
+*
+* For 32-bit words this is a plain rotation. For 64-bit words each
+* 32-bit half is rotated independently, which preserves the invariant
+* that the two halves represent separate block-pairs.
+*/
+template <size_t N, std::unsigned_integral W>
+BOTAN_FORCE_INLINE constexpr W column_rotr(W x) {
+   if constexpr(std::same_as<W, uint32_t>) {
+      return rotr<N>(x);
+   } else {
+      static_assert(N > 0 && N < 32);
+      constexpr W mask = rep32<W>(0xFFFFFFFFU >> N);
+      return ((x >> N) & mask) | ((x << (32 - N)) & ~mask);
+   }
+}
+
+/*
 This is an AES sbox circuit which can execute in bitsliced mode up to 32x in
 parallel.
 
@@ -89,129 +127,130 @@ like MUX, NOR, NAND, etc and so in practice in bitsliced software, its size is
 actually a bit larger than this circuit, as few CPUs have such instructions and
 otherwise they must be emulated using a sequence of available bit operations.
 */
-void AES_SBOX(uint32_t V[8]) {
-   const uint32_t U0 = V[0];
-   const uint32_t U1 = V[1];
-   const uint32_t U2 = V[2];
-   const uint32_t U3 = V[3];
-   const uint32_t U4 = V[4];
-   const uint32_t U5 = V[5];
-   const uint32_t U6 = V[6];
-   const uint32_t U7 = V[7];
+template <std::unsigned_integral W>
+void AES_SBOX(W V[8]) {
+   const W U0 = V[0];
+   const W U1 = V[1];
+   const W U2 = V[2];
+   const W U3 = V[3];
+   const W U4 = V[4];
+   const W U5 = V[5];
+   const W U6 = V[6];
+   const W U7 = V[7];
 
-   const uint32_t y14 = U3 ^ U5;
-   const uint32_t y13 = U0 ^ U6;
-   const uint32_t y9 = U0 ^ U3;
-   const uint32_t y8 = U0 ^ U5;
-   const uint32_t t0 = U1 ^ U2;
-   const uint32_t y1 = t0 ^ U7;
-   const uint32_t y4 = y1 ^ U3;
-   const uint32_t y12 = y13 ^ y14;
-   const uint32_t y2 = y1 ^ U0;
-   const uint32_t y5 = y1 ^ U6;
-   const uint32_t y3 = y5 ^ y8;
-   const uint32_t t1 = U4 ^ y12;
-   const uint32_t y15 = t1 ^ U5;
-   const uint32_t y20 = t1 ^ U1;
-   const uint32_t y6 = y15 ^ U7;
-   const uint32_t y10 = y15 ^ t0;
-   const uint32_t y11 = y20 ^ y9;
-   const uint32_t y7 = U7 ^ y11;
-   const uint32_t y17 = y10 ^ y11;
-   const uint32_t y19 = y10 ^ y8;
-   const uint32_t y16 = t0 ^ y11;
-   const uint32_t y21 = y13 ^ y16;
-   const uint32_t y18 = U0 ^ y16;
-   const uint32_t t2 = y12 & y15;
-   const uint32_t t3 = y3 & y6;
-   const uint32_t t4 = t3 ^ t2;
-   const uint32_t t5 = y4 & U7;
-   const uint32_t t6 = t5 ^ t2;
-   const uint32_t t7 = y13 & y16;
-   const uint32_t t8 = y5 & y1;
-   const uint32_t t9 = t8 ^ t7;
-   const uint32_t t10 = y2 & y7;
-   const uint32_t t11 = t10 ^ t7;
-   const uint32_t t12 = y9 & y11;
-   const uint32_t t13 = y14 & y17;
-   const uint32_t t14 = t13 ^ t12;
-   const uint32_t t15 = y8 & y10;
-   const uint32_t t16 = t15 ^ t12;
-   const uint32_t t17 = t4 ^ y20;
-   const uint32_t t18 = t6 ^ t16;
-   const uint32_t t19 = t9 ^ t14;
-   const uint32_t t20 = t11 ^ t16;
-   const uint32_t t21 = t17 ^ t14;
-   const uint32_t t22 = t18 ^ y19;
-   const uint32_t t23 = t19 ^ y21;
-   const uint32_t t24 = t20 ^ y18;
-   const uint32_t t25 = t21 ^ t22;
-   const uint32_t t26 = t21 & t23;
-   const uint32_t t27 = t24 ^ t26;
-   const uint32_t t28 = t25 & t27;
-   const uint32_t t29 = t28 ^ t22;
-   const uint32_t t30 = t23 ^ t24;
-   const uint32_t t31 = t22 ^ t26;
-   const uint32_t t32 = t31 & t30;
-   const uint32_t t33 = t32 ^ t24;
-   const uint32_t t34 = t23 ^ t33;
-   const uint32_t t35 = t27 ^ t33;
-   const uint32_t t36 = t24 & t35;
-   const uint32_t t37 = t36 ^ t34;
-   const uint32_t t38 = t27 ^ t36;
-   const uint32_t t39 = t29 & t38;
-   const uint32_t t40 = t25 ^ t39;
-   const uint32_t t41 = t40 ^ t37;
-   const uint32_t t42 = t29 ^ t33;
-   const uint32_t t43 = t29 ^ t40;
-   const uint32_t t44 = t33 ^ t37;
-   const uint32_t t45 = t42 ^ t41;
-   const uint32_t z0 = t44 & y15;
-   const uint32_t z1 = t37 & y6;
-   const uint32_t z2 = t33 & U7;
-   const uint32_t z3 = t43 & y16;
-   const uint32_t z4 = t40 & y1;
-   const uint32_t z5 = t29 & y7;
-   const uint32_t z6 = t42 & y11;
-   const uint32_t z7 = t45 & y17;
-   const uint32_t z8 = t41 & y10;
-   const uint32_t z9 = t44 & y12;
-   const uint32_t z10 = t37 & y3;
-   const uint32_t z11 = t33 & y4;
-   const uint32_t z12 = t43 & y13;
-   const uint32_t z13 = t40 & y5;
-   const uint32_t z14 = t29 & y2;
-   const uint32_t z15 = t42 & y9;
-   const uint32_t z16 = t45 & y14;
-   const uint32_t z17 = t41 & y8;
-   const uint32_t tc1 = z15 ^ z16;
-   const uint32_t tc2 = z10 ^ tc1;
-   const uint32_t tc3 = z9 ^ tc2;
-   const uint32_t tc4 = z0 ^ z2;
-   const uint32_t tc5 = z1 ^ z0;
-   const uint32_t tc6 = z3 ^ z4;
-   const uint32_t tc7 = z12 ^ tc4;
-   const uint32_t tc8 = z7 ^ tc6;
-   const uint32_t tc9 = z8 ^ tc7;
-   const uint32_t tc10 = tc8 ^ tc9;
-   const uint32_t tc11 = tc6 ^ tc5;
-   const uint32_t tc12 = z3 ^ z5;
-   const uint32_t tc13 = z13 ^ tc1;
-   const uint32_t tc14 = tc4 ^ tc12;
-   const uint32_t S3 = tc3 ^ tc11;
-   const uint32_t tc16 = z6 ^ tc8;
-   const uint32_t tc17 = z14 ^ tc10;
-   const uint32_t tc18 = ~tc13 ^ tc14;
-   const uint32_t S7 = z12 ^ tc18;
-   const uint32_t tc20 = z15 ^ tc16;
-   const uint32_t tc21 = tc2 ^ z11;
-   const uint32_t S0 = tc3 ^ tc16;
-   const uint32_t S6 = tc10 ^ tc18;
-   const uint32_t S4 = tc14 ^ S3;
-   const uint32_t S1 = ~(S3 ^ tc16);
-   const uint32_t tc26 = tc17 ^ tc20;
-   const uint32_t S2 = ~(tc26 ^ z17);
-   const uint32_t S5 = tc21 ^ tc17;
+   const W y14 = U3 ^ U5;
+   const W y13 = U0 ^ U6;
+   const W y9 = U0 ^ U3;
+   const W y8 = U0 ^ U5;
+   const W t0 = U1 ^ U2;
+   const W y1 = t0 ^ U7;
+   const W y4 = y1 ^ U3;
+   const W y12 = y13 ^ y14;
+   const W y2 = y1 ^ U0;
+   const W y5 = y1 ^ U6;
+   const W y3 = y5 ^ y8;
+   const W t1 = U4 ^ y12;
+   const W y15 = t1 ^ U5;
+   const W y20 = t1 ^ U1;
+   const W y6 = y15 ^ U7;
+   const W y10 = y15 ^ t0;
+   const W y11 = y20 ^ y9;
+   const W y7 = U7 ^ y11;
+   const W y17 = y10 ^ y11;
+   const W y19 = y10 ^ y8;
+   const W y16 = t0 ^ y11;
+   const W y21 = y13 ^ y16;
+   const W y18 = U0 ^ y16;
+   const W t2 = y12 & y15;
+   const W t3 = y3 & y6;
+   const W t4 = t3 ^ t2;
+   const W t5 = y4 & U7;
+   const W t6 = t5 ^ t2;
+   const W t7 = y13 & y16;
+   const W t8 = y5 & y1;
+   const W t9 = t8 ^ t7;
+   const W t10 = y2 & y7;
+   const W t11 = t10 ^ t7;
+   const W t12 = y9 & y11;
+   const W t13 = y14 & y17;
+   const W t14 = t13 ^ t12;
+   const W t15 = y8 & y10;
+   const W t16 = t15 ^ t12;
+   const W t17 = t4 ^ y20;
+   const W t18 = t6 ^ t16;
+   const W t19 = t9 ^ t14;
+   const W t20 = t11 ^ t16;
+   const W t21 = t17 ^ t14;
+   const W t22 = t18 ^ y19;
+   const W t23 = t19 ^ y21;
+   const W t24 = t20 ^ y18;
+   const W t25 = t21 ^ t22;
+   const W t26 = t21 & t23;
+   const W t27 = t24 ^ t26;
+   const W t28 = t25 & t27;
+   const W t29 = t28 ^ t22;
+   const W t30 = t23 ^ t24;
+   const W t31 = t22 ^ t26;
+   const W t32 = t31 & t30;
+   const W t33 = t32 ^ t24;
+   const W t34 = t23 ^ t33;
+   const W t35 = t27 ^ t33;
+   const W t36 = t24 & t35;
+   const W t37 = t36 ^ t34;
+   const W t38 = t27 ^ t36;
+   const W t39 = t29 & t38;
+   const W t40 = t25 ^ t39;
+   const W t41 = t40 ^ t37;
+   const W t42 = t29 ^ t33;
+   const W t43 = t29 ^ t40;
+   const W t44 = t33 ^ t37;
+   const W t45 = t42 ^ t41;
+   const W z0 = t44 & y15;
+   const W z1 = t37 & y6;
+   const W z2 = t33 & U7;
+   const W z3 = t43 & y16;
+   const W z4 = t40 & y1;
+   const W z5 = t29 & y7;
+   const W z6 = t42 & y11;
+   const W z7 = t45 & y17;
+   const W z8 = t41 & y10;
+   const W z9 = t44 & y12;
+   const W z10 = t37 & y3;
+   const W z11 = t33 & y4;
+   const W z12 = t43 & y13;
+   const W z13 = t40 & y5;
+   const W z14 = t29 & y2;
+   const W z15 = t42 & y9;
+   const W z16 = t45 & y14;
+   const W z17 = t41 & y8;
+   const W tc1 = z15 ^ z16;
+   const W tc2 = z10 ^ tc1;
+   const W tc3 = z9 ^ tc2;
+   const W tc4 = z0 ^ z2;
+   const W tc5 = z1 ^ z0;
+   const W tc6 = z3 ^ z4;
+   const W tc7 = z12 ^ tc4;
+   const W tc8 = z7 ^ tc6;
+   const W tc9 = z8 ^ tc7;
+   const W tc10 = tc8 ^ tc9;
+   const W tc11 = tc6 ^ tc5;
+   const W tc12 = z3 ^ z5;
+   const W tc13 = z13 ^ tc1;
+   const W tc14 = tc4 ^ tc12;
+   const W S3 = tc3 ^ tc11;
+   const W tc16 = z6 ^ tc8;
+   const W tc17 = z14 ^ tc10;
+   const W tc18 = ~tc13 ^ tc14;
+   const W S7 = z12 ^ tc18;
+   const W tc20 = z15 ^ tc16;
+   const W tc21 = tc2 ^ z11;
+   const W S0 = tc3 ^ tc16;
+   const W S6 = tc10 ^ tc18;
+   const W S4 = tc14 ^ S3;
+   const W S1 = ~(S3 ^ tc16);
+   const W tc26 = tc17 ^ tc20;
+   const W S2 = ~(tc26 ^ z17);
+   const W S5 = tc21 ^ tc17;
 
    V[0] = S0;
    V[1] = S1;
@@ -228,137 +267,138 @@ A circuit for inverse AES Sbox of size 121 and depth 21 from
 http://www.cs.yale.edu/homes/peralta/CircuitStuff/CMT.html
 http://www.cs.yale.edu/homes/peralta/CircuitStuff/Sinv.txt
 */
-void AES_INV_SBOX(uint32_t V[8]) {
-   const uint32_t U0 = V[0];
-   const uint32_t U1 = V[1];
-   const uint32_t U2 = V[2];
-   const uint32_t U3 = V[3];
-   const uint32_t U4 = V[4];
-   const uint32_t U5 = V[5];
-   const uint32_t U6 = V[6];
-   const uint32_t U7 = V[7];
+template <std::unsigned_integral W>
+void AES_INV_SBOX(W V[8]) {
+   const W U0 = V[0];
+   const W U1 = V[1];
+   const W U2 = V[2];
+   const W U3 = V[3];
+   const W U4 = V[4];
+   const W U5 = V[5];
+   const W U6 = V[6];
+   const W U7 = V[7];
 
-   const uint32_t Y0 = U0 ^ U3;
-   const uint32_t Y2 = ~(U1 ^ U3);
-   const uint32_t Y4 = U0 ^ Y2;
-   const uint32_t RTL0 = U6 ^ U7;
-   const uint32_t Y1 = Y2 ^ RTL0;
-   const uint32_t Y7 = ~(U2 ^ Y1);
-   const uint32_t RTL1 = U3 ^ U4;
-   const uint32_t Y6 = ~(U7 ^ RTL1);
-   const uint32_t Y3 = Y1 ^ RTL1;
-   const uint32_t RTL2 = ~(U0 ^ U2);
-   const uint32_t Y5 = U5 ^ RTL2;
-   const uint32_t sa1 = Y0 ^ Y2;
-   const uint32_t sa0 = Y1 ^ Y3;
-   const uint32_t sb1 = Y4 ^ Y6;
-   const uint32_t sb0 = Y5 ^ Y7;
-   const uint32_t ah = Y0 ^ Y1;
-   const uint32_t al = Y2 ^ Y3;
-   const uint32_t aa = sa0 ^ sa1;
-   const uint32_t bh = Y4 ^ Y5;
-   const uint32_t bl = Y6 ^ Y7;
-   const uint32_t bb = sb0 ^ sb1;
-   const uint32_t ab20 = sa0 ^ sb0;
-   const uint32_t ab22 = al ^ bl;
-   const uint32_t ab23 = Y3 ^ Y7;
-   const uint32_t ab21 = sa1 ^ sb1;
-   const uint32_t abcd1 = ah & bh;
-   const uint32_t rr1 = Y0 & Y4;
-   const uint32_t ph11 = ab20 ^ abcd1;
-   const uint32_t t01 = Y1 & Y5;
-   const uint32_t ph01 = t01 ^ abcd1;
-   const uint32_t abcd2 = al & bl;
-   const uint32_t r1 = Y2 & Y6;
-   const uint32_t pl11 = ab22 ^ abcd2;
-   const uint32_t r2 = Y3 & Y7;
-   const uint32_t pl01 = r2 ^ abcd2;
-   const uint32_t r3 = sa0 & sb0;
-   const uint32_t vr1 = aa & bb;
-   const uint32_t pr1 = vr1 ^ r3;
-   const uint32_t wr1 = sa1 & sb1;
-   const uint32_t qr1 = wr1 ^ r3;
-   const uint32_t ab0 = ph11 ^ rr1;
-   const uint32_t ab1 = ph01 ^ ab21;
-   const uint32_t ab2 = pl11 ^ r1;
-   const uint32_t ab3 = pl01 ^ qr1;
-   const uint32_t cp1 = ab0 ^ pr1;
-   const uint32_t cp2 = ab1 ^ qr1;
-   const uint32_t cp3 = ab2 ^ pr1;
-   const uint32_t cp4 = ab3 ^ ab23;
-   const uint32_t tinv1 = cp3 ^ cp4;
-   const uint32_t tinv2 = cp3 & cp1;
-   const uint32_t tinv3 = cp2 ^ tinv2;
-   const uint32_t tinv4 = cp1 ^ cp2;
-   const uint32_t tinv5 = cp4 ^ tinv2;
-   const uint32_t tinv6 = tinv5 & tinv4;
-   const uint32_t tinv7 = tinv3 & tinv1;
-   const uint32_t d2 = cp4 ^ tinv7;
-   const uint32_t d0 = cp2 ^ tinv6;
-   const uint32_t tinv8 = cp1 & cp4;
-   const uint32_t tinv9 = tinv4 & tinv8;
-   const uint32_t tinv10 = tinv4 ^ tinv2;
-   const uint32_t d1 = tinv9 ^ tinv10;
-   const uint32_t tinv11 = cp2 & cp3;
-   const uint32_t tinv12 = tinv1 & tinv11;
-   const uint32_t tinv13 = tinv1 ^ tinv2;
-   const uint32_t d3 = tinv12 ^ tinv13;
-   const uint32_t sd1 = d1 ^ d3;
-   const uint32_t sd0 = d0 ^ d2;
-   const uint32_t dl = d0 ^ d1;  // NOLINT(misc-confusable-identifiers)
-   const uint32_t dh = d2 ^ d3;
-   const uint32_t dd = sd0 ^ sd1;
-   const uint32_t abcd3 = dh & bh;
-   const uint32_t rr2 = d3 & Y4;
-   const uint32_t t02 = d2 & Y5;
-   const uint32_t abcd4 = dl & bl;
-   const uint32_t r4 = d1 & Y6;
-   const uint32_t r5 = d0 & Y7;
-   const uint32_t r6 = sd0 & sb0;
-   const uint32_t vr2 = dd & bb;
-   const uint32_t wr2 = sd1 & sb1;
-   const uint32_t abcd5 = dh & ah;
-   const uint32_t r7 = d3 & Y0;
-   const uint32_t r8 = d2 & Y1;
-   const uint32_t abcd6 = dl & al;
-   const uint32_t r9 = d1 & Y2;
-   const uint32_t r10 = d0 & Y3;
-   const uint32_t r11 = sd0 & sa0;
-   const uint32_t vr3 = dd & aa;
-   const uint32_t wr3 = sd1 & sa1;
-   const uint32_t ph12 = rr2 ^ abcd3;
-   const uint32_t ph02 = t02 ^ abcd3;
-   const uint32_t pl12 = r4 ^ abcd4;
-   const uint32_t pl02 = r5 ^ abcd4;
-   const uint32_t pr2 = vr2 ^ r6;
-   const uint32_t qr2 = wr2 ^ r6;
-   const uint32_t p0 = ph12 ^ pr2;
-   const uint32_t p1 = ph02 ^ qr2;
-   const uint32_t p2 = pl12 ^ pr2;
-   const uint32_t p3 = pl02 ^ qr2;
-   const uint32_t ph13 = r7 ^ abcd5;
-   const uint32_t ph03 = r8 ^ abcd5;
-   const uint32_t pl13 = r9 ^ abcd6;
-   const uint32_t pl03 = r10 ^ abcd6;
-   const uint32_t pr3 = vr3 ^ r11;
-   const uint32_t qr3 = wr3 ^ r11;
-   const uint32_t p4 = ph13 ^ pr3;
-   const uint32_t S7 = ph03 ^ qr3;
-   const uint32_t p6 = pl13 ^ pr3;
-   const uint32_t p7 = pl03 ^ qr3;
-   const uint32_t S3 = p1 ^ p6;
-   const uint32_t S6 = p2 ^ p6;
-   const uint32_t S0 = p3 ^ p6;
-   const uint32_t X11 = p0 ^ p2;
-   const uint32_t S5 = S0 ^ X11;
-   const uint32_t X13 = p4 ^ p7;
-   const uint32_t X14 = X11 ^ X13;
-   const uint32_t S1 = S3 ^ X14;
-   const uint32_t X16 = p1 ^ S7;
-   const uint32_t S2 = X14 ^ X16;
-   const uint32_t X18 = p0 ^ p4;
-   const uint32_t X19 = S5 ^ X16;
-   const uint32_t S4 = X18 ^ X19;
+   const W Y0 = U0 ^ U3;
+   const W Y2 = ~(U1 ^ U3);
+   const W Y4 = U0 ^ Y2;
+   const W RTL0 = U6 ^ U7;
+   const W Y1 = Y2 ^ RTL0;
+   const W Y7 = ~(U2 ^ Y1);
+   const W RTL1 = U3 ^ U4;
+   const W Y6 = ~(U7 ^ RTL1);
+   const W Y3 = Y1 ^ RTL1;
+   const W RTL2 = ~(U0 ^ U2);
+   const W Y5 = U5 ^ RTL2;
+   const W sa1 = Y0 ^ Y2;
+   const W sa0 = Y1 ^ Y3;
+   const W sb1 = Y4 ^ Y6;
+   const W sb0 = Y5 ^ Y7;
+   const W ah = Y0 ^ Y1;
+   const W al = Y2 ^ Y3;
+   const W aa = sa0 ^ sa1;
+   const W bh = Y4 ^ Y5;
+   const W bl = Y6 ^ Y7;
+   const W bb = sb0 ^ sb1;
+   const W ab20 = sa0 ^ sb0;
+   const W ab22 = al ^ bl;
+   const W ab23 = Y3 ^ Y7;
+   const W ab21 = sa1 ^ sb1;
+   const W abcd1 = ah & bh;
+   const W rr1 = Y0 & Y4;
+   const W ph11 = ab20 ^ abcd1;
+   const W t01 = Y1 & Y5;
+   const W ph01 = t01 ^ abcd1;
+   const W abcd2 = al & bl;
+   const W r1 = Y2 & Y6;
+   const W pl11 = ab22 ^ abcd2;
+   const W r2 = Y3 & Y7;
+   const W pl01 = r2 ^ abcd2;
+   const W r3 = sa0 & sb0;
+   const W vr1 = aa & bb;
+   const W pr1 = vr1 ^ r3;
+   const W wr1 = sa1 & sb1;
+   const W qr1 = wr1 ^ r3;
+   const W ab0 = ph11 ^ rr1;
+   const W ab1 = ph01 ^ ab21;
+   const W ab2 = pl11 ^ r1;
+   const W ab3 = pl01 ^ qr1;
+   const W cp1 = ab0 ^ pr1;
+   const W cp2 = ab1 ^ qr1;
+   const W cp3 = ab2 ^ pr1;
+   const W cp4 = ab3 ^ ab23;
+   const W tinv1 = cp3 ^ cp4;
+   const W tinv2 = cp3 & cp1;
+   const W tinv3 = cp2 ^ tinv2;
+   const W tinv4 = cp1 ^ cp2;
+   const W tinv5 = cp4 ^ tinv2;
+   const W tinv6 = tinv5 & tinv4;
+   const W tinv7 = tinv3 & tinv1;
+   const W d2 = cp4 ^ tinv7;
+   const W d0 = cp2 ^ tinv6;
+   const W tinv8 = cp1 & cp4;
+   const W tinv9 = tinv4 & tinv8;
+   const W tinv10 = tinv4 ^ tinv2;
+   const W d1 = tinv9 ^ tinv10;
+   const W tinv11 = cp2 & cp3;
+   const W tinv12 = tinv1 & tinv11;
+   const W tinv13 = tinv1 ^ tinv2;
+   const W d3 = tinv12 ^ tinv13;
+   const W sd1 = d1 ^ d3;
+   const W sd0 = d0 ^ d2;
+   const W dl = d0 ^ d1;  // NOLINT(misc-confusable-identifiers)
+   const W dh = d2 ^ d3;
+   const W dd = sd0 ^ sd1;
+   const W abcd3 = dh & bh;
+   const W rr2 = d3 & Y4;
+   const W t02 = d2 & Y5;
+   const W abcd4 = dl & bl;
+   const W r4 = d1 & Y6;
+   const W r5 = d0 & Y7;
+   const W r6 = sd0 & sb0;
+   const W vr2 = dd & bb;
+   const W wr2 = sd1 & sb1;
+   const W abcd5 = dh & ah;
+   const W r7 = d3 & Y0;
+   const W r8 = d2 & Y1;
+   const W abcd6 = dl & al;
+   const W r9 = d1 & Y2;
+   const W r10 = d0 & Y3;
+   const W r11 = sd0 & sa0;
+   const W vr3 = dd & aa;
+   const W wr3 = sd1 & sa1;
+   const W ph12 = rr2 ^ abcd3;
+   const W ph02 = t02 ^ abcd3;
+   const W pl12 = r4 ^ abcd4;
+   const W pl02 = r5 ^ abcd4;
+   const W pr2 = vr2 ^ r6;
+   const W qr2 = wr2 ^ r6;
+   const W p0 = ph12 ^ pr2;
+   const W p1 = ph02 ^ qr2;
+   const W p2 = pl12 ^ pr2;
+   const W p3 = pl02 ^ qr2;
+   const W ph13 = r7 ^ abcd5;
+   const W ph03 = r8 ^ abcd5;
+   const W pl13 = r9 ^ abcd6;
+   const W pl03 = r10 ^ abcd6;
+   const W pr3 = vr3 ^ r11;
+   const W qr3 = wr3 ^ r11;
+   const W p4 = ph13 ^ pr3;
+   const W S7 = ph03 ^ qr3;
+   const W p6 = pl13 ^ pr3;
+   const W p7 = pl03 ^ qr3;
+   const W S3 = p1 ^ p6;
+   const W S6 = p2 ^ p6;
+   const W S0 = p3 ^ p6;
+   const W X11 = p0 ^ p2;
+   const W S5 = S0 ^ X11;
+   const W X13 = p4 ^ p7;
+   const W X14 = X11 ^ X13;
+   const W S1 = S3 ^ X14;
+   const W X16 = p1 ^ S7;
+   const W S2 = X14 ^ X16;
+   const W X18 = p0 ^ p4;
+   const W X19 = S5 ^ X16;
+   const W S4 = X18 ^ X19;
 
    V[0] = S0;
    V[1] = S1;
@@ -370,93 +410,77 @@ void AES_INV_SBOX(uint32_t V[8]) {
    V[7] = S7;
 }
 
-inline void bit_transpose(uint32_t B[8]) {
-   swap_bits<uint32_t>(B[1], B[0], 0x55555555, 1);
-   swap_bits<uint32_t>(B[3], B[2], 0x55555555, 1);
-   swap_bits<uint32_t>(B[5], B[4], 0x55555555, 1);
-   swap_bits<uint32_t>(B[7], B[6], 0x55555555, 1);
+template <std::unsigned_integral W>
+inline void bit_transpose(W B[8]) {
+   swap_bits<W>(B[1], B[0], rep32<W>(0x55555555), 1);
+   swap_bits<W>(B[3], B[2], rep32<W>(0x55555555), 1);
+   swap_bits<W>(B[5], B[4], rep32<W>(0x55555555), 1);
+   swap_bits<W>(B[7], B[6], rep32<W>(0x55555555), 1);
 
-   swap_bits<uint32_t>(B[2], B[0], 0x33333333, 2);
-   swap_bits<uint32_t>(B[3], B[1], 0x33333333, 2);
-   swap_bits<uint32_t>(B[6], B[4], 0x33333333, 2);
-   swap_bits<uint32_t>(B[7], B[5], 0x33333333, 2);
+   swap_bits<W>(B[2], B[0], rep32<W>(0x33333333), 2);
+   swap_bits<W>(B[3], B[1], rep32<W>(0x33333333), 2);
+   swap_bits<W>(B[6], B[4], rep32<W>(0x33333333), 2);
+   swap_bits<W>(B[7], B[5], rep32<W>(0x33333333), 2);
 
-   swap_bits<uint32_t>(B[4], B[0], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[5], B[1], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[6], B[2], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[7], B[3], 0x0F0F0F0F, 4);
+   swap_bits<W>(B[4], B[0], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[5], B[1], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[6], B[2], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[7], B[3], rep32<W>(0x0F0F0F0F), 4);
 }
 
-inline void ks_expand(uint32_t B[8], const uint32_t K[], size_t r) {
+template <std::unsigned_integral W>
+inline void ks_expand(W B[8], const uint32_t K[], size_t r) {
    /*
    This is bit_transpose of K[r..r+4] || K[r..r+4], we can save some computation
    due to knowing the first and second halves are the same data.
+
+   For 64-bit words each key word is replicated into both 32-bit halves
+   so that the same round key applies to all block-pairs.
    */
    for(size_t i = 0; i != 4; ++i) {
-      B[i] = K[r + i];
+      B[i] = rep32<W>(K[r + i]);
    }
 
-   swap_bits<uint32_t>(B[1], B[0], 0x55555555, 1);
-   swap_bits<uint32_t>(B[3], B[2], 0x55555555, 1);
+   swap_bits<W>(B[1], B[0], rep32<W>(0x55555555), 1);
+   swap_bits<W>(B[3], B[2], rep32<W>(0x55555555), 1);
 
-   swap_bits<uint32_t>(B[2], B[0], 0x33333333, 2);
-   swap_bits<uint32_t>(B[3], B[1], 0x33333333, 2);
+   swap_bits<W>(B[2], B[0], rep32<W>(0x33333333), 2);
+   swap_bits<W>(B[3], B[1], rep32<W>(0x33333333), 2);
 
    B[4] = B[0];
    B[5] = B[1];
    B[6] = B[2];
    B[7] = B[3];
 
-   swap_bits<uint32_t>(B[4], B[0], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[5], B[1], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[6], B[2], 0x0F0F0F0F, 4);
-   swap_bits<uint32_t>(B[7], B[3], 0x0F0F0F0F, 4);
+   swap_bits<W>(B[4], B[0], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[5], B[1], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[6], B[2], rep32<W>(0x0F0F0F0F), 4);
+   swap_bits<W>(B[7], B[3], rep32<W>(0x0F0F0F0F), 4);
 }
 
-inline void shift_rows(uint32_t B[8]) {
+template <std::unsigned_integral W>
+inline void shift_rows(W B[8]) {
    // 3 0 1 2 7 4 5 6 10 11 8 9 14 15 12 13 17 18 19 16 21 22 23 20 24 25 26 27 28 29 30 31
-   if constexpr(HasNative64BitRegisters) {
-      for(size_t i = 0; i != 8; i += 2) {
-         uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
-         x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
-         x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
-         B[i] = static_cast<uint32_t>(x >> 32);
-         B[i + 1] = static_cast<uint32_t>(x);
-      }
-   } else {
-      for(size_t i = 0; i != 8; ++i) {
-         uint32_t x = B[i];
-         x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
-         x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
-         B[i] = x;
-      }
+   //
+   // For 64-bit words the replicated masks operate on each 32-bit half independently
+   for(size_t i = 0; i != 8; ++i) {
+      B[i] = bit_permute_step<W>(B[i], rep32<W>(0x00223311), 2);
+      B[i] = bit_permute_step<W>(B[i], rep32<W>(0x00550055), 1);
    }
 }
 
-inline void inv_shift_rows(uint32_t B[8]) {
-   // Inverse of shift_rows, just inverting the steps
-
-   if constexpr(HasNative64BitRegisters) {
-      for(size_t i = 0; i != 8; i += 2) {
-         uint64_t x = (static_cast<uint64_t>(B[i]) << 32) | B[i + 1];
-         x = bit_permute_step<uint64_t>(x, 0x0055005500550055, 1);
-         x = bit_permute_step<uint64_t>(x, 0x0022331100223311, 2);
-         B[i] = static_cast<uint32_t>(x >> 32);
-         B[i + 1] = static_cast<uint32_t>(x);
-      }
-   } else {
-      for(size_t i = 0; i != 8; ++i) {
-         uint32_t x = B[i];
-         x = bit_permute_step<uint32_t>(x, 0x00550055, 1);
-         x = bit_permute_step<uint32_t>(x, 0x00223311, 2);
-         B[i] = x;
-      }
+template <std::unsigned_integral W>
+inline void inv_shift_rows(W B[8]) {
+   for(size_t i = 0; i != 8; ++i) {
+      B[i] = bit_permute_step<W>(B[i], rep32<W>(0x00550055), 1);
+      B[i] = bit_permute_step<W>(B[i], rep32<W>(0x00223311), 2);
    }
 }
 
-inline void mix_columns(uint32_t B[8]) {
+template <std::unsigned_integral W>
+inline void mix_columns(W B[8]) {
    // carry high bits in B[0] to positions in 0x1b == 0b11011
-   const uint32_t X2[8] = {
+   const W X2[8] = {
       B[1],
       B[2],
       B[3],
@@ -468,12 +492,13 @@ inline void mix_columns(uint32_t B[8]) {
    };
 
    for(size_t i = 0; i != 8; i++) {
-      const uint32_t X3 = B[i] ^ X2[i];
-      B[i] = X2[i] ^ rotr<8>(B[i]) ^ rotr<16>(B[i]) ^ rotr<24>(X3);
+      const W X3 = B[i] ^ X2[i];
+      B[i] = X2[i] ^ column_rotr<8>(B[i]) ^ column_rotr<16>(B[i]) ^ column_rotr<24>(X3);
    }
 }
 
-void inv_mix_columns(uint32_t B[8]) {
+template <std::unsigned_integral W>
+void inv_mix_columns(W B[8]) {
    /*
    OpenSSL's bsaes implementation credits Jussi Kivilinna with the lovely
    matrix decomposition
@@ -487,7 +512,7 @@ void inv_mix_columns(uint32_t B[8]) {
    multiply first by (05,00,04,00) then perform MixColumns to get the equivalent
    of InvMixColumn.
    */
-   const uint32_t X4[8] = {
+   const W X4[8] = {
       B[2],
       B[3],
       B[4] ^ B[0],
@@ -499,11 +524,48 @@ void inv_mix_columns(uint32_t B[8]) {
    };
 
    for(size_t i = 0; i != 8; i++) {
-      const uint32_t X5 = X4[i] ^ B[i];
-      B[i] = X5 ^ rotr<16>(X4[i]);
+      const W X5 = X4[i] ^ B[i];
+      B[i] = X5 ^ column_rotr<16>(X4[i]);
    }
 
    mix_columns(B);
+}
+
+/*
+* Load up to AES_BITSLICED_BLOCKS blocks from in[] into the bitsliced state B[8].
+*
+* For 32-bit W this is a direct load.  For 64-bit W the data is loaded
+* as uint32_t words and then packed so that each 64-bit word holds two
+* independent 32-bit halves (one from each block-pair).
+*/
+template <std::unsigned_integral W>
+inline void bs_load(W B[8], const uint8_t in[], size_t n_blocks) {
+   if constexpr(std::same_as<W, uint32_t>) {
+      load_be(B, in, n_blocks * 4);
+   } else {
+      uint32_t T[16] = {0};
+      load_be(T, in, n_blocks * 4);
+      for(size_t i = 0; i != 8; ++i) {
+         B[i] = (static_cast<W>(T[i]) << 32) | T[i + 8];
+      }
+   }
+}
+
+/*
+* Store the bitsliced state B[8] to out[], reversing the packing done by bs_load.
+*/
+template <std::unsigned_integral W>
+inline void bs_store(uint8_t out[], const W B[8], size_t n_blocks) {
+   if constexpr(std::same_as<W, uint32_t>) {
+      copy_out_be(std::span(out, n_blocks * 16), std::span(B, 8));
+   } else {
+      uint32_t T[16];
+      for(size_t i = 0; i != 8; ++i) {
+         T[i] = static_cast<uint32_t>(B[i] >> 32);
+         T[i + 8] = static_cast<uint32_t>(B[i]);
+      }
+      copy_out_be(std::span(out, n_blocks * 16), T);
+   }
 }
 
 /*
@@ -514,25 +576,24 @@ void aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
 
    const size_t rounds = (EK.size() - 4) / 4;
 
-   uint32_t KS[13 * 8] = {0};  // actual maximum is (rounds - 1) * 8
+   using W = aes_bs_word;
+
+   W KS[13 * 8] = {0};  // actual maximum is (rounds - 1) * 8
    for(size_t i = 0; i < rounds - 1; i += 1) {
       ks_expand(&KS[8 * i], EK.data(), 4 * i + 4);
    }
 
-   const size_t BLOCK_SIZE = 16;
-   const size_t BITSLICED_BLOCKS = 8 * sizeof(uint32_t) / BLOCK_SIZE;
-
    while(blocks > 0) {
-      const size_t this_loop = std::min(blocks, BITSLICED_BLOCKS);
+      const size_t this_loop = std::min(blocks, AES_BITSLICED_BLOCKS);
 
-      uint32_t B[8] = {0};
+      W B[8] = {0};
 
-      load_be(B, in, this_loop * 4);
+      bs_load(B, in, this_loop);
 
       CT::poison(B, 8);
 
       for(size_t i = 0; i != 8; ++i) {
-         B[i] ^= EK[i % 4];
+         B[i] ^= rep32<W>(EK[i % 4]);
       }
 
       bit_transpose(B);
@@ -553,15 +614,15 @@ void aes_encrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
       bit_transpose(B);
 
       for(size_t i = 0; i != 8; ++i) {
-         B[i] ^= EK[4 * rounds + i % 4];
+         B[i] ^= rep32<W>(EK[4 * rounds + i % 4]);
       }
 
       CT::unpoison(B, 8);
 
-      copy_out_be(std::span(out, this_loop * 4 * sizeof(uint32_t)), B);
+      bs_store(out, B, this_loop);
 
-      in += this_loop * BLOCK_SIZE;
-      out += this_loop * BLOCK_SIZE;
+      in += this_loop * 16;
+      out += this_loop * 16;
       blocks -= this_loop;
    }
 }
@@ -574,25 +635,24 @@ void aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
 
    const size_t rounds = (DK.size() - 4) / 4;
 
-   uint32_t KS[13 * 8] = {0};  // actual maximum is (rounds - 1) * 8
+   using W = aes_bs_word;
+
+   W KS[13 * 8] = {0};  // actual maximum is (rounds - 1) * 8
    for(size_t i = 0; i < rounds - 1; i += 1) {
       ks_expand(&KS[8 * i], DK.data(), 4 * i + 4);
    }
 
-   const size_t BLOCK_SIZE = 16;
-   const size_t BITSLICED_BLOCKS = 8 * sizeof(uint32_t) / BLOCK_SIZE;
-
    while(blocks > 0) {
-      const size_t this_loop = std::min(blocks, BITSLICED_BLOCKS);
+      const size_t this_loop = std::min(blocks, AES_BITSLICED_BLOCKS);
 
-      uint32_t B[8] = {0};
+      W B[8] = {0};
 
-      load_be(B, in, this_loop * 4);
+      bs_load(B, in, this_loop);
 
       CT::poison(B, 8);
 
       for(size_t i = 0; i != 8; ++i) {
-         B[i] ^= DK[i % 4];
+         B[i] ^= rep32<W>(DK[i % 4]);
       }
 
       bit_transpose(B);
@@ -613,15 +673,15 @@ void aes_decrypt_n(const uint8_t in[], uint8_t out[], size_t blocks, const secur
       bit_transpose(B);
 
       for(size_t i = 0; i != 8; ++i) {
-         B[i] ^= DK[4 * rounds + i % 4];
+         B[i] ^= rep32<W>(DK[4 * rounds + i % 4]);
       }
 
       CT::unpoison(B, 8);
 
-      copy_out_be(std::span(out, this_loop * 4 * sizeof(uint32_t)), B);
+      bs_store(out, B, this_loop);
 
-      in += this_loop * BLOCK_SIZE;
-      out += this_loop * BLOCK_SIZE;
+      in += this_loop * 16;
+      out += this_loop * 16;
       blocks -= this_loop;
    }
 }
@@ -654,7 +714,7 @@ void InvMixColumn_x4(uint32_t x[4]) {
 }
 
 uint32_t SE_word(uint32_t x) {
-   uint32_t I[8] = {0};
+   aes_bs_word I[8] = {0};
 
    for(size_t i = 0; i != 8; ++i) {
       I[i] = (x >> (7 - i)) & 0x01010101;
@@ -665,7 +725,7 @@ uint32_t SE_word(uint32_t x) {
    x = 0;
 
    for(size_t i = 0; i != 8; ++i) {
-      x |= ((I[i] & 0x01010101) << (7 - i));
+      x |= static_cast<uint32_t>((I[i] & 0x01010101) << (7 - i));
    }
 
    return x;
@@ -765,7 +825,7 @@ size_t aes_parallelism() {
 #endif
 
    // bitsliced:
-   return 2;
+   return AES_BITSLICED_BLOCKS;
 }
 
 std::string aes_provider() {


### PR DESCRIPTION
On all tested 64-bit processors (Tiger Lake, POWER10, Cortex X925) this regresses performance somewhat (10-30%) for 1 and 2 block messages, and improves for 3 blocks and up. The improvement for 1024 byte messages is 50 to 70%, compared to the 32-bit implementation.

The short input performance could be clawed back by continuing the use the 32-bit pathway for 1-2 block inputs, but the extra complexity does not seem worth it at this time.