### PR TITLE
SCAN_Name improvements and tests

### DIFF
--- a/src/lib/utils/scan_name.cpp
+++ b/src/lib/utils/scan_name.cpp
@@ -7,6 +7,7 @@
 
 #include <botan/internal/scan_name.h>
 
+#include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/internal/parsing.h>
 
@@ -26,11 +27,15 @@ std::string make_arg(const std::vector<std::pair<size_t, std::string>>& name, si
       }
 
       if(name[i].first > level) {
-         output += "(" + name[i].second;
-         ++paren_depth;
+         for(size_t j = level; j < name[i].first; j++) {
+            output += "(";
+            ++paren_depth;
+         }
+         output += name[i].second;
       } else if(name[i].first < level) {
          for(size_t j = name[i].first; j < level; j++) {
             output += ")";
+            BOTAN_ASSERT_NOMSG(paren_depth != 0);
             --paren_depth;
          }
          output += "," + name[i].second;
@@ -53,18 +58,24 @@ std::string make_arg(const std::vector<std::pair<size_t, std::string>>& name, si
 
 }  // namespace
 
-SCAN_Name::SCAN_Name(const char* algo_spec) : SCAN_Name(std::string(algo_spec)) {}
-
 SCAN_Name::SCAN_Name(std::string_view algo_spec) : m_orig_algo_spec(algo_spec) {
    if(algo_spec.empty()) {
       throw Invalid_Argument("Expected algorithm name, got empty string");
+   }
+
+   // Fast path for a bare name with no arguments or modes (eg "SHA-256"),
+   // which is the common case. Equivalent to the general parse below, which
+   // for such input produces a single token and no args/modes.
+   if(algo_spec.find_first_of("(),/") == std::string_view::npos) {
+      m_alg_name = std::string(algo_spec);
+      return;
    }
 
    std::vector<std::pair<size_t, std::string>> name;
    size_t level = 0;
    std::pair<size_t, std::string> accum = std::make_pair(level, "");
 
-   const std::string decoding_error = "Bad SCAN name '" + m_orig_algo_spec + "': ";
+   bool expect_token = true;
 
    for(const char c : algo_spec) {
       if(c == '/' || c == ',' || c == '(' || c == ')') {
@@ -72,21 +83,27 @@ SCAN_Name::SCAN_Name(std::string_view algo_spec) : m_orig_algo_spec(algo_spec) {
             ++level;
          } else if(c == ')') {
             if(level == 0) {
-               throw Decoding_Error(decoding_error + "Mismatched parens");
+               throw Invalid_Algorithm_Name(m_orig_algo_spec);
             }
             --level;
          }
 
          if(c == '/' && level > 0) {
             accum.second.push_back(c);
+            expect_token = false;
          } else {
+            if(expect_token) {
+               throw Invalid_Algorithm_Name(m_orig_algo_spec);
+            }
             if(!accum.second.empty()) {
                name.push_back(accum);
             }
             accum = std::make_pair(level, "");
+            expect_token = (c != ')');
          }
       } else {
          accum.second.push_back(c);
+         expect_token = false;
       }
    }
 
@@ -95,11 +112,16 @@ SCAN_Name::SCAN_Name(std::string_view algo_spec) : m_orig_algo_spec(algo_spec) {
    }
 
    if(level != 0) {
-      throw Decoding_Error(decoding_error + "Missing close paren");
+      throw Invalid_Algorithm_Name(m_orig_algo_spec);
+   }
+
+   if(expect_token) {
+      // A trailing separator with no following token, eg "Foo/" or "Foo,"
+      throw Invalid_Algorithm_Name(m_orig_algo_spec);
    }
 
    if(name.empty()) {
-      throw Decoding_Error(decoding_error + "Empty name");
+      throw Invalid_Algorithm_Name(m_orig_algo_spec);
    }
 
    m_alg_name = name[0].second;

--- a/src/lib/utils/scan_name.h
+++ b/src/lib/utils/scan_name.h
@@ -19,14 +19,8 @@ namespace Botan {
 A class encapsulating a SCAN name (similar to JCE conventions)
 http://www.users.zetnet.co.uk/hopwood/crypto/scan/
 */
-class SCAN_Name final {
+class BOTAN_TEST_API SCAN_Name final {
    public:
-      /**
-      * Create a SCAN_Name
-      * @param algo_spec A SCAN-format name
-      */
-      explicit SCAN_Name(const char* algo_spec);
-
       /**
       * Create a SCAN_Name
       * @param algo_spec A SCAN-format name

--- a/src/tests/test_utils.cpp
+++ b/src/tests/test_utils.cpp
@@ -22,6 +22,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/parsing.h>
 #include <botan/internal/rounding.h>
+#include <botan/internal/scan_name.h>
 #include <botan/internal/target_info.h>
 
 #include <bit>
@@ -790,6 +791,103 @@ class Utility_Function_Tests final : public Test {
 };
 
 BOTAN_REGISTER_SMOKE_TEST("utils", "util", Utility_Function_Tests);
+
+class SCAN_Name_Tests final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+
+         results.push_back(parse_bare_name());
+         results.push_back(parse_name_with_arg());
+         results.push_back(parse_nested_args());
+         results.push_back(parse_mode_name());
+         results.push_back(parse_nested_names());
+         results.push_back(parse_invalid_names());
+
+         return results;
+      }
+
+   private:
+      static Test::Result parse_bare_name() {
+         Test::Result result("SCAN_Name bare name parse");
+         const Botan::SCAN_Name n("SHA-256");
+         result.test_str_eq("algo name", n.algo_name(), "SHA-256");
+         result.test_sz_eq("no args", n.arg_count(), 0);
+         result.test_str_eq("orig", n.to_string(), "SHA-256");
+         return result;
+      }
+
+      static Test::Result parse_name_with_arg() {
+         Test::Result result("SCAN_Name parse with arg");
+         const Botan::SCAN_Name n("HMAC(SHA-256)");
+         result.test_str_eq("algo name", n.algo_name(), "HMAC");
+         result.test_sz_eq("one arg", n.arg_count(), 1);
+         result.test_str_eq("arg", n.arg(0), "SHA-256");
+         return result;
+      }
+
+      static Test::Result parse_nested_args() {
+         Test::Result result("SCAN_Name with nested argument");
+         const Botan::SCAN_Name n("Foo(A,B(C))");
+         result.test_str_eq("algo name", n.algo_name(), "Foo");
+         result.test_sz_eq("two args", n.arg_count(), 2);
+         result.test_str_eq("arg0", n.arg(0), "A");
+         result.test_str_eq("arg1", n.arg(1), "B(C)");
+         return result;
+      }
+
+      static Test::Result parse_mode_name() {
+         Test::Result result("SCAN_Name mode and padding");
+         const Botan::SCAN_Name n("AES-128/CBC/PKCS7");
+         result.test_str_eq("algo name", n.algo_name(), "AES-128");
+         result.test_str_eq("mode", n.cipher_mode(), "CBC");
+         result.test_str_eq("mode pad", n.cipher_mode_pad(), "PKCS7");
+         return result;
+      }
+
+      static Test::Result parse_nested_names() {
+         Test::Result result("SCAN_Name nesting accepted");
+         const Botan::SCAN_Name n("Foo(A(B),C)");
+         result.test_str_eq("algo name", n.algo_name(), "Foo");
+         result.test_sz_eq("two args", n.arg_count(), 2);
+         result.test_str_eq("arg0", n.arg(0), "A(B)");
+         result.test_str_eq("arg1", n.arg(1), "C");
+         return result;
+      }
+
+      static void verify_name_is_rejected(Test::Result& result, std::string_view name) {
+         result.test_throws<Botan::Invalid_Argument>(Botan::fmt("Invalid name '{}', rejected", name),
+                                                     [&] { const Botan::SCAN_Name _parsed(name); });
+      }
+
+      static Test::Result parse_invalid_names() {
+         Test::Result result("SCAN_Name invalid names rejected");
+
+         const std::vector<std::string> testcases = {
+            "",
+            "Foo((A))",
+            "Foo(A(((B))C))",
+            "Foo()",
+            "Foo,",
+            "Foo(",
+            "Foo)",
+            "Foo(,)",
+            "Foo(,A)",
+            "Foo(A,)",
+            "Foo(A,,B)",
+            "AES-128//CBC",
+            "/Foo",
+            "Foo/",
+         };
+
+         for(const auto& tc : testcases) {
+            verify_name_is_rejected(result, tc);
+         }
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("utils", "scan_name", SCAN_Name_Tests);
 
 class BitOps_Tests final : public Test {
    public:


### PR DESCRIPTION
Detect the fast case where the string is just a bare name (like "SHA-256") and skip all the parsing and allocations entirely.

Reliably detect and reject invalid paren nestings.

Throw Invalid_Argument_Name for all invalid argument names, instead of randomly throwing Decoding_Error for some of the cases.