### PR TITLE
jitter_rng: make FIPS mode optional, allow NTG.1 and custom OSR

### DIFF
--- a/doc/api_ref/rng.rst
+++ b/doc/api_ref/rng.rst
@@ -242,6 +242,35 @@ This is an RNG based on low-level CPU timing jitter, using the
 Can be enabled with ``configure.py`` via ``--enable-modules="jitter_rng"``, provided
 you have the library installed and made available to the build, including headers.
 
+The constructor takes the compliance mode which should be requested from
+jitterentropy, as well as the oversampling rate:
+
+``Jitter_RNG::Mode::Default``
+   Leaves the library at its defaults. The SP800-90B health tests are then only
+   enforced if the system itself runs in FIPS mode.
+
+``Jitter_RNG::Mode::FIPS``
+   Forces full SP800-90B compliance including the online health tests
+   (``JENT_FORCE_FIPS``), independent of the state of the system.
+
+``Jitter_RNG::Mode::NTG1``
+   Requests AIS 20/31 NTG.1 compliance (``JENT_NTG1``). This implies FIPS mode
+   and additionally disables the internal timer of jitterentropy, so it is
+   unavailable on platforms without a usable high resolution timer. It requires
+   jitterentropy 3.7.0 or later, both at build and at run time; otherwise the
+   constructor throws ``Not_Implemented``. Use ``Jitter_RNG::ntg1_supported()``
+   to query this beforehand.
+
+The oversampling rate controls how many timing samples are collected per output
+bit. Higher values are more conservative but slower; the default of zero lets
+jitterentropy apply its own minimal rate. Rates the library rejects as out of
+range cause the constructor to throw.
+
+.. note::
+   Before 3.14.0, ``Jitter_RNG`` always requested ``JENT_FORCE_FIPS``. The
+   default is now ``Mode::Default``; pass ``Mode::FIPS`` explicitly to retain
+   the previous behavior.
+
 Entropy Sources
 ---------------------------------
 
@@ -304,7 +333,7 @@ not protect against PID wrap around. The process ID is usually
 implemented as a 16 bit integer. In this scenario, a process will
 spawn a new child process, which exits the parent process and
 spawns a new child process himself. If the PID wrapped around, the
-second child process may get assigned the process ID of it's 
+second child process may get assigned the process ID of it's
 grandparent and the fork safety can not be ensured.
 
 Therefore, it is strongly recommended to explicitly reseed any

--- a/news.rst
+++ b/news.rst
@@ -7,6 +7,12 @@ Version 3.14.0, Not Yet Released
 * Modify the bitsliced AES implementation to use the native word size of the
   processor, instead of always 32 bits. (GH #5826)
 
+* ``Jitter_RNG`` now accepts the compliance mode and the oversampling rate which
+  should be used by the jitterentropy library. AIS 20/31 NTG.1 compliance can be
+  requested with ``Jitter_RNG::Mode::NTG1`` if jitterentropy 3.7.0 or later is
+  used. Note that ``Jitter_RNG`` no longer forces the FIPS mode of jitterentropy
+  by default; use ``Jitter_RNG::Mode::FIPS`` to retain the previous behavior.
+
 Version 3.13.0, 2026-08-13
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -93,6 +93,8 @@ class Processor_RNG_EntropySource final : public Entropy_Source {
 
 class Jitter_RNG_EntropySource final : public Entropy_Source {
    public:
+      Jitter_RNG_EntropySource(Jitter_RNG::Mode mode) : m_rng(mode) {}
+
       size_t poll(RandomNumberGenerator& rng) override {
          rng.reseed_from_rng(m_rng);
          return RandomNumberGenerator::DefaultPollBits;
@@ -143,7 +145,13 @@ std::unique_ptr<Entropy_Source> Entropy_Source::create(std::string_view name) {
 
 #if defined(BOTAN_HAS_JITTER_RNG)
    if(name == "jitter_rng") {
-      return std::make_unique<Jitter_RNG_EntropySource>();
+      return std::make_unique<Jitter_RNG_EntropySource>(Jitter_RNG::Mode::Default);
+   }
+   if(name == "jitter_rng_fips") {
+      return std::make_unique<Jitter_RNG_EntropySource>(Jitter_RNG::Mode::FIPS);
+   }
+   if(name == "jitter_rng_ntg1") {
+      return std::make_unique<Jitter_RNG_EntropySource>(Jitter_RNG::Mode::NTG1);
    }
 #endif
 

--- a/src/lib/rng/jitter_rng/jitter_rng.cpp
+++ b/src/lib/rng/jitter_rng/jitter_rng.cpp
@@ -10,14 +10,26 @@
 #include <botan/assert.h>
 #include <botan/exceptn.h>
 #include <botan/mutex.h>
+#include <botan/internal/int_utils.h>
 
 #include <jitterentropy.h>
+
+/*
+* BSI AIS 20/31 NTG.1 support (JENT_NTG1) was added in jitterentropy 3.7.0.
+* The version encoding used by JENT_VERSION and jent_version() is
+* major * 1000000 + minor * 10000 + patchlevel * 100.
+*/
+#define BOTAN_JITTER_RNG_NTG1_MIN_VERSION 3070000
+
+#if defined(JENT_NTG1) && JENT_VERSION >= BOTAN_JITTER_RNG_NTG1_MIN_VERSION
+   #define BOTAN_JITTER_RNG_HAS_NTG1
+#endif
 
 namespace Botan {
 
 class Jitter_RNG_Internal final {
    public:
-      Jitter_RNG_Internal();
+      Jitter_RNG_Internal(Jitter_RNG::Mode mode, size_t osr);
       ~Jitter_RNG_Internal();
       void collect_into_buffer(std::span<uint8_t> buf);
 
@@ -27,16 +39,64 @@ class Jitter_RNG_Internal final {
       Jitter_RNG_Internal& operator=(Jitter_RNG_Internal&& other) = delete;
 
    private:
+      static unsigned int flags_for_mode(Jitter_RNG::Mode mode);
+
       mutex_type m_mutex;
       rand_data* m_rand_data;
 };
 
-Jitter_RNG_Internal::Jitter_RNG_Internal() {
-   constexpr unsigned int oversampling_rate = 0;    // use default oversampling
-   constexpr unsigned int flags = JENT_FORCE_FIPS;  // enable health tests
+unsigned int Jitter_RNG_Internal::flags_for_mode(Jitter_RNG::Mode mode) {
+   switch(mode) {
+      case Jitter_RNG::Mode::Default:
+         return 0;
+      case Jitter_RNG::Mode::FIPS:
+         // enable the SP800-90B health tests
+         return JENT_FORCE_FIPS;
+      case Jitter_RNG::Mode::NTG1:
+#if defined(BOTAN_JITTER_RNG_HAS_NTG1)
+         /*
+         * An older runtime library would silently ignore the unknown flag bit
+         * and hand out an entropy collector which is not NTG.1 compliant, so
+         * the version the headers were taken from is not sufficient here.
+         */
+         if(jent_version() < BOTAN_JITTER_RNG_NTG1_MIN_VERSION) {
+            throw Not_Implemented("The linked jitterentropy library is too old to support NTG.1");
+         }
 
-   // if flags and osr are used, use the same values for init and alloc
-   static const int result = jent_entropy_init_ex(oversampling_rate, flags);
+         /*
+         * Enable BSI AIS 20/31 3.0 NTG.1 mode
+         * NTG.1 implies FIPS mode within jitterentropy
+         */
+         return JENT_NTG1;
+#else
+         throw Not_Implemented("Botan was built against a jitterentropy version without NTG.1 support");
+#endif
+   }
+
+   BOTAN_ASSERT_UNREACHABLE();
+}
+
+bool Jitter_RNG::ntg1_supported() {
+#if defined(BOTAN_JITTER_RNG_HAS_NTG1)
+   return jent_version() >= BOTAN_JITTER_RNG_NTG1_MIN_VERSION;
+#else
+   return false;
+#endif
+}
+
+Jitter_RNG_Internal::Jitter_RNG_Internal(Jitter_RNG::Mode mode, size_t osr) {
+   const auto oversampling_rate =
+      checked_cast_to_or_throw<unsigned int, Invalid_Argument>(osr, "Jitter_RNG oversampling rate is too large");
+   const unsigned int flags = flags_for_mode(mode);
+
+   /*
+   * This performs new health checks for the chosen osr and flags.
+   * It is safe to do this multiple times, it will not alter existing
+   * instances.
+   *
+   * If flags and osr are used, use the same values for init and alloc.
+   */
+   const int result = jent_entropy_init_ex(oversampling_rate, flags);
 
    // no further details documented regarding the return value
    if(result != 0) {
@@ -70,7 +130,7 @@ void Jitter_RNG_Internal::collect_into_buffer(std::span<uint8_t> buf) {
       const auto error_msg = [&]() -> std::string_view {
          switch(num_bytes) {
             case -1:  // should never happen because of the check above
-               return "JitterRNG: Uninitilialized";
+               return "JitterRNG: Uninitialized";
             case -2:
                return "JitterRNG: SP800-90B repetition count online health test failed";
             case -3:
@@ -80,11 +140,16 @@ void Jitter_RNG_Internal::collect_into_buffer(std::span<uint8_t> buf) {
             case -5:
                return "JitterRNG: LAG predictor health test failed";
             case -6:
-               return "JitterRNG: Repetitive count test (RCT) failed permanently";
+               return "JitterRNG: Repetition count test (RCT) failed permanently";
             case -7:
                return "JitterRNG: Adaptive proportion test (APT) failed permanently";
             case -8:
                return "JitterRNG: LAG prediction test failed permanently";
+            // the following are only returned by jitterentropy 3.7.0 and newer
+            case -9:
+               return "JitterRNG: Repetition count test with memory failed";
+            case -10:
+               return "JitterRNG: Repetition count test with memory failed permanently";
             default:
                return "JitterRNG: Error reading entropy";
          }
@@ -92,13 +157,13 @@ void Jitter_RNG_Internal::collect_into_buffer(std::span<uint8_t> buf) {
       throw Internal_Error(error_msg);
    }
 
-   // According to the docs, `jent_read_entropy` itself runs its logic as often
+   // According to the docs, `jent_read_entropy_safe` itself runs its logic as often
    // as necessary to gather the requested number of bytes,
    // so this should actually never happen.
    BOTAN_ASSERT(static_cast<size_t>(num_bytes) == buf.size(), "JitterRNG produced the expected number of bytes");
 }
 
-Jitter_RNG::Jitter_RNG() : m_jitter{std::make_unique<Jitter_RNG_Internal>()} {}
+Jitter_RNG::Jitter_RNG(Mode mode, size_t osr) : m_jitter{std::make_unique<Jitter_RNG_Internal>(mode, osr)} {}
 
 Jitter_RNG::~Jitter_RNG() = default;
 

--- a/src/lib/rng/jitter_rng/jitter_rng.h
+++ b/src/lib/rng/jitter_rng/jitter_rng.h
@@ -17,14 +17,59 @@ namespace Botan {
 class Jitter_RNG_Internal;
 
 /**
-* RNG using libjitterentropy (https://github.com/smuellerDD/jitterentropy-library)
+* RNG using jitterentropy (https://github.com/smuellerDD/jitterentropy-library)
 */
 class BOTAN_PUBLIC_API(3, 6) Jitter_RNG final : public RandomNumberGenerator {
    public:
       /**
-      * Create a Jitter_RNG, throwing if libjitterentropy cannot be initialized
+      * The compliance mode requested from the underlying jitterentropy library
       */
-      Jitter_RNG();
+      enum class Mode : uint8_t {
+         /**
+         * Leave the library at its defaults. The SP800-90B health tests are
+         * then only enforced if the system itself runs in FIPS mode.
+         */
+         Default,
+
+         /**
+         * Force full SP800-90B compliance, including the online health tests,
+         * regardless of the state of the system (``JENT_FORCE_FIPS``).
+         */
+         FIPS,
+
+         /**
+         * Request AIS 20/31 NTG.1 compliance (``JENT_NTG1``). This implies
+         * FIPS mode and additionally disables the internal timer, so it is not
+         * available on platforms which have no usable high resolution timer.
+         *
+         * Requires jitterentropy 3.7.0 or later, both at build and at run
+         * time; the constructor throws Not_Implemented otherwise. See
+         * ntg1_supported().
+         */
+         NTG1,
+      };
+
+      /**
+      * Let jitterentropy pick the oversampling rate
+      */
+      static constexpr size_t default_osr = 0;
+
+      /**
+      * @return true if the linked jitterentropy supports Mode::NTG1
+      */
+      static bool ntg1_supported();
+
+      /**
+      * Create a Jitter_RNG, throwing if jitterentropy cannot be initialized
+      *
+      * @param mode the compliance mode to request from jitterentropy
+      * @param osr the oversampling rate to use. Higher values collect more
+      * timing samples per output bit, which is slower but more conservative.
+      * The default lets the library apply its own (minimal) rate. Values the
+      * library considers out of range cause the constructor to throw.
+      */
+      explicit Jitter_RNG(Mode mode = Mode::Default, size_t osr = default_osr);
+
       ~Jitter_RNG() override;
 
       Jitter_RNG(const Jitter_RNG& other) = delete;

--- a/src/tests/test_jitter_rng.cpp
+++ b/src/tests/test_jitter_rng.cpp
@@ -10,6 +10,7 @@
 
    #include <botan/auto_rng.h>
    #include <botan/entropy_src.h>
+   #include <botan/exceptn.h>
    #include <botan/jitter_rng.h>
    #include <botan/system_rng.h>
 
@@ -20,17 +21,18 @@ namespace {
 std::vector<Test::Result> test_jitter_rng() {
    return {
       CHECK("Jitter_RNG basic usage",
-            [](Test::Result&) {
+            [](Test::Result& result) {
                const std::vector<size_t> sample_counts{0, 1, 2, 4, 64, 128, 512};
 
                Botan::Jitter_RNG rng;
                for(auto sample_count : sample_counts) {
                   [[maybe_unused]] auto buf = rng.random_vec(sample_count);
                }
+               result.test_success("Basic usage working.");
             }),
 
       CHECK("Jitter_RNG clear",
-            [](Test::Result&) {
+            [](Test::Result& result) {
                const std::vector<size_t> sample_counts{64, 128};
 
                Botan::Jitter_RNG rng;
@@ -38,15 +40,62 @@ std::vector<Test::Result> test_jitter_rng() {
                   [[maybe_unused]] auto buf = rng.random_vec(sample_count);
                   rng.clear();
                }
+               result.test_success("Clearing works.");
+            }),
+
+      CHECK("Jitter_RNG modes and oversampling rate",
+            [](Test::Result& result) {
+               for(auto mode : {Botan::Jitter_RNG::Mode::Default, Botan::Jitter_RNG::Mode::FIPS}) {
+                  Botan::Jitter_RNG rng(mode);
+                  result.test_sz_eq("output produced", rng.random_vec(64).size(), size_t(64));
+
+                  // an oversampling rate the library accepts in any mode
+                  Botan::Jitter_RNG rng_osr(mode, 3);
+                  result.test_sz_eq("output produced with explicit osr", rng_osr.random_vec(64).size(), size_t(64));
+               }
+            }),
+
+      CHECK("Jitter_RNG NTG.1",
+            [](Test::Result& result) {
+               const auto ntg1 = Botan::Jitter_RNG::Mode::NTG1;
+
+               if(Botan::Jitter_RNG::ntg1_supported()) {
+                  try {
+                     Botan::Jitter_RNG rng(ntg1);
+                     result.test_sz_eq("output produced", rng.random_vec(64).size(), size_t(64));
+                  } catch(const Botan::Internal_Error&) {
+                     result.test_note("NTG.1 init error due to failing health tests.");
+                  } catch(const Botan::Not_Implemented&) {
+                     result.test_failure(
+                        "NTG.1 check not working. Not_Implemented should only be thrown when jitterentropy is "
+                        "older than 3.7.0 and does not support the NTG.1 mode.");
+                  }
+               } else {
+                  result.test_throws<Botan::Not_Implemented>("NTG.1 is rejected if unsupported by jitterentropy",
+                                                             [ntg1]() { Botan::Jitter_RNG rng(ntg1); });
+               }
             }),
 
       CHECK("JitterRNG as entropy source",
-            [](Test::Result&) {
-               Botan::Entropy_Sources entropy_sources;
-               entropy_sources.add_source(Botan::Entropy_Source::create("jitter_rng"));
-               Botan::AutoSeeded_RNG rng{entropy_sources};
+            [](Test::Result& result) {
+               for(std::string_view mode : {"jitter_rng", "jitter_rng_fips", "jitter_rng_ntg1"}) {
+                  try {
+                     Botan::Entropy_Sources entropy_sources;
+                     entropy_sources.add_source(Botan::Entropy_Source::create(mode));
+                     Botan::AutoSeeded_RNG rng{entropy_sources};
 
-               [[maybe_unused]] auto buf = rng.random_vec(512);
+                     [[maybe_unused]] auto buf = rng.random_vec(512);
+                  } catch(const Botan::Internal_Error&) {
+                     if(mode == "jitter_rng") {
+                        result.test_failure("Default mode without health tests should not throw an Internal_Error.");
+                     }
+                  } catch(const Botan::Not_Implemented&) {
+                     if(mode != "jitter_rng_ntg1") {
+                        result.test_failure("All modes other than NTG.1 should always be implemented.");
+                     }
+                  }
+               }
+               result.test_success("All modes supported modes working.");
             }),
    };
 }


### PR DESCRIPTION
I did some small maintenance of the jitter_rng in order to reflect jitterentropy >= 3.7.0 in the code. jitterentropy often lead to failures in our CI runs because of failing health tests in the always enabled FIPS mode. I relaxed this setting, by defaulting to no health tests and letting the user enable them. Anyone actually using this in a FIPS setting nevertheless has to think about the used options, so this change should make no harm here.

This also allows to enable jitterentropy in the NixOS botan package again.