### PR TITLE
Test: Downgrade during TLS session resumption

### DIFF
--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -1188,6 +1188,25 @@ class TLS_Unit_Tests final : public Test {
 
             test.go();
             results.push_back(test.results());
+
+            if(expect_version_mismatch) {
+               continue;
+            }
+
+            TLS_Handshake_Test test_resumption(c.name,
+                                               c.offer_version,
+                                               creds,
+                                               client_policy,
+                                               server_policy,
+                                               rng,
+                                               client_ses,
+                                               server_ses,
+                                               false,
+                                               c.expected_version);
+
+            test_resumption.expect_session_resumption();
+            test_resumption.go();
+            results.push_back(test_resumption.results());
          }
       }
 


### PR DESCRIPTION
This is a follow-up for #5817 that also exercises the downgrade after finding a TLS 1.2 session within the TLS 1.3 implementation.