### PR TITLE
Bound the HelloVerifyRequest messages a DTLS client acts on

### DIFF
--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -54,6 +54,8 @@ class Client_Handshake_State_12 final : public Handshake_State {
 
       void mark_as_renegotiation() { m_is_reneg = true; }
 
+      size_t note_hello_verify_request() { return ++m_hello_verify_requests; }
+
       const secure_vector<uint8_t>& resume_master_secret() const {
          BOTAN_STATE_CHECK(is_a_resumption());
          return m_resumed_session->master_secret();
@@ -90,6 +92,7 @@ class Client_Handshake_State_12 final : public Handshake_State {
       // Used during session resumption
       std::optional<Session> m_resumed_session;
       bool m_is_reneg = false;
+      size_t m_hello_verify_requests = 0;
 };
 
 }  // namespace
@@ -293,6 +296,22 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
    }
 
    if(type == Handshake_Type::HelloVerifyRequest) {
+      // RFC 6347 4.2.1 requires tolerating more than one: "This may result in
+      // clients receiving multiple HelloVerifyRequest messages with different
+      // cookies. Clients SHOULD handle this by sending a new ClientHello with a
+      // cookie in response to the new HelloVerifyRequest."
+      //
+      // Each one makes us re-send the ClientHello, and a HelloVerifyRequest is
+      // unauthenticated epoch-zero data that resets the retransmission counter,
+      // so an unbounded stream of forged ones would have us flood the server
+      // indefinitely. Bound how many we will act on.
+      const size_t hello_verify_requests = state.note_hello_verify_request();
+      const std::optional<size_t> max_hello_verify_requests = policy().dtls_maximum_hello_verify_requests();
+
+      if(max_hello_verify_requests.has_value() && hello_verify_requests > max_hello_verify_requests.value()) {
+         throw TLS_Exception(Alert::UnexpectedMessage, "Too many DTLS HelloVerifyRequest messages");
+      }
+
       state.set_expected_next(Handshake_Type::ServerHello);
       state.set_expected_next(Handshake_Type::HelloVerifyRequest);  // might get it again
 

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -512,6 +512,12 @@ size_t Policy::dtls_maximum_timeout() const {
    return 60 * 1000;
 }
 
+// Generous next to the one or two a legitimate cookie-secret rotation can
+// produce, while still bounding a forged stream.
+std::optional<size_t> Policy::dtls_maximum_hello_verify_requests() const {
+   return 4;
+}
+
 std::optional<size_t> Policy::dtls_maximum_retransmissions() const {
    // Matches BoringSSL's DTLS1_MAX_TIMEOUTS.
    //

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -597,6 +597,21 @@ class BOTAN_PUBLIC_API(2, 0) Policy /* NOLINT(*-special-member-functions) */ {
       virtual std::optional<size_t> dtls_maximum_retransmissions() const;
 
       /**
+      * @return the number of HelloVerifyRequest messages a DTLS client will act
+      * on within one handshake before abandoning it. Return nullopt to accept
+      * them without limit; return 0 to reject any cookie exchange.
+      *
+      * RFC 6347 4.2.1 requires more than one to be tolerated: "This may result
+      * in clients receiving multiple HelloVerifyRequest messages with different
+      * cookies. Clients SHOULD handle this by sending a new ClientHello with a
+      * cookie in response to the new HelloVerifyRequest." A HelloVerifyRequest
+      * is unauthenticated and carries no retransmission state of its own, so
+      * without a bound a forged stream of them makes a client re-send its
+      * ClientHello indefinitely.
+      */
+      virtual std::optional<size_t> dtls_maximum_hello_verify_requests() const;
+
+      /**
       * @return the maximum size of a single handshake message, in bytes.
       * Messages larger than this will be rejected prior to processing.
       * Return 0 to disable this and accept any size.
@@ -907,6 +922,8 @@ class BOTAN_PUBLIC_API(2, 0) Text_Policy : public Policy {
       size_t dtls_initial_timeout() const override;
 
       size_t dtls_maximum_timeout() const override;
+
+      std::optional<size_t> dtls_maximum_hello_verify_requests() const override;
 
       bool require_cert_revocation_info() const override;
 

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -190,6 +190,20 @@ size_t Text_Policy::dtls_maximum_timeout() const {
    return get_len("dtls_maximum_timeout", Policy::dtls_maximum_timeout());
 }
 
+std::optional<size_t> Text_Policy::dtls_maximum_hello_verify_requests() const {
+   const std::string v = get_str("dtls_maximum_hello_verify_requests");
+
+   if(v.empty()) {
+      return Policy::dtls_maximum_hello_verify_requests();
+   }
+
+   if(v == "none") {
+      return std::nullopt;
+   }
+
+   return to_u32bit(v);
+}
+
 bool Text_Policy::require_cert_revocation_info() const {
    return get_bool("require_cert_revocation_info", Policy::require_cert_revocation_info());
 }

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -467,6 +467,13 @@ std::vector<uint8_t> dtls_handshake_fragment(Botan::TLS::Handshake_Type type,
    return msg;
 }
 
+// A complete, unfragmented DTLS handshake message.
+std::vector<uint8_t> dtls_handshake_message(Botan::TLS::Handshake_Type type,
+                                            uint16_t message_sequence,
+                                            std::span<const uint8_t> body) {
+   return dtls_handshake_fragment(type, body.size(), message_sequence, 0, body);
+}
+
 // A record carrying only a handshake header: it declares `message_length` bytes
 // but delivers none of them.
 std::vector<uint8_t> empty_dtls_handshake_fragment(Botan::TLS::Handshake_Type type,
@@ -1022,6 +1029,68 @@ class DTLS_Core_Regression_Tests final : public Test {
             client.received_data(in.data(), in.size());
          });
          result.test_is_false("client is no longer active", client.is_active());
+
+         return result;
+      }
+
+      // A HelloVerifyRequest is unauthenticated and resets the retransmission
+      // counter, so without a bound a forged stream of them makes a client
+      // re-send its ClientHello forever.
+      static Test::Result test_hello_verify_request_flood_is_bounded() {
+         Test::Result result("DTLS HelloVerifyRequest flood is bounded");
+
+         auto rng = Test::new_shared_rng("dtls-core-hvr-flood");
+         auto policy = std::make_shared<DTLS_PSK_Policy>();
+         auto creds = std::make_shared<DTLS_PSK_Credentials>();
+
+         std::vector<uint8_t> c2s;
+         std::vector<uint8_t> client_recv;
+         // This client is expected to fail, so do not fail the test on its alert.
+         Test::Result ignored_alerts("ignored");
+         auto client_callbacks = std::make_shared<DTLS_Test_Callbacks>(ignored_alerts, c2s, client_recv);
+         Botan::TLS::Client client(client_callbacks,
+                                   std::make_shared<Botan::TLS::Session_Manager_Noop>(),
+                                   creds,
+                                   policy,
+                                   rng,
+                                   Botan::TLS::Server_Information("localhost"),
+                                   Botan::TLS::Protocol_Version::latest_dtls_version());
+
+         const size_t first_client_hello = c2s.size();
+         result.test_is_true("client sent an initial ClientHello", first_client_hello > 0);
+
+         const std::optional<size_t> max_hvr = policy->dtls_maximum_hello_verify_requests();
+         if(!result.test_is_true("policy bounds HelloVerifyRequests", max_hvr.has_value())) {
+            return result;
+         }
+         const size_t limit = max_hvr.value();
+
+         size_t answered = 0;
+         size_t emitted = 0;
+         for(size_t i = 0; i != limit + 20; ++i) {
+            // Body of a HelloVerifyRequest: version, then a cookie.
+            std::vector<uint8_t> body = {0xFE, 0xFD, 0x08};
+            body.insert(body.end(), 8, static_cast<uint8_t>(i));
+
+            const auto forged = unprotected_dtls_record(
+               Botan::TLS::Record_Type::Handshake,
+               1000 + i,
+               dtls_handshake_message(Botan::TLS::Handshake_Type::HelloVerifyRequest, static_cast<uint16_t>(i), body));
+            c2s.clear();
+            try {
+               client.received_data(forged.data(), forged.size());
+            } catch(const Botan::TLS::TLS_Exception&) {
+               break;
+            }
+            if(!c2s.empty()) {
+               answered += 1;
+               emitted += c2s.size();
+            }
+         }
+
+         result.test_sz_eq("client answered at most the configured number", answered, limit);
+         result.test_is_true("client abandoned the handshake", client.is_closed());
+         result.test_is_true("outbound traffic stayed bounded", emitted <= limit * 2 * first_client_hello);
 
          return result;
       }
@@ -2021,6 +2090,7 @@ class DTLS_Core_Regression_Tests final : public Test {
                  test_forged_epoch0_appdata_during_renegotiation(),
                  test_no_renegotiation_before_ccs_is_accepted(),
                  test_no_renegotiation_after_ccs_ends_the_association(),
+                 test_hello_verify_request_flood_is_bounded(),
                  test_epoch_retirement_does_not_outlive_a_restart(),
                  test_timed_out_initial_handshake_closes_the_channel(),
                  test_timed_out_renegotiation_keeps_the_association(),


### PR DESCRIPTION
Each HelloVerifyRequest makes the client re-send its ClientHello and resets the retransmission counter. A HelloVerifyRequest is unauthenticated, so without a bound a forged stream of them keeps a client emitting ClientHellos indefinitely.