### PR TITLE
Correct and bound DTLS terminal-flight replay

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -485,9 +485,11 @@ void Channel_Impl_12::activate_session() {
       map_remove_if(not_current_epoch, m_read_cipher_states);
    }
 
-   // In a full handshake the server sends the terminal flight; in an
-   // abbreviated handshake the client does. Both endpoints retain handshake
-   // sequence state, but only the terminal sender replays its outgoing flight.
+   // RFC 6347 4.2.4: "the node that transmits the last flight (the server in an
+   // ordinary handshake or the client in a resumed handshake) MUST respond to a
+   // retransmit of the peer's last flight with a retransmit of the last
+   // flight." Both endpoints retain handshake sequence state, but only that
+   // node replays its outgoing flight.
    const bool sent_terminal_dtls_flight = m_is_datagram && (m_is_server == (state.server_hello_done() != nullptr));
 
    if(m_is_datagram) {

--- a/src/lib/tls/tls12/tls_connection_state_12.h
+++ b/src/lib/tls/tls12/tls_connection_state_12.h
@@ -82,8 +82,6 @@ class Active_Connection_State_12 final {
        */
       Datagram_Handshake_IO* dtls_handshake_io() { return m_dtls_handshake_io.get(); }
 
-      const Datagram_Handshake_IO* dtls_handshake_io() const { return m_dtls_handshake_io.get(); }
-
    private:
       Protocol_Version m_version;
       uint16_t m_ciphersuite_code = 0;

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -22,6 +22,10 @@ namespace {
 
 constexpr size_t DTLS_HANDSHAKE_HEADER_SIZE = 12;
 
+// Bound on peer-cued flight replays when the policy leaves the timer's own retransmission
+// count unlimited. Matches the default value of Policy::dtls_maximum_retransmissions.
+constexpr size_t DEFAULT_PEER_REPLAY_BUDGET = 12;
+
 inline size_t load_be24(const uint8_t q[3]) {
    return make_uint32(0, q[0], q[1], q[2]);
 }
@@ -210,12 +214,58 @@ Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
    return Protocol_Version::DTLS_V12;
 }
 
-void Datagram_Handshake_IO::retransmit_last_flight() {
+std::optional<size_t> Datagram_Handshake_IO::last_completed_flight_index() const {
    // m_flights keeps an empty trailing slot while waiting for the peer, so the
    // last completed flight is normally the one before it.
    const size_t flight_idx = (m_flights.size() == 1) ? 0 : (m_flights.size() - 2);
-   retransmit_flight(flight_idx);
-   m_last_write = m_steady_clock_ms();
+
+   // A peer can ask us to replay a flight before we have sent one, eg
+   // with a ClientHello whose message_seq is past the reassembly
+   // window. In that case there is nothing to retransmit.
+   if(m_flights[flight_idx].empty()) {
+      return std::nullopt;
+   }
+
+   return flight_idx;
+}
+
+void Datagram_Handshake_IO::retransmit_last_flight() {
+   if(const auto flight_idx = last_completed_flight_index()) {
+      retransmit_flight(*flight_idx);
+      m_last_write = m_steady_clock_ms();
+   }
+}
+
+/*
+* RFC 6347 4.2.4 gives the WAITING state a "read retransmit" transition that
+* replays our flight when the peer retransmits theirs.
+*
+* The cue for it is unauthenticated epoch-zero data, so this deliberately is not
+* retransmit_last_flight(). Re-anchoring m_last_write the way that does means a
+* peer cueing faster than the timeout keeps next_retransmission_timeout() from
+* ever expiring, so m_retransmit_count never advances and the handshake never
+* gives up; and unbounded, each cue draws a whole flight toward whatever address
+* the cue claims to come from.
+*
+* Spending the timer's own budget, reset by the same forward progress, caps a
+* continuously cueing peer at doubling the flight traffic the handshake would
+* emit anyway. Counting rather than rate limiting answers a legitimate peer's
+* retransmit promptly, which BoGo's DTLS-Retransmit-Client-Basic requires.
+*/
+void Datagram_Handshake_IO::replay_last_flight_for_peer() {
+   // An unset m_max_retransmissions means "retransmit on my own timer forever",
+   // which is a different proposition from "replay whenever an unauthenticated
+   // packet asks me to". This path is never unbounded, whatever the policy.
+   const size_t bound = m_max_retransmissions.value_or(DEFAULT_PEER_REPLAY_BUDGET);
+
+   if(m_peer_replay_count >= bound) {
+      return;
+   }
+
+   if(const auto flight_idx = last_completed_flight_index()) {
+      m_peer_replay_count += 1;
+      retransmit_flight(*flight_idx);
+   }
 }
 
 void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx) {
@@ -244,10 +294,6 @@ void Datagram_Handshake_IO::retransmit_flight(size_t flight_idx) {
 }
 
 bool Datagram_Handshake_IO::have_more_data() const {
-   if(m_retransmitted_client_hello.has_value() && m_retransmitted_client_hello->second.complete()) {
-      return true;
-   }
-
    // Future or incomplete fragments remain buffered, but only a complete
    // next-in-sequence message is trailing handshake data.
    const auto next = m_messages.find(m_in_message_seq);
@@ -263,8 +309,9 @@ void Datagram_Handshake_IO::finalize_handshake(bool retransmit_terminal_flight) 
       m_flight_ccs.emplace_back();
    }
 
-   // RFC 6347 4.2.4 transitions directly to FINISHED after sending the
-   // terminal flight. Keep the flight for reactive replay when the peer
+   // RFC 6347 4.2.4: "Once the messages have been sent, the implementation
+   // then enters the FINISHED state if this is the last flight in the
+   // handshake." Keep the flight for reactive replay when the peer
    // retransmits, but do not arm a proactive retransmission timer.
    m_finished = true;
    m_retransmit_terminal_flight = retransmit_terminal_flight;
@@ -439,39 +486,41 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
          return false;
       }
 
+      // RFC 6347 4.2.4 makes the terminal-flight sender "respond to a retransmit
+      // of the peer's last flight with a retransmit of the last flight". Once our
+      // handshake has completed, the peer's last flight is the one ending in its
+      // Finished, never a ClientHello.
+      if(m_finished) {
+         return false;
+      }
+
       return reassemble_retransmitted_fragment(
          fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq);
    }
 
-   // Other previous-flight messages request an immediate response only after
-   // the handshake IO was retained by an active association. While pending,
-   // the normal retransmission timer handles recovery.
+   // Only an association that has already completed its handshake answers a
+   // retransmitted peer flight here.
+   //
+   // RFC 6347 4.2.4 also gives the WAITING state a "read retransmit" exit that
+   // replays the outgoing flight immediately. Applying that while the handshake
+   // is still pending misfires under fragment reordering: a late duplicate
+   // fragment of an already-consumed message is indistinguishable from a
+   // genuine retransmission, so the peer sees a flight replay it never asked
+   // for (BoGo ReorderHandshakeFragments-Large). Recovery is left to the local
+   // retransmission timer, which costs latency but cannot desynchronise a peer
+   // that was not retransmitting. A retransmitted ClientHello is handled above,
+   // because the stateless cookie response has no timer of its own.
    if(!retransmitted_flight) {
       return false;
    }
 
-   if(msg_type == Handshake_Type::ServerHello) {
-      m_retransmitted_server_hello_complete = reassemble_retransmitted_fragment(
-         fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq);
-
-      if(m_retransmitted_server_hello_complete && m_retransmitted_server_hello_done_complete) {
-         m_retransmitted_server_hello_complete = false;
-         m_retransmitted_server_hello_done_complete = false;
-         return true;
-      }
-   } else if(msg_type == Handshake_Type::ServerHelloDone && msg_length == 0) {
-      if(reassemble_retransmitted_fragment(
-            fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
-         m_retransmitted_server_hello_done_complete = true;
-         if(m_retransmitted_server_hello_complete) {
-            m_retransmitted_server_hello_complete = false;
-            m_retransmitted_server_hello_done_complete = false;
-            return true;
-         }
-      }
-   } else if(msg_type == Handshake_Type::Finished &&
-             reassemble_retransmitted_fragment(
-                fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
+   // A genuine Finished follows a ChangeCipherSpec, so it is authenticated
+   // under a non-zero epoch. An unauthenticated epoch-zero record claiming to
+   // be one is spoofable off-path, and must not clear a ChangeCipherSpec we
+   // have legitimately saved to pair against the real Finished.
+   if(msg_type == Handshake_Type::Finished && epoch > 0 &&
+      reassemble_retransmitted_fragment(
+         fragment, fragment_length, fragment_offset, epoch, msg_type, msg_length, message_seq)) {
       // A final-flight retransmission includes CCS, but UDP may deliver its
       // records in either order. Wait until both have been observed.
       if(m_retransmitted_ccs_epoch == epoch) {
@@ -479,6 +528,10 @@ bool Datagram_Handshake_IO::process_previous_handshake_fragment(const uint8_t fr
          return true;
       }
 
+      // Only the matching pair means anything, so a half seen for some other
+      // epoch is stale. Leaving it set would keep this armed indefinitely for an
+      // epoch an attacker chose, since epoch-zero CCS records are unauthenticated.
+      m_retransmitted_ccs_epoch.reset();
       m_retransmitted_finished_epoch = epoch;
    }
 
@@ -491,6 +544,21 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
                                        uint64_t record_sequence,
                                        bool retransmitted_flight) {
    const uint16_t epoch = static_cast<uint16_t>(record_sequence >> 48);
+
+   // A record under a non-zero epoch authenticated at the record layer, so the
+   // peer is live and is who it claims to be. Restore the peer-cued replay
+   // budget: RFC 6347 4.2.4 requires the terminal-flight sender to answer a
+   // retransmit of the peer's last flight for as long as the association lasts,
+   // and the retained IO never sends a new flight to reset the count otherwise.
+   //
+   // Only once our handshake has finished, though. While it is still pending,
+   // forward progress already resets the count in send_under_epoch, so
+   // restoring it here as well would let a peer alternate a cheap out-of-window
+   // protected record with an epoch-zero cue to draw the pending flight without
+   // bound.
+   if(epoch > 0 && m_finished) {
+      m_peer_replay_count = 0;
+   }
 
    if(record_type == Record_Type::ChangeCipherSpec) {
       if(record_len != 1 || record[0] != 1) {
@@ -507,9 +575,10 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
          if(m_retransmitted_finished_epoch == finished_epoch) {
             m_retransmitted_finished_epoch.reset();
             if(m_retransmit_terminal_flight) {
-               retransmit_last_flight();
+               replay_last_flight_for_peer();
             }
          } else {
+            m_retransmitted_finished_epoch.reset();
             m_retransmitted_ccs_epoch = finished_epoch;
          }
       }
@@ -614,7 +683,7 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
    }
 
    if(retransmit_response && (!m_finished || m_retransmit_terminal_flight)) {
-      retransmit_last_flight();
+      replay_last_flight_for_peer();
    }
 }
 
@@ -797,7 +866,7 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
    }
 
    m_flights.rbegin()->push_back(m_out_message_seq);
-   m_flight_data.emplace(m_out_message_seq, Message_Info(epoch, msg_type, msg_bits));
+   m_flight_data.insert_or_assign(m_out_message_seq, Message_Info(epoch, msg_type, msg_bits));
 
    m_out_message_seq += 1;
    m_last_write = m_steady_clock_ms();
@@ -805,6 +874,7 @@ std::vector<uint8_t> Datagram_Handshake_IO::send_under_epoch(const Handshake_Mes
    // Sending a new flight is forward progress: reset the give-up counter so the
    // retransmission budget applies per flight, not across the whole handshake.
    m_retransmit_count = 0;
+   m_peer_replay_count = 0;
 
    return send_message(m_out_message_seq - 1, epoch, msg_type, msg_bits);
 }

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -205,6 +205,11 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
 
       void retransmit_flight(size_t flight);
       void retransmit_last_flight();
+      void replay_last_flight_for_peer();
+
+      // Index of the last completed outgoing flight, or nullopt when no
+      // flight has been sent yet.
+      std::optional<size_t> last_completed_flight_index() const;
 
       std::vector<uint8_t> format_fragment(const uint8_t fragment[],
                                            size_t fragment_len,
@@ -290,8 +295,6 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       std::optional<uint16_t> m_retransmitted_ccs_epoch;
       std::optional<uint16_t> m_retransmitted_finished_epoch;
       std::map<Handshake_Type, std::pair<uint16_t, Handshake_Reassembly>> m_retransmitted_messages;
-      bool m_retransmitted_server_hello_complete = false;
-      bool m_retransmitted_server_hello_done_complete = false;
       std::vector<std::vector<uint16_t>> m_flights;
       // Each entry records where in the corresponding flight a CCS was sent
       // and the epoch under which it was transmitted.
@@ -318,6 +321,11 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // A caller's clock may legitimately read zero, so the absence of a write
       // cannot be spelled as a reserved timestamp.
       std::optional<uint64_t> m_last_write;
+
+      // Flight replays the peer has cued since the current flight was sent.
+      // Kept apart from the timer's own budget because the cue for it is
+      // unauthenticated. See replay_last_flight_for_peer.
+      size_t m_peer_replay_count = 0;
 
       uint64_t m_next_timeout = 0;
 

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -1608,14 +1608,23 @@ class DTLS_Core_Regression_Tests final : public Test {
          // A delayed retransmission of the cookie-bearing ClientHello has
          // message_seq 1. It belongs to the completed handshake, whereas a
          // genuinely new association starts at message_seq 0.
+         //
+         // It draws no response. Once the server has completed, the peer's last
+         // flight is the one ending in its Finished, so a peer still
+         // retransmitting a ClientHello cannot be asking for the final flight.
+         // Answering would also let a replayed epoch-zero record pull a flight
+         // out of the server without limit.
          deliver_copy(result, "stale client hello 2", cookie_client_hello, server);
          result.test_is_true("server remains active", server.is_active());
-         result.test_is_true("stale ClientHello replays the final server flight", !s2c.empty());
-         s2c.clear();
+         result.test_is_true("stale ClientHello draws no response", s2c.empty());
 
+         // Recovery still works: the client's own retransmitted final flight is
+         // what asks for the server's final flight, and it is authenticated.
          fire_retransmission_timer(result, *assoc->client_cb, client, c2s);
          deliver(result, "retransmitted client final flight", c2s, server);
          result.test_is_true("client final flight still receives a response", !s2c.empty());
+         deliver(result, "server final flight", s2c, client);
+         result.test_is_true("client became active", client.is_active());
 
          return result;
       }

--- a/src/tests/test_tls_handshake_io.cpp
+++ b/src/tests/test_tls_handshake_io.cpp
@@ -78,6 +78,19 @@ class Datagram_IO_Fixture {
          m_io.add_record(record.data(), record.size(), Record_Type::Handshake, record_seq);
       }
 
+      // Retransmitted-flight variants reach the terminal-flight replay path a
+      // finished association uses to answer a peer's retransmitted last flight.
+      void feed_retransmitted(std::span<const uint8_t> record, uint16_t epoch = 0) {
+         const uint64_t record_seq = static_cast<uint64_t>(epoch) << 48;
+         m_io.add_retransmitted_record(record.data(), record.size(), Record_Type::Handshake, record_seq);
+      }
+
+      void feed_ccs_retransmitted(uint16_t epoch) {
+         const uint64_t record_seq = static_cast<uint64_t>(epoch) << 48;
+         const uint8_t ccs = 1;
+         m_io.add_retransmitted_record(&ccs, 1, Record_Type::ChangeCipherSpec, record_seq);
+      }
+
       std::pair<Handshake_Type, std::vector<uint8_t>> next_message() {
          return m_io.get_next_record(false, k_max_handshake_msg_size);
       }
@@ -607,6 +620,52 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                                   [&] { fix.io().timeout_check(); });
             }),
 
+      // An unset dtls_maximum_retransmissions() means "retransmit on my own
+      // timer forever", which is a different proposition from "replay whenever an
+      // unauthenticated packet asks me to". The peer-cued budget must stay
+      // bounded whatever the timer policy says.
+      CHECK("peer-cued replays stay bounded when the timer budget is unlimited",
+            [&](Test::Result& result) {
+               constexpr std::optional<size_t> unlimited = std::nullopt;
+               Datagram_IO_Fixture fix(1000, 60000, unlimited);
+
+               fix.advance_clock_ms(1);
+               const auto real_ch = dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64));
+               fix.feed(real_ch);
+               result.test_is_true("priming ClientHello delivered",
+                                   fix.next_message().first == Handshake_Type::ClientHello);
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.reset_send_counter();
+
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               for(int i = 0; i < 200; ++i) {
+                  fix.feed(cue);
+               }
+
+               // With no timer budget to spend, the replay bound falls back to the
+               // policy default rather than becoming unlimited.
+               const size_t fallback_budget = Botan::TLS::Policy().dtls_maximum_retransmissions().value();
+               result.test_sz_eq(
+                  "replays bounded despite the unlimited timer", fix.handshake_records_sent(), fallback_budget);
+
+               // While the handshake is still pending, an out-of-window
+               // protected record is not forward progress and must not restore
+               // the budget: otherwise a peer could alternate one with an
+               // epoch-zero cue to draw the flight without bound. Genuine
+               // progress resets the count through send_under_epoch instead.
+               const auto out_of_window = dtls_hs_record(Handshake_Type::Certificate, 4, 1000, 0, make_payload(4));
+               fix.feed(out_of_window, 1);
+               fix.reset_send_counter();
+
+               fix.feed(cue);
+               result.test_sz_eq("an out-of-window protected record does not restore the pending budget",
+                                 fix.handshake_records_sent(),
+                                 size_t(0));
+            }),
+
       // message_seq is 16 bits, and no legitimate handshake delivers 65536
       // messages. Once the counter wraps all further handshake input is
       // refused: a fresh message at a wrapped sequence number must not be
@@ -643,6 +702,148 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                   const uint16_t msg_seq = (static_cast<uint16_t>(formatted[4]) << 8) | formatted[5];
                   result.test_sz_eq("it names the wrapped sequence number", msg_seq, size_t(0xFFFF));
                }
+            }),
+
+      // RFC 6347 4.2.4 has us replay our flight when the peer retransmits
+      // theirs, but the cue is unauthenticated epoch-zero data, so it must not
+      // be able to draw out a flight per datagram.
+      CHECK("peer-cued flight replays are bounded",
+            [&](Test::Result& result) {
+               constexpr uint64_t initial_timeout = 1000;
+               constexpr size_t max_replays = 3;
+               Datagram_IO_Fixture fix(initial_timeout, 60000, max_replays);
+
+               fix.advance_clock_ms(1);
+
+               // Deliver and consume a ClientHello so a msg_seq 0 record is
+               // afterwards a fragment of a previous message, then send a flight.
+               const auto real_ch = dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64));
+               fix.feed(real_ch);
+               result.test_is_true("priming ClientHello delivered",
+                                   fix.next_message().first == Handshake_Type::ClientHello);
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.reset_send_counter();
+
+               // The cue: a bare ClientHello whose body is never parsed.
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               // A legitimate peer's retransmit is answered at once, up to the
+               // per-flight budget. Past it the cues draw nothing.
+               for(size_t i = 0; i < max_replays; ++i) {
+                  fix.feed(cue);
+               }
+               result.test_sz_eq(
+                  "cues within the budget each replay the flight", fix.handshake_records_sent(), max_replays);
+
+               fix.reset_send_counter();
+               for(int i = 0; i < 20; ++i) {
+                  fix.feed(cue);
+               }
+               result.test_sz_eq("cues past the budget draw nothing", fix.handshake_records_sent(), size_t(0));
+
+               // Forward progress restores it, as it does for the timer. The
+               // flight now holds two messages, so a replay emits two records.
+               const Stub_Handshake_Message next(Handshake_Type::Certificate, std::vector<uint8_t>(64, 0x33));
+               fix.io().send(next);
+               fix.reset_send_counter();
+               fix.feed(cue);
+               result.test_sz_eq("a new flight restores the replay budget", fix.handshake_records_sent(), size_t(2));
+            }),
+
+      // A peer cueing faster than the timeout must not re-anchor the timer:
+      // that keeps it from ever expiring, so the handshake never gives up.
+      CHECK("peer cues do not hold off the give-up timer",
+            [&](Test::Result& result) {
+               constexpr uint64_t initial_timeout = 1000;
+               Datagram_IO_Fixture fix(initial_timeout, 60000, 3);
+
+               fix.advance_clock_ms(1);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64)));
+               fix.next_message();
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x22));
+               fix.io().send(sh);
+
+               const auto cue = dtls_hs_record(Handshake_Type::ClientHello, 42, 0, 0, std::vector<uint8_t>(42, 0x00));
+
+               bool gave_up = false;
+               for(int i = 0; i < 200 && !gave_up; ++i) {
+                  fix.advance_clock_ms(initial_timeout - 100);
+                  fix.feed(cue);
+                  try {
+                     fix.io().timeout_check();
+                  } catch(const Botan::TLS::TLS_Exception&) {
+                     gave_up = true;
+                  }
+               }
+               result.test_is_true("the handshake still gives up while being cued", gave_up);
+            }),
+
+      // A finished association sends no new flights, so an authenticated record
+      // is what restores its peer-cued budget. RFC 6347 4.2.4 requires answering
+      // a retransmit of the peer's last flight for as long as the association
+      // lasts, and a genuine retransmit carries the peer's authenticated
+      // Finished, so it keeps being answered past the bare-cue budget.
+      CHECK("a finished association keeps answering authenticated peer retransmits",
+            [&](Test::Result& result) {
+               constexpr size_t max_replays = 2;
+               Datagram_IO_Fixture fix(1000, 60000, max_replays);
+
+               fix.advance_clock_ms(1);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64)));
+               fix.next_message();
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.io().finalize_handshake(true);
+               fix.reset_send_counter();
+
+               // A genuine terminal-flight retransmit is a ChangeCipherSpec under
+               // the old epoch plus an authenticated Finished under the new one.
+               const auto finished = dtls_hs_record(Handshake_Type::Finished, 12, 0, 0, std::vector<uint8_t>(12, 0x00));
+
+               for(int i = 0; i < 4 * static_cast<int>(max_replays); ++i) {
+                  fix.reset_send_counter();
+                  fix.feed_ccs_retransmitted(0);
+                  fix.feed_retransmitted(finished, 1);
+                  result.test_sz_eq(
+                     "each authenticated retransmit is answered", fix.handshake_records_sent(), size_t(1));
+               }
+            }),
+
+      // The final-flight cue pairs an unauthenticated ChangeCipherSpec with the
+      // peer's authenticated Finished. A spoofed epoch-zero Finished must not be
+      // able to discard a legitimately saved ChangeCipherSpec and suppress the
+      // recovery the genuine Finished would otherwise complete.
+      CHECK("an unauthenticated epoch-zero Finished does not clear a saved CCS",
+            [&](Test::Result& result) {
+               Datagram_IO_Fixture fix(1000, 60000, 12);
+
+               fix.advance_clock_ms(1);
+               fix.feed(dtls_hs_record(Handshake_Type::ClientHello, 64, 0, 0, make_payload(64)));
+               fix.next_message();
+
+               const Stub_Handshake_Message sh(Handshake_Type::ServerHello, std::vector<uint8_t>(64, 0x11));
+               fix.io().send(sh);
+               fix.io().finalize_handshake(true);
+               fix.reset_send_counter();
+
+               // The genuine ChangeCipherSpec of the peer's retransmit arrives.
+               fix.feed_ccs_retransmitted(0);
+
+               // A spoofed epoch-zero Finished is discarded rather than clearing
+               // the saved ChangeCipherSpec.
+               const auto forged = dtls_hs_record(Handshake_Type::Finished, 12, 0, 0, std::vector<uint8_t>(12, 0x00));
+               fix.feed_retransmitted(forged, 0);
+               result.test_sz_eq("the spoofed Finished draws nothing", fix.handshake_records_sent(), size_t(0));
+
+               // The genuine authenticated Finished still completes the pair.
+               const auto real = dtls_hs_record(Handshake_Type::Finished, 12, 0, 0, std::vector<uint8_t>(12, 0x11));
+               fix.feed_retransmitted(real, 1);
+               result.test_sz_eq(
+                  "the authenticated Finished completes recovery", fix.handshake_records_sent(), size_t(1));
             }),
 
       // A caller's monotonic clock may legitimately read zero, so sending the
@@ -727,7 +928,6 @@ std::vector<Test::Result> dtls12_handshake_io_tests() {
                seqs.new_read_cipher_state();  // epoch 3
                result.test_is_true("window released two rekeys later", !seqs.already_seen(epoch1_seq));
             }),
-
    };
 }
 


### PR DESCRIPTION
In DTLS a peer must handle the case where their final flight is lost; this situation is detected when the peer retransmits their previous flight. Previously this reactive replay was both mis-triggered and unbounded.

Previously the replay was completely reactive; a quickly repeated retransmission kept resetting the send timer which would cause indefinite flight replays. Now a replay that was in response to a retransmit is accounted against a budget.

In addition, fix a bug where a flight replay could be instigated by a ClientHello even after the handshake had progressed. Once we've already received a client's Finished message, they clearly have seen the server's first flight and there is no reason to replay it.

Extracted from #5783 