### PR TITLE
In DTLS distinguish a delayed or replayed handshake message from a current one

### DIFF
--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -237,7 +237,7 @@ std::optional<std::string> Channel_Impl_12::external_psk_identity() const {
    return std::nullopt;
 }
 
-Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version version) {
+Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version version, bool epoch0_restart) {
    if(pending_state() != nullptr) {
       throw Internal_Error("create_handshake_state called during handshake");
    }
@@ -267,6 +267,16 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
    m_epochs_before_latest_renegotiation = Epochs_Before_Latest_Renegotiation{sequence_numbers().current_read_epoch(),
                                                                              sequence_numbers().current_write_epoch()};
 
+   // Floor for the pending handshake's reassembly: a delayed record from the
+   // handshake arrives under a lower epoch and must be rejected. It would
+   // otherwise take the sequence slot the real message needs.
+   //
+   // Zero on an epoch-zero restart, because there the peer legitimately
+   // begins again at epoch zero and the floor would reject it. This is keyed
+   // on the restart actually occurring, not on the policy allowing it: an
+   // ordinary renegotiation needs the floor either way.
+   const uint16_t initial_epoch = epoch0_restart ? 0 : m_epochs_before_latest_renegotiation->read_epoch;
+
    using namespace std::placeholders;
 
    std::unique_ptr<Handshake_IO> io;
@@ -287,7 +297,8 @@ Handshake_State& Channel_Impl_12::create_handshake_state(Protocol_Version versio
                                                    initial_timeout_ms,
                                                    max_timeout_ms,
                                                    max_retransmissions,
-                                                   policy().maximum_handshake_message_size());
+                                                   policy().maximum_handshake_message_size(),
+                                                   initial_epoch);
    } else {
       auto send_record_f = [this](Record_Type rec_type, const std::vector<uint8_t>& record) {
          send_record(rec_type, record);
@@ -724,16 +735,16 @@ void Channel_Impl_12::process_handshake_ccs(const secure_vector<uint8_t>& record
                if(m_active_state.has_value() && !starts_new_handshake) {
                   process_retransmitted_record();
                } else {
-                  create_handshake_state(record_version);
+                  create_handshake_state(record_version, epoch0_restart);
                }
             } else if(current_epoch > 0 && epoch == current_epoch - 1) {
                process_retransmitted_record();
             }
          } else {
-            create_handshake_state(record_version);
+            create_handshake_state(record_version, epoch0_restart);
          }
       } else {
-         create_handshake_state(record_version);
+         create_handshake_state(record_version, epoch0_restart);
       }
    }
 

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -158,7 +158,7 @@ class Channel_Impl_12 : public Channel_Impl {
                                          const std::vector<uint8_t>& contents,
                                          bool epoch0_restart) = 0;
 
-      Handshake_State& create_handshake_state(Protocol_Version version);
+      Handshake_State& create_handshake_state(Protocol_Version version, bool epoch0_restart = false);
       virtual std::unique_ptr<Handshake_State> new_handshake_state(std::unique_ptr<Handshake_IO> io) = 0;
 
       void inspect_handshake_message(const Handshake_Message& msg);

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -197,13 +197,16 @@ Datagram_Handshake_IO::Datagram_Handshake_IO(writer_fn writer,
                                              uint64_t initial_timeout_ms,
                                              uint64_t max_timeout_ms,
                                              std::optional<size_t> max_retransmissions,
-                                             size_t max_handshake_msg_size) :
+                                             size_t max_handshake_msg_size,
+                                             uint16_t initial_epoch) :
       m_seqs(seq),
       m_flights(1),
       m_flight_ccs(1),
       m_initial_timeout(initial_timeout_ms),
       m_max_timeout(max_timeout_ms),
       m_max_retransmissions(max_retransmissions),
+      m_initial_epoch(initial_epoch),
+      m_last_delivered_epoch(initial_epoch),
       m_send_hs(std::move(writer)),
       m_steady_clock_ms(std::move(steady_clock_ms)),
       m_mtu(mtu),
@@ -626,6 +629,36 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
             continue;
          }
 
+         // Epochs never decrease within a handshake, so a fragment carrying an
+         // older epoch belongs to an earlier handshake whose records were
+         // delayed into this one. Renegotiation restarts message_seq at zero,
+         // so without this such a record can occupy a slot the current
+         // handshake still needs.
+         if(epoch < m_last_delivered_epoch) {
+            record += total_size;
+            record_len -= total_size;
+            continue;
+         }
+
+         /*
+         RFC 6347 4.2.2 keeps message_seq across a retransmission but gives the
+         record a new sequence number, and a rehandshake restarts message_seq at
+         zero. A delayed Finished from the previous handshake therefore arrives
+         with a plausible sequence number and, before this handshake's own
+         ChangeCipherSpec, the same epoch as its pre-CCS records, so neither the
+         sequence nor the epoch floor tells it apart. It cannot be genuine
+         though: a Finished is sent under the epoch its own ChangeCipherSpec
+         installed, which is always above the one this handshake began in.
+
+         Left in, it takes the slot the real Finished needs, and a complete slot
+         is never replaced, so verification fails against the wrong transcript.
+         */
+         if(msg_type == Handshake_Type::Finished && epoch <= m_initial_epoch) {
+            record += total_size;
+            record_len -= total_size;
+            continue;
+         }
+
          if(retransmitted_flight) {
             if(fragment_length == 0) {
                record += total_size;
@@ -687,6 +720,17 @@ void Datagram_Handshake_IO::add_record(const uint8_t record[],
    }
 }
 
+void Datagram_Handshake_IO::discard_stale_epoch_messages() {
+   for(auto i = m_messages.lower_bound(m_in_message_seq); i != m_messages.end();) {
+      if(i->second.epoch() < m_last_delivered_epoch) {
+         release_reassembly_bytes(i->second);
+         i = m_messages.erase(i);
+      } else {
+         ++i;
+      }
+   }
+}
+
 std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_record(bool expecting_ccs,
                                                                                        size_t /*max_message_size*/) {
    // Expecting a message means the last flight is concluded
@@ -733,8 +777,15 @@ std::pair<Handshake_Type, std::vector<uint8_t>> Datagram_Handshake_IO::get_next_
       m_awaiting_cookie_client_hello = false;
    }
 
+   const uint16_t delivered_epoch = i->second.epoch();
+
    release_reassembly_bytes(i->second);
    m_messages.erase(i);
+
+   if(delivered_epoch > m_last_delivered_epoch) {
+      m_last_delivered_epoch = delivered_epoch;
+      discard_stale_epoch_messages();
+   }
 
    return result;
 }

--- a/src/lib/tls/tls12/tls_handshake_io.h
+++ b/src/lib/tls/tls12/tls_handshake_io.h
@@ -139,7 +139,8 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                             uint64_t initial_timeout_ms,
                             uint64_t max_timeout_ms,
                             std::optional<size_t> max_retransmissions,
-                            size_t max_handshake_msg_size);
+                            size_t max_handshake_msg_size,
+                            uint16_t initial_epoch = 0);
 
       Protocol_Version initial_record_version() const override;
 
@@ -202,6 +203,10 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
                                                size_t msg_length,
                                                uint16_t message_seq,
                                                bool retransmitted_flight);
+
+      // Drop buffered messages left over from an earlier handshake, identified
+      // by an epoch below the most recently delivered one.
+      void discard_stale_epoch_messages();
 
       void retransmit_flight(size_t flight);
       void retransmit_last_flight();
@@ -340,6 +345,14 @@ class BOTAN_TEST_API Datagram_Handshake_IO final : public Handshake_IO {
       // Set once m_in_message_seq wraps, after which all handshake input is
       // refused; see process_handshake_fragment.
       bool m_in_message_seq_wrapped = false;
+
+      // Epoch in force when this handshake began. Records from the previous one
+      // sit at or below it, and a Finished has to sit above it.
+      uint16_t m_initial_epoch;
+
+      // Epoch of the most recently delivered incoming handshake message. Used
+      // to reject records held over from a previous handshake.
+      uint16_t m_last_delivered_epoch = 0;
 
       writer_fn m_send_hs;
       steady_clock_fn m_steady_clock_ms;

--- a/src/tests/test_dtls12.cpp
+++ b/src/tests/test_dtls12.cpp
@@ -149,6 +149,7 @@ struct DTLS_Policy_Options final {
       std::optional<size_t> max_retransmissions;
       std::optional<std::string> cipher;
       bool allow_epoch0_restart = true;
+      bool require_cookie_exchange = true;
       bool reuse_session_tickets = false;
       size_t initial_timeout_ms = 1;
       size_t maximum_timeout_ms = 8;
@@ -186,6 +187,8 @@ class DTLS_PSK_Policy final : public Botan::TLS::Policy {
 
       bool allow_dtls_epoch0_restart() const override { return m_opts.allow_epoch0_restart; }
 
+      bool dtls_server_require_cookie_exchange() const override { return m_opts.require_cookie_exchange; }
+
       bool allow_server_initiated_renegotiation() const override { return true; }
 
       bool allow_client_initiated_renegotiation() const override { return true; }
@@ -214,6 +217,14 @@ std::shared_ptr<DTLS_PSK_Policy> dtls_policy_with_max_retransmissions(size_t lim
 std::shared_ptr<DTLS_PSK_Policy> dtls_policy_without_epoch0_restart() {
    DTLS_Policy_Options opts;
    opts.allow_epoch0_restart = false;
+   return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
+}
+
+// Without the cookie exchange the client's flight carries the same message
+// sequence numbers in the initial handshake as in a renegotiation.
+std::shared_ptr<DTLS_PSK_Policy> dtls_policy_without_cookie_exchange() {
+   DTLS_Policy_Options opts;
+   opts.require_cookie_exchange = false;
    return std::make_shared<DTLS_PSK_Policy>(std::move(opts));
 }
 
@@ -2208,6 +2219,144 @@ class DTLS_Reconnection_Test : public Test {
 };
 
 BOTAN_REGISTER_TEST("tls", "tls_dtls_reconnect", DTLS_Reconnection_Test);
+
+// End-to-end coverage for DTLS 1.2 renegotiation in both directions. RFC 6347
+// 4.2.2 restarts msg_seq at 0 for each handshake, so the message that opens a
+// renegotiation looks like a stray retransmit to a naive sequence check.
+//
+// BoGo does not exercise DTLS renegotiation at all (BoringSSL itself does not
+// support it), so this test is the only regression coverage.
+class DTLS_Renegotiation_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         std::vector<Test::Result> results;
+         results.push_back(run_one("client-initiated", false));
+         results.push_back(run_one("server-initiated", true));
+         return results;
+      }
+
+   private:
+      Test::Result run_one(const std::string& subtest, bool server_initiates) {
+         Test::Result result("DTLS renegotiation: " + subtest);
+
+         auto rng = Test::new_shared_rng(this->test_name() + "/" + subtest);
+         auto assoc = make_association(result, rng);
+
+         const auto sessions_established = [&](size_t n) {
+            return assoc->client_cb->sessions_established() == n && assoc->server_cb->sessions_established() == n &&
+                   assoc->both_active();
+         };
+
+         result.test_is_true("initial DTLS handshake completed",
+                             assoc->pump_until([&] { return sessions_established(1); }));
+
+         // App data must flow before and after the renegotiation, under each
+         // set of keys in turn.
+         const std::vector<uint8_t> ping(8, 0xAA);
+         const std::vector<uint8_t> pong(8, 0x55);
+
+         const auto exchange_app_data = [&](const std::string& label) {
+            assoc->server_recv.clear();
+            assoc->client_recv.clear();
+            assoc->client->send(ping);
+            assoc->server->send(pong);
+            result.test_is_true(
+               label, assoc->pump_until([&] { return assoc->server_recv == ping && assoc->client_recv == pong; }));
+         };
+
+         exchange_app_data("app data exchanged before renegotiation");
+
+         // If the receiver drops the initiator because msg_seq is below the
+         // active handshake's, this pump exhausts its rounds with one session.
+         if(server_initiates) {
+            assoc->server->renegotiate();
+         } else {
+            assoc->client->renegotiate();
+         }
+         result.test_is_true("renegotiation completed", assoc->pump_until([&] { return sessions_established(2); }));
+
+         exchange_app_data("app data exchanged after renegotiation");
+
+         return result;
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_renegotiate", DTLS_Renegotiation_Test);
+
+// A delayed datagram carrying the previous handshake's client Finished must
+// not stall a renegotiation, even on a server whose policy permits epoch-zero
+// restarts. The reassembly floor that rejects it is keyed on a restart
+// actually occurring; policy-keyed, the floor would be zero here and the old
+// Finished would occupy the slot the renegotiation's real Finished needs.
+class DTLS_Renegotiation_Delayed_Finished_Test : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("DTLS renegotiation with delayed Finished from previous handshake");
+
+         auto rng = Test::new_shared_rng(this->test_name());
+
+         // Without the cookie exchange, both handshakes number the client's
+         // messages identically: ClientHello 0, ClientKeyExchange 1,
+         // Finished 2. The delayed Finished then lands exactly on the slot
+         // the renegotiation's own Finished needs.
+         auto assoc = make_association(result, rng, dtls_policy_without_cookie_exchange());
+
+         deliver(result, "client hello", assoc->c2s, *assoc->server);
+         deliver(result, "server handshake flight", assoc->s2c, *assoc->client);
+         deliver(result, "client final flight", assoc->c2s, *assoc->server);
+
+         if(!result.test_is_true("server is active", assoc->server->is_active())) {
+            return {result};
+         }
+
+         // Withhold the server's final flight so the client retransmits its
+         // own final flight (ClientKeyExchange, CCS, Finished) under fresh
+         // record sequence numbers. Held aside, the retransmission is a
+         // genuinely delayed datagram the replay window has never seen.
+         const auto timeout = assoc->client->next_retransmission_timeout();
+         if(!result.test_is_true("client retransmission timer is armed", timeout.has_value())) {
+            return {result};
+         }
+         assoc->client_cb->advance_clock_ms(static_cast<uint64_t>(timeout->count()));
+         result.test_is_true("client retransmitted its final flight", assoc->client->timeout_check());
+
+         std::vector<uint8_t> delayed_flight;
+         std::swap(delayed_flight, assoc->c2s);
+         if(!result.test_is_true("delayed flight captured", !delayed_flight.empty())) {
+            return {result};
+         }
+
+         deliver(result, "server final flight", assoc->s2c, *assoc->client);
+         result.test_is_true("initial handshake completed", assoc->both_active());
+
+         // Full renegotiation, so that the client's flight repeats the
+         // initial handshake's numbering; an abbreviated one has no
+         // ClientKeyExchange and numbers its Finished differently. The
+         // delayed flight has to arrive after the server has created its
+         // pending handshake, which is what sets the reassembly floor.
+         assoc->client->renegotiate(true /* force full renegotiation */);
+         deliver(result, "renegotiation client hello", assoc->c2s, *assoc->server);
+
+         deliver_copy(result, "delayed flight mid-renegotiation", delayed_flight, *assoc->server);
+
+         const auto sessions_established = [&](size_t n) {
+            return assoc->client_cb->sessions_established() == n && assoc->server_cb->sessions_established() == n &&
+                   assoc->both_active();
+         };
+         result.test_is_true("renegotiation completed", assoc->pump_until([&] { return sessions_established(2); }));
+         result.test_is_true("renegotiation was a full handshake",
+                             assoc->server_cb->session_was_resumption() == std::optional<bool>(false));
+
+         const std::vector<uint8_t> ping(8, 0xAA);
+         assoc->client->send(ping);
+         result.test_is_true("app data flows after renegotiation",
+                             assoc->pump_until([&] { return assoc->server_recv == ping; }));
+
+         return {result};
+      }
+};
+
+BOTAN_REGISTER_TEST("tls", "tls_dtls_renegotiate_delayed_finished", DTLS_Renegotiation_Delayed_Finished_Test);
 
 // One unauthenticated epoch-0 record, from anyone able to target the
 // connection's 5-tuple, must not be able to end an established association.


### PR DESCRIPTION
A new DTLS handshake restarts the message_seq field, but the epoch remains the same (and increments once the CCS is processed). During a DTLS renegotiation, a packet retransmit from the first handshake would take up a reassembly slot, which would block the real message from completing and stall the handshake.

A fragment whose epoch is below the most recently delivered one is now recognized as belonging to an earlier handshake and dropped. A delayed Finished needs a further check. A genuine Finished is sent under the epoch its own ChangeCipherSpec installed, always above the epoch the handshake began in, so one at or below the current epoch cannot be genuine and is now discarded. Messages left buffered from a superseded epoch are also dropped once a later epoch is delivered.

Extracted from #5783 