### PR TITLE
Treat empty AutoSeeded_RNG requests as no-ops

### DIFF
--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -104,7 +104,9 @@ size_t AutoSeeded_RNG::reseed_from_sources(Entropy_Sources& srcs, size_t poll_bi
 }
 
 void AutoSeeded_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) {
-   if(in.empty()) {
+   if(out.empty() && in.empty()) {
+      return;
+   } else if(in.empty()) {
       m_rng->randomize_with_ts_input(out);
    } else {
       m_rng->randomize_with_input(out, in);

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -750,6 +750,21 @@ class AutoSeeded_RNG_Tests final : public Test {
          rng.random_vec(16);  // generate and discard output
          result.test_is_true("AutoSeeded_RNG can be reseeded", rng.is_seeded());
 
+         Request_Counting_RNG counting_rng;
+         Botan::AutoSeeded_RNG counted_rng(counting_rng);
+         const size_t initial_reseed_count = counting_rng.randomize_count();
+
+         counted_rng.clear();
+         counted_rng.randomize(std::span<uint8_t>{});
+         result.test_is_false("Empty output does not seed AutoSeeded_RNG", counted_rng.is_seeded());
+         result.test_sz_eq(
+            "Empty output does not invoke underlying RNG", counting_rng.randomize_count(), initial_reseed_count);
+
+         counted_rng.random_vec(1);
+         result.test_is_true("Nonempty output reseeds AutoSeeded_RNG", counted_rng.is_seeded());
+         result.test_sz_eq(
+            "Nonempty output invokes underlying RNG", counting_rng.randomize_count(), initial_reseed_count + 1);
+
          for(size_t i = 0; i != 4096; ++i) {
             std::vector<uint8_t> buf(i);
             rng.randomize(buf.data(), buf.size());


### PR DESCRIPTION
## Summary

- Return immediately when both the output and additional-input spans are empty.
- Preserve the current behavior for nonempty output and explicit additional input.
- Add an `auto_rng_unit` regression test for empty requests and the following reseed.

## Testing

- `./botan-test auto_rng_unit`
