### PR TITLE
In TLS 1.2 session summaries, report the pending PSK identity

### DIFF
--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -763,8 +763,8 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
 
       // Give the application a chance for a final veto before fully
       // establishing the connection.
-      callbacks().tls_session_established([&, this] {
-         Session_Summary summary(session_info, state.is_a_resumption(), external_psk_identity());
+      callbacks().tls_session_established([&] {
+         Session_Summary summary(session_info, state.is_a_resumption(), state.psk_identity());
          summary.set_session_id(state.server_hello()->session_id());
          if(const auto* nst = state.new_session_ticket()) {
             summary.set_session_ticket(nst->ticket());

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -664,8 +664,8 @@ void Server_Impl_12::process_finished_msg(Server_Handshake_State& pending_state,
 
       // Give the application a chance for a final veto before fully
       // establishing the connection.
-      callbacks().tls_session_established([&, this] {
-         Session_Summary summary(session_info, pending_state.is_a_resumption(), external_psk_identity());
+      callbacks().tls_session_established([&] {
+         Session_Summary summary(session_info, pending_state.is_a_resumption(), pending_state.psk_identity());
          summary.set_session_id(pending_state.server_hello()->session_id());
          return summary;
       }());


### PR DESCRIPTION
For a full renegotiation where the first negotiation used one PSK and the renegotiation another (eg, during a PSK rollover), the session summary of the renegotiation would report the identity for the first PSK, rather than the identity of the PSK associated with the session currently being established.