### PR TITLE
Make TLS 1.3 record padding more configurable

### DIFF
--- a/news.rst
+++ b/news.rst
@@ -113,8 +113,9 @@ Version 3.13.0, Not Yet Released
 * Add support for the Brainpool ECDH groups in TLS 1.3 as specified in RFC 8734
   (GH #5691)
 
-* Add ``TLS::Policy::minimum_record_size``, which allows padding TLS 1.3 records
-  out to a minimum plaintext size (GH #5752)
+* Add ``TLS::Policy::record_padding_bytes``, which allows padding TLS 1.3
+  records, for example out to a minimum plaintext size or to a multiple of
+  some block size (GH #5752)
 
 * TLS 1.3 handshake hardening and various minor TLS fixes (GH #5664 #5721 #5767)
 

--- a/src/lib/tls/tls13/tls_channel_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_channel_impl_13.cpp
@@ -37,15 +37,6 @@ bool is_error_alert(const Botan::TLS::Alert& alert) {
 
 namespace Botan::TLS {
 
-namespace {
-
-const auto& checked_deref(const auto& ptr) {
-   BOTAN_ASSERT_NONNULL(ptr);
-   return *ptr;
-}
-
-}  // namespace
-
 Channel_Impl_13::Channel_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
                                  const std::shared_ptr<Session_Manager>& session_manager,
                                  const std::shared_ptr<Credentials_Manager>& credentials_manager,
@@ -58,7 +49,7 @@ Channel_Impl_13::Channel_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
       m_credentials_manager(credentials_manager),
       m_rng(rng),
       m_policy(policy),
-      m_record_layer(m_side, checked_deref(m_policy)),
+      m_record_layer(m_side, m_policy),
       m_handshake_layer(m_side),
       m_can_read(true),
       m_can_write(true),

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -146,11 +146,11 @@ class TLSPlaintext_Header final {
 
 }  // namespace
 
-Record_Layer::Record_Layer(Connection_Side side, const Policy& policy) :
+Record_Layer::Record_Layer(Connection_Side side, std::shared_ptr<const Policy> policy) :
       m_side(side),
+      m_policy(std::move(policy)),
       m_outgoing_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */),
-      m_incoming_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */),
-      m_outgoing_minimum_record_size(policy.minimum_record_size().value_or(0))
+      m_incoming_record_size_limit(MAX_PLAINTEXT_SIZE + 1 /* content type byte */)
 
       // RFC 8446 5.1
       //    legacy_record_version: MUST be set to 0x0303 for all records
@@ -173,8 +173,7 @@ Record_Layer::Record_Layer(Connection_Side side, const Policy& policy) :
       ,
       m_sending_compat_mode(m_side == Connection_Side::Client),
       m_receiving_compat_mode(true) {
-   BOTAN_ARG_CHECK(m_outgoing_minimum_record_size <= m_outgoing_record_size_limit,
-                   "Configured minimum record size is larger than the specified plaintext size limit");
+   BOTAN_ASSERT_NONNULL(m_policy);
 }
 
 void Record_Layer::copy_data(std::span<const uint8_t> data) {
@@ -234,14 +233,21 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
 
    const auto records = std::max((data.size() + max_plaintext_size - 1) / max_plaintext_size, size_t(1));
    auto output_length = records * TLS_HEADER_SIZE;
+
+   // Policy-requested padding (RFC 9846 5.4) is applied to the final record
+   // only; all preceding records are filled to the maximum plaintext size
+   // already, leaving no room for padding within the record size limit.
+   size_t final_record_padding = 0;
+
    if(protect) {
       // n-1 full records of size max_plaintext_size
       output_length +=
          (records - 1) * cipher_state->encrypt_output_length(max_plaintext_size + content_type_tag_length);
       // last record with size of remaining data
       const auto remaining_bytes = data.size() - ((records - 1) * max_plaintext_size) + content_type_tag_length;
-      const auto padded_remaining_bytes = std::max<size_t>(remaining_bytes, m_outgoing_minimum_record_size);
-      output_length += cipher_state->encrypt_output_length(padded_remaining_bytes);
+      final_record_padding = std::min<size_t>(m_policy->record_padding_bytes(remaining_bytes),
+                                              m_outgoing_record_size_limit - remaining_bytes);
+      output_length += cipher_state->encrypt_output_length(remaining_bytes + final_record_padding);
    } else {
       output_length += data.size();
    }
@@ -258,7 +264,8 @@ std::vector<uint8_t> Record_Layer::prepare_records(const Record_Type type,
    do {
       const size_t pt_size = std::min<size_t>(to_process, max_plaintext_size);
       const size_t pt_size_with_type = pt_size + content_type_tag_length;
-      const size_t pt_size_with_type_and_padding = std::max<size_t>(pt_size_with_type, m_outgoing_minimum_record_size);
+      const bool final_record = (pt_size == to_process);
+      const size_t pt_size_with_type_and_padding = pt_size_with_type + (final_record ? final_record_padding : 0);
       BOTAN_ASSERT_IMPLICATION(protect,
                                pt_size_with_type_and_padding <= m_outgoing_record_size_limit,
                                "Padded record size is within the negotiated record size limit");
@@ -437,8 +444,6 @@ void Record_Layer::set_record_size_limits(const uint16_t outgoing_limit, const u
    BOTAN_ARG_CHECK(outgoing_limit >= 64, "Invalid outgoing record size limit");
    BOTAN_ARG_CHECK(incoming_limit >= 64 && incoming_limit <= MAX_PLAINTEXT_SIZE + 1,
                    "Invalid incoming record size limit");
-   BOTAN_ARG_CHECK(outgoing_limit >= m_outgoing_minimum_record_size,
-                   "Configured minimum record size is not compatible with the negotiated outgoing record size limit");
 
    // RFC 8449 4.
    //    Even if a larger record size limit is provided by a peer, an endpoint

--- a/src/lib/tls/tls13/tls_record_layer_13.h
+++ b/src/lib/tls/tls13/tls_record_layer_13.h
@@ -11,6 +11,7 @@
 
 #include <botan/secmem.h>
 #include <botan/tls_magic.h>
+#include <memory>
 #include <optional>
 #include <span>
 #include <variant>
@@ -46,7 +47,7 @@ class Policy;
  */
 class BOTAN_TEST_API Record_Layer {
    public:
-      Record_Layer(Connection_Side side, const Policy& policy);
+      Record_Layer(Connection_Side side, std::shared_ptr<const Policy> policy);
 
       template <typename ResT>
       using ReadResult = std::variant<BytesNeeded, ResT>;
@@ -109,13 +110,13 @@ class BOTAN_TEST_API Record_Layer {
       size_t m_read_offset = 0;
       Connection_Side m_side;
 
+      // Queried for Record Padding as defined in RFC 9846 5.4
+      std::shared_ptr<const Policy> m_policy;
+
       // Those are either the limits set by the TLS 1.3 specification (RFC 8446),
       // or the ones negotiated via the "record_size_limit" extension (RFC 8449).
       uint16_t m_outgoing_record_size_limit;
       uint16_t m_incoming_record_size_limit;
-
-      // For Record Padding as defined in RFC 9846 5.4
-      uint16_t m_outgoing_minimum_record_size;
 
       // Those status flags are required for version validation where the initial
       // records for sending and receiving is handled differently for backward

--- a/src/lib/tls/tls_policy.cpp
+++ b/src/lib/tls/tls_policy.cpp
@@ -423,8 +423,9 @@ std::optional<uint16_t> Policy::record_size_limit() const {
    return std::nullopt;
 }
 
-std::optional<uint16_t> Policy::minimum_record_size() const {
-   return std::nullopt;
+size_t Policy::record_padding_bytes(size_t plaintext_bytes) const {
+   BOTAN_UNUSED(plaintext_bytes);
+   return 0;
 }
 
 bool Policy::support_cert_status_message() const {
@@ -787,9 +788,6 @@ void Policy::print(std::ostream& o) const {
    print_bool(o, "hash_hello_random", hash_hello_random());
    if(record_size_limit().has_value()) {
       o << "record_size_limit = " << record_size_limit().value() << '\n';
-   }
-   if(minimum_record_size().has_value()) {
-      o << "minimum_record_size = " << minimum_record_size().value() << '\n';
    }
    o << "maximum_session_tickets_per_client_hello = " << maximum_session_tickets_per_client_hello() << '\n';
    o << "session_ticket_lifetime = " << session_ticket_lifetime().count() << '\n';

--- a/src/lib/tls/tls_policy.h
+++ b/src/lib/tls/tls_policy.h
@@ -473,20 +473,23 @@ class BOTAN_PUBLIC_API(2, 0) Policy /* NOLINT(*-special-member-functions) */ {
       virtual std::optional<uint16_t> record_size_limit() const;
 
       /**
-       * Defines the minimum plaintext size of any protected TLS 1.3 record.
-       * If an outgoing record contains less plaintext payload than this value,
-       * it will be transparently padded to reach the specified minimum size.
+       * Defines the number of padding octets added to a protected TLS 1.3
+       * record that contains @p plaintext_bytes of plaintext. The plaintext
+       * size is counted like the record size limit, i.e. per RFC 8449 4.:
+       * "The value includes the content type and padding added in TLS 1.3
+       * (that is, the complete length of TLSInnerPlaintext)."
        *
        * This may be used to reduce the amount of information leaked by the
        * length of TLS records.
        *
-       * The value must be compatible with the negotiated record size limit.
+       * Padding that would grow a record beyond the negotiated record size
+       * limit is truncated to reach exactly that limit.
        *
        * @note This feature is available in TLS 1.3 only (see RFC 9846 5.4).
        *
-       * Default: std::nullopt (no minimum record size is enforced)
+       * Default: 0 (records are not padded)
        */
-      virtual std::optional<uint16_t> minimum_record_size() const;
+      virtual size_t record_padding_bytes(size_t plaintext_bytes) const;
 
       /**
       * Indicates whether certificate status messages should be supported
@@ -898,7 +901,7 @@ class BOTAN_PUBLIC_API(2, 0) Text_Policy : public Policy {
 
       std::optional<uint16_t> record_size_limit() const override;
 
-      std::optional<uint16_t> minimum_record_size() const override;
+      size_t record_padding_bytes(size_t plaintext_bytes) const override;
 
       bool support_cert_status_message() const override;
 

--- a/src/lib/tls/tls_text_policy.cpp
+++ b/src/lib/tls/tls_text_policy.cpp
@@ -118,10 +118,11 @@ std::optional<uint16_t> Text_Policy::record_size_limit() const {
    return (limit > 0) ? std::make_optional(static_cast<uint16_t>(limit)) : std::nullopt;
 }
 
-std::optional<uint16_t> Text_Policy::minimum_record_size() const {
-   const auto limit = get_len("minimum_record_size", 0);
-   BOTAN_ARG_CHECK(limit <= record_size_limit().value_or(16385), "TLS 1.3 minimum record size too large");
-   return (limit > 0) ? std::make_optional(static_cast<uint16_t>(limit)) : std::nullopt;
+size_t Text_Policy::record_padding_bytes(size_t plaintext_bytes) const {
+   // Text policies can express the simplest padding scheme only: pad
+   // records to a fixed minimum size.
+   const auto minimum_record_size = get_len("minimum_record_size", 0);
+   return (plaintext_bytes < minimum_record_size) ? minimum_record_size - plaintext_bytes : 0;
 }
 
 bool Text_Policy::support_cert_status_message() const {

--- a/src/tests/test_tls_record_layer_13.cpp
+++ b/src/tests/test_tls_record_layer_13.cpp
@@ -21,6 +21,8 @@
    #include <botan/internal/tls_reader.h>
    #include <botan/internal/tls_record_layer_13.h>
    #include <array>
+   #include <functional>
+   #include <memory>
 
 namespace Botan_Tests {
 
@@ -32,19 +34,26 @@ using Records = std::vector<TLS::Record>;
 
 class Test_Policy : public Botan::TLS::Policy {
    public:
-      explicit Test_Policy(std::optional<uint16_t> minimum_record_size = std::nullopt) :
-            m_minimum_record_size(minimum_record_size) {}
+      explicit Test_Policy(std::function<size_t(size_t)> record_padding = {}) :
+            m_record_padding(std::move(record_padding)) {}
 
-      std::optional<uint16_t> minimum_record_size() const override { return m_minimum_record_size; }
+      size_t record_padding_bytes(size_t plaintext_bytes) const override {
+         return m_record_padding ? m_record_padding(plaintext_bytes) : 0;
+      }
 
    private:
-      std::optional<uint16_t> m_minimum_record_size;
+      std::function<size_t(size_t)> m_record_padding;
 };
 
+std::function<size_t(size_t)> pad_to_minimum_size(size_t minimum_record_size) {
+   return [=](size_t plaintext_bytes) {
+      return (plaintext_bytes < minimum_record_size) ? minimum_record_size - plaintext_bytes : 0;
+   };
+}
+
 TLS::Record_Layer record_layer_client(const bool skip_client_hello = false,
-                                      std::optional<uint16_t> minimum_record_size = {}) {
-   auto policy = Test_Policy(minimum_record_size);
-   auto rl = TLS::Record_Layer(TLS::Connection_Side::Client, policy);
+                                      std::function<size_t(size_t)> record_padding = {}) {
+   auto rl = TLS::Record_Layer(TLS::Connection_Side::Client, std::make_shared<Test_Policy>(std::move(record_padding)));
 
    // this is relevant for tests that rely on the legacy version in the record
    if(skip_client_hello) {
@@ -54,10 +63,8 @@ TLS::Record_Layer record_layer_client(const bool skip_client_hello = false,
    return rl;
 }
 
-TLS::Record_Layer record_layer_server(const bool skip_client_hello = false,
-                                      std::optional<uint16_t> minimum_record_size = {}) {
-   auto policy = Test_Policy(minimum_record_size);
-   auto rl = TLS::Record_Layer(TLS::Connection_Side::Server, policy);
+TLS::Record_Layer record_layer_server(const bool skip_client_hello = false) {
+   auto rl = TLS::Record_Layer(TLS::Connection_Side::Server, std::make_shared<Test_Policy>());
 
    // this is relevant for tests that rely on the legacy version in the record
    if(skip_client_hello) {
@@ -791,7 +798,7 @@ std::vector<Test::Result> write_encrypted_records() {
       CHECK("write a record with padding",
             [&](Test::Result& result) {
                std::vector<uint8_t> data(5);
-               auto rl = record_layer_client(true, 128);
+               auto rl = record_layer_client(true, pad_to_minimum_size(128));
 
                auto ct = rl.prepare_records(TLS::Record_Type::Handshake, data, cs.get());
 
@@ -1050,42 +1057,38 @@ std::vector<Test::Result> record_size_limits() {
                                   [&] { rls.next_record(css.get()); });
             }),
 
-      CHECK("record size limits incompatible with the padding size are rejected",
-            [&](Test::Result& result) {
-               constexpr uint16_t minimum_record_size = 1024;
-               auto rl = record_layer_client(true, minimum_record_size);
-
-               const uint16_t valid_record_size_limit = minimum_record_size;
-               const uint16_t invalid_record_size_limit = minimum_record_size - 1;
-
-               result.test_no_throw("padding size is compatible with record size limit", [&] {
-                  rl.set_record_size_limits(valid_record_size_limit, valid_record_size_limit);
-               });
-
-               result.test_throws(
-                  "padding size exceeds record size limit",
-                  "Configured minimum record size is not compatible with the negotiated outgoing record size limit",
-                  [&] { rl.set_record_size_limits(invalid_record_size_limit, invalid_record_size_limit); });
-
-               result.test_no_throw("incoming record size limit is not relevant", [&] {
-                  rl.set_record_size_limits(valid_record_size_limit, invalid_record_size_limit);
-               });
-
-               const uint16_t content_type_byte = 1;
-               const uint16_t absolute_plaintext_size_limit = Botan::TLS::MAX_PLAINTEXT_SIZE + content_type_byte;
-               const uint16_t invalid_plaintext_size_limit = absolute_plaintext_size_limit + 1;
-
-               result.test_no_throw("padding size exceeds record size limit",
-                                    [&] { record_layer_client(true, absolute_plaintext_size_limit); });
-               result.test_throws("padding size exceeds record size limit",
-                                  "Configured minimum record size is larger than the specified plaintext size limit",
-                                  [&] { record_layer_client(true, invalid_plaintext_size_limit); });
-            }),
-
-      CHECK("preparing a record where minimum_record_size == maximum_size_limit",
+      CHECK("padding requests are truncated to the negotiated record size limit",
             [&](Test::Result& result) {
                constexpr uint16_t limit = 1024;
-               auto rl = record_layer_client(true, /* minimum_record_size = */ limit);
+               auto rl = record_layer_client(true, pad_to_minimum_size(4096));
+               rl.set_record_size_limits(/* outgoing_limit = */ limit,
+                                         /* incoming_limit = */ limit);
+
+               auto cs = rfc8448_rtt1_handshake_traffic();
+               const std::array<uint8_t, 5> data = {0x01, 0x02, 0x03, 0x04, 0x05};
+               const auto ct = rl.prepare_records(TLS::Record_Type::ApplicationData, data, cs.get());
+
+               const auto expected_length = cs->encrypt_output_length(limit) + Botan::TLS::TLS_HEADER_SIZE;
+               result.test_sz_eq("record was padded to the limit only", ct.size(), expected_length);
+            }),
+
+      CHECK("padding requests are truncated to the protocol's plaintext size limit",
+            [&](Test::Result& result) {
+               auto rl = record_layer_client(true, [](size_t) -> size_t { return 100000; });
+
+               auto cs = rfc8448_rtt1_handshake_traffic();
+               const std::array<uint8_t, 5> data = {0x01, 0x02, 0x03, 0x04, 0x05};
+               const auto ct = rl.prepare_records(TLS::Record_Type::ApplicationData, data, cs.get());
+
+               const auto expected_length =
+                  cs->encrypt_output_length(Botan::TLS::MAX_PLAINTEXT_SIZE + 1) + Botan::TLS::TLS_HEADER_SIZE;
+               result.test_sz_eq("record was padded to the protocol limit only", ct.size(), expected_length);
+            }),
+
+      CHECK("preparing a record where the padded size == maximum_size_limit",
+            [&](Test::Result& result) {
+               constexpr uint16_t limit = 1024;
+               auto rl = record_layer_client(true, pad_to_minimum_size(limit));
                rl.set_record_size_limits(/* outgoing_limit = */ limit,
                                          /* incoming_limit = */ limit);
 
@@ -1095,6 +1098,37 @@ std::vector<Test::Result> record_size_limits() {
 
                const auto expected_length = cs->encrypt_output_length(limit) + Botan::TLS::TLS_HEADER_SIZE;
                result.test_sz_eq("encryption result has the correct length", ct.size(), expected_length);
+            }),
+
+      CHECK("pad records to a block boundary",
+            [&](Test::Result& result) {
+               auto rl = record_layer_client(true, [](size_t ptb) { return (32 - ptb % 32) % 32; });
+               auto cs = rfc8448_rtt1_handshake_traffic();
+
+               for(const size_t data_size : {0, 5, 31, 32, 100}) {
+                  const auto ct =
+                     rl.prepare_records(TLS::Record_Type::ApplicationData, std::vector<uint8_t>(data_size), cs.get());
+
+                  // plaintext is data plus one content type byte, rounded up
+                  // to the next multiple of 32
+                  const size_t padded_pt_size = (data_size + 1 + 31) / 32 * 32;
+                  const auto expected_length = cs->encrypt_output_length(padded_pt_size) + Botan::TLS::TLS_HEADER_SIZE;
+                  result.test_sz_eq("record is padded to a 32-byte boundary", ct.size(), expected_length);
+               }
+            }),
+
+      CHECK("only the final record of a multi-record write is padded",
+            [&](Test::Result& result) {
+               auto rl = record_layer_client(true, pad_to_minimum_size(1024));
+               auto cs = rfc8448_rtt1_handshake_traffic();
+
+               const std::vector<uint8_t> data(Botan::TLS::MAX_PLAINTEXT_SIZE + 10);
+               const auto ct = rl.prepare_records(TLS::Record_Type::ApplicationData, data, cs.get());
+
+               const auto expected_length = 2 * Botan::TLS::TLS_HEADER_SIZE +
+                                            cs->encrypt_output_length(Botan::TLS::MAX_PLAINTEXT_SIZE + 1) +
+                                            cs->encrypt_output_length(1024);
+               result.test_sz_eq("first record is full, trailing record is padded", ct.size(), expected_length);
             }),
    };
 }


### PR DESCRIPTION
The initial implementation only allowed setting a minimum record size.  Change this so instead the policy indicates the number of padding bytes that should be applied, relative to the size of the plaintext. This allows not just setting a minimum record size but also for example rounding the record to the next multiple of 32 bytes.

#5777

Rather more churn than I expected tbh but overall worth it.