### PR TITLE
Randomize BoGo RNG and fix an inmem TLS session storage bug

### DIFF
--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -20,6 +20,7 @@
 #include <botan/mem_ops.h>
 #include <botan/ocsp.h>
 #include <botan/pkcs8.h>
+#include <botan/system_rng.h>
 #include <botan/tls_algos.h>
 #include <botan/tls_callbacks.h>
 #include <botan/tls_client.h>
@@ -2206,7 +2207,7 @@ int main(int /*argc*/, char* argv[]) {
       const bool is_datagram = args->flag_set("dtls");
       const size_t buf_size = args->get_int_opt_or_else("read-size", 18 * 1024);
 
-      auto rng = std::make_shared<Botan::ChaCha_RNG>(Botan::secure_vector<uint8_t>(64));
+      auto rng = std::make_shared<Botan::ChaCha_RNG>(Botan::system_rng().random_vec(64));
       auto creds = std::make_shared<Shim_Credentials>(*args);
       auto session_manager = [&]() -> std::shared_ptr<Botan::TLS::Session_Manager> {
          if(args->flag_set("no-ticket") || args->flag_set("on-resume-no-ticket")) {

--- a/src/lib/tls/tls_session_manager_memory.cpp
+++ b/src/lib/tls/tls_session_manager_memory.cpp
@@ -10,6 +10,9 @@
 
 #include <botan/rng.h>
 #include <botan/internal/stl_util.h>
+#include <algorithm>
+#include <functional>
+#include <tuple>
 
 namespace Botan::TLS {
 
@@ -38,7 +41,7 @@ void Session_Manager_In_Memory::store(const Session& session, const Session_Hand
    // Generate a random session ID if the peer did not provide one. Note that
    // this ID is just for internal use and won't be returned on ::find().
    auto id = handle.id().value_or(m_rng->random_vec<Session_ID>(32));
-   m_sessions.emplace(id, Session_with_Handle{session, handle});
+   m_sessions.emplace(id, Stored_Session{Session_with_Handle{session, handle}, m_next_sequence_number++});
 
    if(m_fifo.has_value()) {
       m_fifo->emplace_back(std::move(id));
@@ -51,7 +54,7 @@ std::optional<Session> Session_Manager_In_Memory::retrieve_one(const Session_Han
    if(auto id = handle.id()) {
       const auto session = m_sessions.find(id.value());
       if(session != m_sessions.end()) {
-         return session->second.session;
+         return session->second.session_and_handle.session;
       }
    }
 
@@ -64,12 +67,26 @@ std::vector<Session_with_Handle> Session_Manager_In_Memory::find_some(const Serv
 
    const lock_guard_type<recursive_mutex_type> lk(mutex());
 
-   std::vector<Session_with_Handle> found_sessions;
-   // TODO: std::copy_if?
-   for(const auto& [_, session_and_handle] : m_sessions) {
-      if(session_and_handle.session.server_info() == info) {
-         found_sessions.emplace_back(session_and_handle);
+   std::vector<std::reference_wrapper<const Stored_Session>> matches;
+   for(const auto& [_, stored] : m_sessions) {
+      if(stored.session_and_handle.session.server_info() == info) {
+         matches.emplace_back(stored);
       }
+   }
+
+   // Prefer the most recently established session, i.e. the freshest ticket.
+   // Insertion order breaks ties, e.g. between tickets received within the
+   // same connection or from applications with a coarse-grained clock.
+   std::ranges::sort(matches, [](const Stored_Session& a, const Stored_Session& b) {
+      const auto a_start = a.session_and_handle.session.start_time();
+      const auto b_start = b.session_and_handle.session.start_time();
+      return std::tie(a_start, a.sequence_number) > std::tie(b_start, b.sequence_number);
+   });
+
+   std::vector<Session_with_Handle> found_sessions;
+   found_sessions.reserve(matches.size());
+   for(const Stored_Session& stored : matches) {
+      found_sessions.emplace_back(stored.session_and_handle);
    }
 
    return found_sessions;
@@ -90,9 +107,11 @@ size_t Session_Manager_In_Memory::remove_internal(const Session_Handle& handle) 
                            //       not contain a plethora of sessions and this should be fine. If
                            //       it's not, we'll need to consider another index on tickets.
                            return std::erase_if(m_sessions, [&](const auto& item) {
-                              const auto& [_unused1, session_and_handle] = item;
-                              const auto& [_unused2, this_handle] = session_and_handle;
-                              return this_handle.is_ticket() && this_handle.ticket().value() == ticket;
+                              const auto& [_unused1, stored] = item;
+                              const auto& [_unused2, this_handle] = stored.session_and_handle;
+                              // TLS 1.3 clients store their tickets as Opaque_Session_Handle
+                              const auto this_ticket = this_handle.ticket();
+                              return this_ticket.has_value() && this_ticket.value() == ticket;
                            });
                         },
                         [&](const Session_ID& id) -> size_t { return m_sessions.erase(id); },

--- a/src/lib/tls/tls_session_manager_memory.h
+++ b/src/lib/tls/tls_session_manager_memory.h
@@ -62,10 +62,16 @@ class BOTAN_PUBLIC_API(3, 0) Session_Manager_In_Memory final : public Session_Ma
       size_t remove_internal(const Session_Handle& handle);
 
    private:
+      struct Stored_Session {
+            Session_with_Handle session_and_handle;
+            uint64_t sequence_number{};
+      };
+
       size_t m_max_sessions;
 
-      std::map<Session_ID, Session_with_Handle> m_sessions;
+      std::map<Session_ID, Stored_Session> m_sessions;
       std::optional<std::deque<Session_ID>> m_fifo;
+      uint64_t m_next_sequence_number = 0;
 };
 
 }  // namespace TLS

--- a/src/tests/test_tls_session_manager.cpp
+++ b/src/tests/test_tls_session_manager.cpp
@@ -168,6 +168,19 @@ std::vector<Test::Result> test_session_manager_in_memory() {
    Session_Manager_Callbacks cbs;
    Session_Manager_Policy plcy;
 
+   auto session_at = [](std::chrono::system_clock::time_point start_time) {
+      return Botan::TLS::Session(Botan::secure_vector<uint8_t>(48, 0x42),
+                                 Botan::TLS::Protocol_Version::TLS_V12,
+                                 0x009C,
+                                 Botan::TLS::Connection_Side::Client,
+                                 true,
+                                 true,
+                                 {},
+                                 server_info(),
+                                 0,
+                                 start_time);
+   };
+
    return {
       CHECK("creation", [&](auto&) { mgr.emplace(rng, 5); }),
 
@@ -337,6 +350,80 @@ std::vector<Test::Result> test_session_manager_in_memory() {
                                  1);
                result.test_sz_eq(
                   "can find only one via server info", local_mgr.find(server_info(), cbs, plcy).size(), 1);
+            }),
+
+      CHECK("removing sessions stored under a long opaque handle",
+            [&](auto& result) {
+               // TLS 1.3 clients store their tickets as Opaque_Session_Handle,
+               // which is typically longer than a Session_ID could be
+               Botan::TLS::Session_Manager_In_Memory local_mgr(rng);
+
+               const auto handle1 = rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128);
+               const auto handle2 = rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128);
+               const auto handle3 = rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128);
+
+               local_mgr.store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle1);
+               local_mgr.store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle2);
+               local_mgr.store(default_session(Botan::TLS::Connection_Side::Client, cbs), handle3);
+               result.test_sz_eq("can find them via server info", local_mgr.find(server_info(), cbs, plcy).size(), 3);
+
+               result.test_sz_eq("remove one session by opaque handle", local_mgr.remove(handle2), 1);
+               result.test_sz_eq("can find two via server info", local_mgr.find(server_info(), cbs, plcy).size(), 2);
+
+               result.test_sz_eq(
+                  "remove one session by ticket", local_mgr.remove(Botan::TLS::Session_Ticket(handle3.get())), 1);
+               result.test_sz_eq(
+                  "can find only one via server info", local_mgr.find(server_info(), cbs, plcy).size(), 1);
+
+               result.test_sz_eq("unknown handles remove nothing",
+                                 local_mgr.remove(rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128)),
+                                 0);
+               result.test_sz_eq("remove_all clears the rest", local_mgr.remove_all(), 1);
+            }),
+
+      CHECK("find prefers the most recently established session",
+            [&](auto& result) {
+               Botan::TLS::Session_Manager_In_Memory local_mgr(rng);
+
+               const auto now = cbs.tls_current_timestamp();
+               const auto old_handle = rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128);
+               const auto new_handle = rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128);
+
+               // The newer session is stored first
+               local_mgr.store(session_at(now), new_handle);
+               local_mgr.store(session_at(now - std::chrono::minutes(1)), old_handle);
+
+               auto sessions = local_mgr.find(server_info(), cbs, plcy);
+               if(result.test_sz_eq("both sessions found", sessions.size(), 2)) {
+                  result.test_bin_eq("newest session first", sessions[0].handle.opaque_handle(), new_handle);
+                  result.test_bin_eq("older session second", sessions[1].handle.opaque_handle(), old_handle);
+               }
+               local_mgr.remove_all();
+
+               // Sessions with the same start time (e.g. multiple tickets from
+               // one connection) are preferred in reverse order of insertion.
+               // Sessions must not be reused, so each find() removes the
+               // session it returned.
+               Session_Manager_Policy no_reuse_policy;
+               no_reuse_policy.set_session_limit(1);
+               no_reuse_policy.set_allow_session_reuse(false);
+
+               std::vector<Botan::TLS::Opaque_Session_Handle> handles;
+               for(size_t i = 0; i < 3; ++i) {
+                  handles.push_back(rng->random_vec<Botan::TLS::Opaque_Session_Handle>(128));
+                  local_mgr.store(session_at(now), handles.back());
+               }
+
+               for(size_t i = handles.size(); i > 0; --i) {
+                  sessions = local_mgr.find(server_info(), cbs, no_reuse_policy);
+                  if(result.test_sz_eq("exactly one session found", sessions.size(), 1)) {
+                     result.test_bin_eq(
+                        "most recently stored session found", sessions[0].handle.opaque_handle(), handles[i - 1]);
+                  }
+               }
+
+               result.test_is_true("no sessions left", local_mgr.find(server_info(), cbs, no_reuse_policy).empty());
+               result.test_sz_eq("storage is empty", local_mgr.remove_all(), 0);
             }),
 
       CHECK(


### PR DESCRIPTION
Should fix the flake seen in #5121 