### PR TITLE
Migrate off of using 22.04 images in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,18 +87,19 @@ jobs:
 
       matrix:
         include:
-          - compiler: gcc
+          # gcc-11 and clang-14 are the minimum supported compilers (see doc/support.rst)
+          - compiler: gcc-11
             target: shared
-            host_os: ubuntu-22.04 # Testing old GCC
+            host_os: ubuntu-24.04
           - compiler: gcc
             target: amalgamation
             host_os: ubuntu-26.04
-          - compiler: gcc
+          - compiler: gcc-11
             target: static
-            host_os: ubuntu-22.04 # Testing old GCC
-          - compiler: clang
+            host_os: ubuntu-24.04
+          - compiler: clang-14
             target: shared
-            host_os: ubuntu-22.04 # Testing old Clang
+            host_os: ubuntu-24.04
 
     runs-on: ${{ matrix.host_os }}
 

--- a/src/scripts/ci/gha_linux_packages.py
+++ b/src/scripts/ci/gha_linux_packages.py
@@ -20,6 +20,14 @@ def gha_linux_packages(target, compiler):
     if compiler in ['gcc-14']:
         packages.append('gcc-14')
 
+    if compiler in ['gcc-11']:
+        packages.append('g++-11')
+
+    if compiler in ['clang-14']:
+        packages.append('clang-14')
+        # provides the libstdc++-11 headers that clang-14 is pinned to
+        packages.append('libstdc++-11-dev')
+
     if target.startswith('valgrind'):
         packages.append('valgrind')
 
@@ -30,7 +38,10 @@ def gha_linux_packages(target, compiler):
         packages.append('clang')
 
     if target in ['cross-i386']:
-        packages.append('g++-multilib')
+        if compiler == 'gcc-11':
+            packages.append('g++-11-multilib')
+        else:
+            packages.append('g++-multilib')
         packages.append('linux-libc-dev')
         packages.append('libc6-dev-i386')
 

--- a/src/scripts/ci_build.py
+++ b/src/scripts/ci_build.py
@@ -728,9 +728,19 @@ def main(args=None):
     if options.cc_bin is None:
         if options.cc == 'gcc':
             options.cc_bin = 'g++'
+        elif options.cc == 'gcc-11':
+            options.cc = 'gcc' # Hack: versioned ids are not valid for ``./configure.py --cc``
+            options.cc_bin = 'g++-11'
         elif options.cc == 'gcc-14':
-            options.cc = 'gcc' # Hack: 'gcc-14' is not a valid compiler identifier for ``./configure.py --cc``
+            options.cc = 'gcc'
             options.cc_bin = 'g++-14'
+        elif options.cc == 'clang-14':
+            # Clang 14 cannot parse the libstdc++-14 headers, pin to libstdc++-11
+            options.cc = 'clang'
+            options.cc_bin = 'clang++-14'
+            options.extra_cxxflags += ['-nostdinc++',
+                                       '-isystem/usr/include/c++/11',
+                                       '-isystem/usr/include/x86_64-linux-gnu/c++/11']
         elif options.cc in ['clang', 'xcode']:
             options.cc_bin = 'clang++'
         elif options.cc == 'msvc':


### PR DESCRIPTION
These were still in use to check compilation on our oldest supported compilers (GCC 11 and Clang 14). However the GHA 22.04 image is scheduled to be retired in spring 2027, while we need to continue testing these compilers throughout the lifecycle of Botan3 (at least end of 2028). Fortunately we can test these compilers on the 24.04 image with only minimal hacks.