### PR TITLE
Modify botan3.py so it can adapt to any release of Botan3

### DIFF
--- a/doc/api_ref/python.rst
+++ b/doc/api_ref/python.rst
@@ -15,6 +15,26 @@ The versioning of the Python module follows the major versioning of
 the C++ library. So for Botan 2, the module is named ``botan2`` while
 for Botan 3 it is ``botan3``.
 
+Library Version Compatibility
+----------------------------------------
+
+The module loads any Botan 3.x shared library, preferring the newest it can
+find. It is written against the FFI API of the release it ships with, but the
+library does not need to match: functionality which the loaded library
+predates raises :class:`BotanFunctionUnavailable` when used, and everything
+else works as usual. This means an application can bundle the newest
+``botan3.py`` and run against whichever library the system provides.
+
+The library in use can be identified with :func:`version_string` or
+:func:`ffi_api_version`.
+
+.. autodata:: BOTAN_FFI_VERSION
+
+.. autodata:: BOTAN_MINIMUM_FFI_VERSION
+
+.. autoclass:: BotanFunctionUnavailable
+   :members:
+
 Versioning
 ----------------------------------------
 .. autofunction:: version_major

--- a/src/python/botan3.py
+++ b/src/python/botan3.py
@@ -49,13 +49,19 @@ from time import mktime, strptime
 from time import time as system_time
 from typing import Any, Callable, Union
 
-# This Python module requires the FFI API version introduced in Botan 3.13.0
+# This Python module is written against the FFI API version introduced in
+# Botan 3.13.0, but loads any library from Botan 3.0.0 onwards. Functionality
+# which the loaded library does not provide raises BotanFunctionUnavailable.
 #
-# 3.13.0 - botan_hash_security_level, SPAKE2+
+# 3.13.0 - botan_hash_security_level, SPAKE2+, RFC 3779 extensions
 # 3.12.0 - EcScalar/EcPoint, DRBG
-# 3.11.0 - XOF API
+# 3.11.0 - XOF API, CRL creation
 # 3.10.0 - introduced botan_pubkey_load_ec*_sec1()
-BOTAN_FFI_VERSION = 20260811  #: The minimum FFI API version this module requires of the library.
+BOTAN_FFI_VERSION = 20260811  #: The FFI API version this module was written against.
+
+BOTAN_MINIMUM_FFI_VERSION = 20230403  #: The oldest FFI API version (Botan 3.0.0) this module can load.
+
+_NOT_IMPLEMENTED_RC = -40  # BOTAN_FFI_ERROR_NOT_IMPLEMENTED
 
 
 class BotanException(Exception):
@@ -66,7 +72,7 @@ class BotanException(Exception):
         code, the description of that error plus the library's most recent exception
         message are appended."""
 
-        self.__rc = rc
+        self._rc = rc
 
         if rc == 0:
             super().__init__(message)
@@ -82,13 +88,34 @@ class BotanException(Exception):
 
     def error_code(self) -> int:
         """Returns the library error code associated with this exception, or zero if there is none"""
-        return self.__rc
+        return self._rc
+
+
+class BotanFunctionUnavailable(BotanException):
+    """Raised when the loaded Botan library predates an FFI function required
+    for the requested operation.
+
+    The error code is ``BOTAN_FFI_ERROR_NOT_IMPLEMENTED`` (-40), the same code
+    the library itself returns for functionality compiled out of the build, so
+    code which already handles that error will treat an older library the same
+    way. Catch this exception type to distinguish the two cases."""
+
+    def __init__(self, fn_name: str):
+        """Create an exception for the missing FFI function ``fn_name``"""
+        # The library never saw this call, so its last exception message does
+        # not apply; format the message here and set the error code directly
+        err_descr = _DLL.botan_error_description(_NOT_IMPLEMENTED_RC).decode('ascii')
+        lib_version = "%d.%d.%d" % (version_major(), version_minor(), version_patch())
+        super().__init__("%s failed: %d (%s): not available in the loaded Botan library (Botan %s)" %
+                         (fn_name, _NOT_IMPLEMENTED_RC, err_descr, lib_version))
+        self._rc = _NOT_IMPLEMENTED_RC
+        self.function_name = fn_name  #: Name of the FFI function the library does not provide
 
 #
 # Module initialization
 #
 
-def _load_botan_dll(expected_version):
+def _load_botan_dll(minimum_version):
 
     possible_dll_names = []
 
@@ -102,8 +129,8 @@ def _load_botan_dll(expected_version):
         # assumed to be some Unix/Linux system
         possible_dll_names.append('libbotan-3.so')
 
-        min_minor = 8 # minimum supported FFI
-        max_minor = 32 # arbitrary but probably large enough
+        min_minor = 0 # BOTAN_MINIMUM_FFI_VERSION corresponds to Botan 3.0
+        max_minor = 22 # 3.22 would be Q4 2028, likely Botan3 stops around 3.17
         possible_dll_names += ['libbotan-3.so.%d' % (v) for v in reversed(range(min_minor, max_minor))]
 
     for dll_name in possible_dll_names:
@@ -112,12 +139,48 @@ def _load_botan_dll(expected_version):
             if hasattr(dll, 'botan_ffi_supports_api'):
                 dll.botan_ffi_supports_api.argtypes = [c_uint32]
                 dll.botan_ffi_supports_api.restype = c_int
-                if dll.botan_ffi_supports_api(expected_version) == 0:
+                if dll.botan_ffi_supports_api(minimum_version) == 0:
                     return dll
         except OSError:
             pass
 
-    raise BotanException("Could not find a usable Botan shared object library")
+    raise BotanException("Could not find a usable Botan shared object library (FFI API %d or later)" % (minimum_version))
+
+class _UnavailableFunction:
+    """Stands in for an FFI function the loaded library does not export.
+
+    The stub is installed on the loaded library object under the function's
+    name, so callers are written against the full API without regard to which
+    library version is loaded; invoking it raises BotanFunctionUnavailable.
+
+    Destructors are the exception: an object whose constructor is unavailable
+    can only ever hold a null handle, and the library accepts destroying a null
+    handle, so a stubbed destructor likewise succeeds without complaint."""
+
+    def __init__(self, fn_name: str):
+        self.__name__ = fn_name
+
+    def __call__(self, *_args):
+        if self.__name__.endswith('_destroy'):
+            return 0
+        raise BotanFunctionUnavailable(self.__name__)
+
+class _FFISymbolResolver:
+    """Resolves FFI symbols in ``dll``, substituting an _UnavailableFunction
+    for any the library does not export and recording their names"""
+
+    def __init__(self, dll):
+        self.dll = dll
+        self.unavailable = []
+
+    def __getattr__(self, fn_name):
+        try:
+            return getattr(self.dll, fn_name)
+        except AttributeError:
+            stub = _UnavailableFunction(fn_name)
+            setattr(self.dll, fn_name, stub)
+            self.unavailable.append(fn_name)
+            return stub
 
 _VIEW_BIN_CALLBACK = CFUNCTYPE(c_int, c_void_p, POINTER(c_char), c_size_t)
 _VIEW_STR_CALLBACK = CFUNCTYPE(c_int, c_void_p, c_char_p, c_size_t)
@@ -698,9 +761,12 @@ def _set_prototypes(dll):
     return dll
 
 #
-# Load the DLL and set prototypes on it
+# Load the DLL and set prototypes on it. Any FFI function the library does
+# not export is replaced by a stub which raises BotanFunctionUnavailable.
 #
-_DLL = _set_prototypes(_load_botan_dll(BOTAN_FFI_VERSION))
+_DLL_RESOLVER = _FFISymbolResolver(_load_botan_dll(BOTAN_MINIMUM_FFI_VERSION))
+_set_prototypes(_DLL_RESOLVER)
+_DLL = _DLL_RESOLVER.dll
 
 #
 # Internal utilities
@@ -2974,11 +3040,22 @@ class MPI:
         return self.__obj
 
     def __int__(self):
-        hexv = _call_fn_viewing_str(lambda vc, vfn: _DLL.botan_mp_view_hex(self.__obj, vc, vfn))
+        try:
+            hexv = _call_fn_viewing_str(lambda vc, vfn: _DLL.botan_mp_view_hex(self.__obj, vc, vfn))
+        except BotanFunctionUnavailable:
+            # The view function requires Botan 3.10; older libraries write to a buffer
+            out = create_string_buffer(2*self.byte_count() + 5)
+            _DLL.botan_mp_to_hex(self.__obj, out)
+            hexv = out.value.decode('ascii')
         return int(hexv, 16)
 
     def __repr__(self):
-        return _call_fn_viewing_str(lambda vc, vfn: _DLL.botan_mp_view_str(self.__obj, 10, vc, vfn))
+        try:
+            return _call_fn_viewing_str(lambda vc, vfn: _DLL.botan_mp_view_str(self.__obj, 10, vc, vfn))
+        except BotanFunctionUnavailable:
+            # The view function requires Botan 3.10; older libraries write to a buffer
+            return _call_fn_returning_str(self.bit_count() + 2,
+                                          lambda out, out_len: _DLL.botan_mp_to_str(self.__obj, 10, out, out_len))
 
     def to_bytes(self) -> Array[c_char]:
         """Returns the big-endian binary encoding of this value"""

--- a/src/scripts/test_python.py
+++ b/src/scripts/test_python.py
@@ -9,6 +9,8 @@ Botan is released under the Simplified BSD License (see license.txt)
 import argparse
 import binascii
 import copy
+import functools
+import gc
 import hashlib
 import os
 import platform
@@ -40,6 +42,36 @@ ARGS = None
 def test_data(relpath):
     return os.path.join(ARGS.test_data_dir, relpath)
 
+def library_at_least(major, minor):
+    """Return True if the loaded library is at least the given version"""
+    return (botan.version_major(), botan.version_minor()) >= (major, minor)
+
+# The module can be loaded against a library older than the one it was written
+# against; anything such a library does not provide should skip, not fail.
+LIBRARY_IS_OLDER_THAN_MODULE = botan.ffi_api_version() < botan.BOTAN_FFI_VERSION
+
+def skip_if_unsupported_by_older_library(cls):
+    """Class decorator: when running against an older library, turn 'not implemented'
+    errors (including FFI functions the library predates) into skips. Against a library
+    matching the module's API version, such errors remain failures."""
+
+    def wrap(test_fn):
+        @functools.wraps(test_fn)
+        def wrapper(self, *args, **kwargs):
+            try:
+                return test_fn(self, *args, **kwargs)
+            except botan.BotanException as e:
+                if LIBRARY_IS_OLDER_THAN_MODULE and e.error_code() == -40:
+                    self.skipTest("Not supported by the loaded library: %s" % (e))
+                raise
+        return wrapper
+
+    for name, fn in list(vars(cls).items()):
+        if name.startswith('test_') and callable(fn):
+            setattr(cls, name, wrap(fn))
+    return cls
+
+@skip_if_unsupported_by_older_library
 class BotanPythonTests(unittest.TestCase):
     def test_version(self):
         version_str = botan.version_string()
@@ -48,7 +80,45 @@ class BotanPythonTests(unittest.TestCase):
         self.assertEqual(botan.version_major(), 3)
         self.assertGreaterEqual(botan.version_minor(), 0)
 
-        self.assertGreaterEqual(botan.ffi_api_version(), 20180713)
+        self.assertGreaterEqual(botan.ffi_api_version(), botan.BOTAN_MINIMUM_FFI_VERSION)
+        self.assertLessEqual(botan.BOTAN_MINIMUM_FFI_VERSION, botan.BOTAN_FFI_VERSION)
+
+    def test_unavailable_functions(self):
+        # A library at (or beyond) the module's API version must provide every function
+        # the module binds; an older library lacks some, and each is a raising stub
+        unavailable = botan._DLL_RESOLVER.unavailable # pylint: disable=protected-access
+
+        if botan.ffi_api_version() >= botan.BOTAN_FFI_VERSION:
+            self.assertEqual(unavailable, [])
+        else:
+            self.assertNotEqual(unavailable, [])
+
+        # botan_hash_security_level was added in Botan 3.13
+        sha256 = botan.HashFunction('SHA-256')
+        if library_at_least(3, 13):
+            self.assertNotIn('botan_hash_security_level', unavailable)
+            self.assertEqual(sha256.security_level(), 128)
+        else:
+            self.assertIn('botan_hash_security_level', unavailable)
+            with self.assertRaises(botan.BotanFunctionUnavailable) as cm:
+                sha256.security_level()
+            self.assertIsInstance(cm.exception, botan.BotanException)
+            self.assertEqual(cm.exception.error_code(), -40)
+            self.assertEqual(cm.exception.function_name, 'botan_hash_security_level')
+            self.assertIn('botan_hash_security_level failed: -40 (Not implemented)', str(cm.exception))
+
+        # Even when a class cannot be constructed, its destructor must not complain
+        if not library_at_least(3, 11):
+            unraisable = []
+            prev_hook = sys.unraisablehook
+            sys.unraisablehook = unraisable.append
+            try:
+                with self.assertRaises(botan.BotanFunctionUnavailable):
+                    botan.XOF('SHAKE-128')
+                gc.collect()
+            finally:
+                sys.unraisablehook = prev_hook
+            self.assertEqual(unraisable, [])
 
     def test_compare(self):
 
@@ -184,7 +254,7 @@ class BotanPythonTests(unittest.TestCase):
         hmac = botan.MsgAuthCode('HMAC(SHA-256)')
         self.assertEqual(hmac.algo_name(), 'HMAC(SHA-256)')
         self.assertEqual(hmac.minimum_keylength(), 0)
-        self.assertEqual(hmac.maximum_keylength(), 8192)
+        self.assertEqual(hmac.maximum_keylength(), 8192 if library_at_least(3, 11) else 4096)
 
         expected = hex_decode('A21B1F5D4CF4F73A4DD939750F7A066A7F98CC131CB16A6692759021CFAB8181')
 
@@ -410,14 +480,10 @@ class BotanPythonTests(unittest.TestCase):
         except botan.BotanException as e:
             self.assertEqual(str(e), "botan_hash_init failed: -40 (Not implemented)")
 
-        sha1 = botan.HashFunction('SHA-1')
-        self.assertEqual(sha1.security_level(), 61)
-
         sha256 = botan.HashFunction('SHA-256')
         self.assertEqual(sha256.algo_name(), 'SHA-256')
         self.assertEqual(sha256.output_length(), 32)
         self.assertEqual(sha256.block_size(), 64)
-        self.assertEqual(sha256.security_level(), 128)
 
         sha256.update('ignore this please')
         sha256.clear()
@@ -442,13 +508,21 @@ class BotanPythonTests(unittest.TestCase):
         self.assertEqual(hex_encode(sha256.final()),
                          "08bfce15fd2406114825ee6f770a06b1b00c129cb48fcddc54ef58b5de48bdf5")
 
+    def test_hash_security_level(self):
+        sha1 = botan.HashFunction('SHA-1')
+        self.assertEqual(sha1.security_level(), 61)
+
+        sha256 = botan.HashFunction('SHA-256')
+        self.assertEqual(sha256.security_level(), 128)
+
     def test_xof(self):
+        shake128 = botan.XOF('SHAKE-128')
+
         try:
             _h = botan.XOF('NoSuchXof')
         except botan.BotanException as e:
             self.assertEqual(str(e), "botan_xof_init failed: -40 (Not implemented)")
 
-        shake128 = botan.XOF('SHAKE-128')
         self.assertEqual(shake128.algo_name(), 'SHAKE-128')
         self.assertEqual(shake128.block_size(), 168)
         self.assertTrue(shake128.accepts_input())
@@ -488,7 +562,7 @@ class BotanPythonTests(unittest.TestCase):
             elif mode == 'Serpent/GCM':
                 self.assertEqual(enc.algo_name(), 'Serpent/GCM(16)')
                 self.assertTrue(enc.is_authenticated())
-                self.assertEqual(enc.update_granularity(), 1)
+                self.assertEqual(enc.update_granularity(), 1 if library_at_least(3, 7) else 16)
                 self.assertGreater(enc.ideal_update_granularity(), 16)
             elif mode == 'ChaCha20Poly1305':
                 self.assertEqual(enc.algo_name(), 'ChaCha20Poly1305')
@@ -580,8 +654,9 @@ ofvkP1EDmpx50fHLawIDAQAB
 
         rsapub = botan.PublicKey.load(rsa_pub_pem)
         self.assertEqual(rsapub.to_pem(), rsa_pub_pem)
-        with self.assertRaisesRegex(botan.BotanException, r".*Only ECC keys.*"):
-            rsapub.used_explicit_encoding()
+        if library_at_least(3, 2):
+            with self.assertRaisesRegex(botan.BotanException, r".*Only ECC keys.*"):
+                rsapub.used_explicit_encoding()
 
         n = 0xB5AD8818DCA1F256FF8FAB0888D0667D95DF2098B0D201A4C75590D3EBDFA159DD91C64AFDA082609EF885B2D1F4DC055C8FF9FA371C2F3398E0B612C603151131C81DB322C8D15E53EB56B4DF7325F05046889CB25021DE4282E16B9B28F5CBB2B8DDECE0F8E4E8A77F674F26AE92B7220920A1FBE43F51039A9C79D1F1CB6B
         e = 0x10001
@@ -655,7 +730,7 @@ ofvkP1EDmpx50fHLawIDAQAB
         try:
             rsapub = botan.PublicKey.load_rsa(n - 1, e)
         except botan.BotanException as e:
-            self.assertEqual(str(e), "botan_pubkey_load_rsa failed: -1 (Invalid input): Invalid RSA public key modulus")
+            self.assertRegex(str(e), r"botan_pubkey_load_rsa failed: -1 \(Invalid input\): Invalid RSA public key (modulus|parameters)")
 
     def _pksign_roundtrips(self, sk, pk, param_str):
         def verify_positive_and_negative(verifier, sig):
@@ -1068,17 +1143,33 @@ ofvkP1EDmpx50fHLawIDAQAB
 
     def test_x509_extensions(self):
         no_ext_cert = botan.X509Cert(filename=test_data("src/tests/data/x509/x509test/root.pem"))
-
-        with self.assertRaisesRegex(botan.BotanException, r".*No value available.*"):
-            no_ext_cert.ext_as_blocks_asnum()
-
-        with self.assertRaisesRegex(botan.BotanException, r".*No value available.*"):
-            no_ext_cert.ext_as_blocks_rdi()
-
-        with self.assertRaisesRegex(botan.BotanException, r".*No value available.*"):
-            no_ext_cert.ext_ip_addr_blocks()
-
         ip_addr_blocks_cert = botan.X509Cert(filename=test_data("src/tests/data/x509/x509test/IPAddrBlocksUnsorted.pem"))
+        as_blocks_cert = botan.X509Cert(filename=test_data("src/tests/data/x509/x509test/ASNumberInherit.pem"))
+
+        rpki_accessors = [
+            lambda cert: cert.ext_as_blocks_asnum(),
+            lambda cert: cert.ext_as_blocks_rdi(),
+            lambda cert: cert.ext_ip_addr_blocks(),
+        ]
+
+        if not library_at_least(3, 13):
+            # The RFC 3779 FFI functions were added in Botan 3.13; against an older
+            # library every accessor must fail with the "not available" error
+            unavailable_msg = r"^botan_x509_ext_[a-z0-9_]+ failed: -40 \(Not implemented\): " \
+                              r"not available in the loaded Botan library \(Botan \d+\.\d+\.\d+\)$"
+
+            for cert in [no_ext_cert, ip_addr_blocks_cert, as_blocks_cert]:
+                for accessor in rpki_accessors:
+                    with self.assertRaisesRegex(botan.BotanFunctionUnavailable, unavailable_msg) as cm:
+                        accessor(cert)
+                    self.assertEqual(cm.exception.error_code(), -40)
+                    self.assertTrue(cm.exception.function_name.startswith('botan_x509_ext_'))
+            return
+
+        for accessor in rpki_accessors:
+            with self.assertRaisesRegex(botan.BotanException, r".*No value available.*"):
+                accessor(no_ext_cert)
+
         v4, v6 = ip_addr_blocks_cert.ext_ip_addr_blocks()
 
         self.assertEqual(v4, [
@@ -1093,7 +1184,7 @@ ofvkP1EDmpx50fHLawIDAQAB
             )]),
             (1, None)
         ])
-        as_blocks_cert = botan.X509Cert(filename=test_data("src/tests/data/x509/x509test/ASNumberInherit.pem"))
+
         asnum = as_blocks_cert.ext_as_blocks_asnum()
         rdi = as_blocks_cert.ext_as_blocks_rdi()
 


### PR DESCRIPTION
This turns out to be quite simple since ctypes already lets us query if the function symbol exists or not. If it doesn't, then just synthesize a -40 (not implemented) error which is handled in the normal way.

cc @arckoor 

Inspired by (and much easier than) the equivalent change to the Rust binding in https://github.com/randombit/botan-rs/pull/193