### PR TITLE
test_runner: ensure that std::all_of is available

### DIFF
--- a/src/tests/runner/test_runner.cpp
+++ b/src/tests/runner/test_runner.cpp
@@ -24,6 +24,7 @@
    #include <botan/internal/thread_pool.h>
 #endif
 
+#include <algorithm>
 #include <shared_mutex>
 
 namespace Botan_Tests {


### PR DESCRIPTION
When trying to build Botan 3.13.0 on Windows with Microsoft Visual Studio 2022_17.10 and 2026_18.5, the build of `src/tests/runner/test_runner.cpp` always failed due to `all_of` being unknown in namespace `std`. Patching in an explicit `#include <algorithm>` fixed the issue for me.

My guess is that the reason why it fails for me, but not in CI, is that I'm not enabling all modules.

Ref: https://en.cppreference.com/cpp/algorithm/all_any_none_of
