### PR TITLE
Enable Windows ARM64 CI support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,22 @@ jobs:
             arch: x86
             host_os: windows-2022
             compiler: clangcl
+          - target: shared
+            arch: arm64
+            host_os: windows-11-arm
+            compiler: msvc
+          - target: static
+            arch: arm64
+            host_os: windows-11-arm
+            compiler: msvc
+          - target: amalgamation
+            arch: arm64
+            host_os: windows-11-arm
+            compiler: msvc
+          - target: shared
+            arch: arm64
+            host_os: windows-11-arm
+            compiler: clangcl
 
     runs-on: ${{ matrix.host_os }}
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,10 +101,17 @@ jobs:
           - target: sanitizer
             compiler: msvc
             host_os: windows-2022
+            arch: x64
+            make_tool: ninja
+          - target: sanitizer
+            compiler: msvc
+            host_os: windows-11-arm
+            arch: arm64
             make_tool: ninja
           - target: sanitizer
             compiler: gcc-14
             host_os: ubuntu-26.04
+            arch: x64
 
     runs-on: ${{ matrix.host_os }}
 
@@ -130,10 +137,11 @@ jobs:
         with:
           target: ${{ matrix.target }}
           compiler: ${{ matrix.compiler }}
-          cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-x86_64-${{ matrix.target }}
+          arch: ${{ matrix.arch }}
+          cache-key: ${{ matrix.host_os }}-${{ matrix.compiler }}-${{ matrix.arch }}-${{ matrix.target }}
 
       - name: Build and Test Botan
-        run: python3 ./source/src/scripts/ci_build.py --root-dir=${{ github.workspace }}/source --build-dir=${{ github.workspace }}/build --boringssl-dir=${{ github.workspace }}/boringssl --cc='${{ matrix.compiler }}' --ci-image='${{ matrix.host_os }}' --make-tool='${{ matrix.make_tool }}' --test-results-dir=junit_results ${{ matrix.target }}
+        run: python3 ./source/src/scripts/ci_build.py --root-dir=${{ github.workspace }}/source --build-dir=${{ github.workspace }}/build --boringssl-dir=${{ github.workspace }}/boringssl --cc='${{ matrix.compiler }}' --ci-image='${{ matrix.host_os }}' --make-tool='${{ matrix.make_tool }}' --cpu='${{ matrix.arch }}' --test-results-dir=junit_results ${{ matrix.target }}
 
   x-compile:
     name: "Cross"

--- a/src/scripts/ci/cmake_tests/CMakePresets.json
+++ b/src/scripts/ci/cmake_tests/CMakePresets.json
@@ -15,6 +15,10 @@
             "architecture": "Win32"
         },
         {
+            "name": "windows_arm64",
+            "architecture": "ARM64"
+        },
+        {
             "name": "unix"
         }
     ]

--- a/src/scripts/ci_check_install.py
+++ b/src/scripts/ci_check_install.py
@@ -86,7 +86,12 @@ def verify_cmake_package(build_config):
 
     def cmake_preset():
         if build_config['os'] == 'windows':
-            return 'windows_x86_64' if build_config['arch'] == 'x86_64' else 'windows_x86'
+            if build_config['arch'] == 'x86_64':
+                return 'windows_x86_64'
+            elif build_config['arch'] in ['arm64', 'aarch64']:
+                return 'windows_arm64'
+            else:
+                return 'windows_x86'
         return 'unix'
 
     def test_target():


### PR DESCRIPTION
This PR adds Windows on ARM64 (WoA) CI support for Botan.

**Changes**

- Add `shared`, `static`, `amalgamation`, and `Clang-cl` build configurations for WoA.
- Add ARM64 sanitizer coverage to the nightly workflow.
- Extend CI build and cache configuration to handle the target architecture.
- Add an ARM64 CMake preset for install/package validation.
- Update `ci_check_install.py` to select the appropriate CMake preset for ARM64 builds.

This enables Botan builds and CI validation on WoA runners.