### PR TITLE
Use Hash_Engine batching in HSS-LMS

### DIFF
--- a/src/lib/pubkey/hss_lms/info.txt
+++ b/src/lib/pubkey/hss_lms/info.txt
@@ -18,6 +18,7 @@ hss.h
 </header:internal>
 
 <requires>
+hash_engine
 rng
 sha2_32
 shake

--- a/src/lib/pubkey/hss_lms/lm_ots.cpp
+++ b/src/lib/pubkey/hss_lms/lm_ots.cpp
@@ -14,6 +14,7 @@
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/ct_utils.h>
+#include <botan/internal/hash_engine.h>
 #include <botan/internal/hss_lms_utils.h>
 #include <botan/internal/int_utils.h>
 
@@ -25,31 +26,55 @@ constexpr uint16_t D_MESG = 0x8181;
 /// For derivation of C as in https://github.com/cisco/hash-sigs
 constexpr uint16_t C_INDEX = 0xFFFD;
 
-class Chain_Generator {
+/**
+ * Steps many hash chains at once, computing for each selected lane
+ * Hash(identifier || u32str(q) || u16str(i) || u8str(j) || inputs[lane])
+ *
+ * The lanes cover the p chains of one or more consecutive LM-OTS
+ * instances, instance-major (all chains of first_q, then those of
+ * first_q + 1, ...).
+ */
+class Batch_Chain_Generator {
    public:
-      Chain_Generator(const LMS_Identifier& identifier, LMS_Tree_Node_Idx q) : m_gen(identifier) {
-         m_gen.set_q(q.get());
-      }
-
-      void process(HashFunction& hash,
-                   uint16_t chain_idx,
-                   uint8_t start,
-                   uint8_t end,
-                   std::span<const uint8_t> in,
-                   std::span<uint8_t> out) {
-         BOTAN_ARG_CHECK(start <= end, "Start value is bigger than end value");
-
-         copy_mem(out, in);
-         m_gen.set_i(chain_idx);
-
-         for(uint8_t j = start; j < end; ++j) {
-            m_gen.set_j(j);
-            m_gen.gen(out, hash, out);
+      Batch_Chain_Generator(
+         Hash_Engine& engine, const LMS_Identifier& identifier, LMS_Tree_Node_Idx first_q, size_t q_count, uint16_t p) :
+            m_engine(engine),
+            m_prefix_len(identifier.size() + sizeof(uint32_t) + sizeof(uint16_t) + sizeof(uint8_t)),
+            m_prefixes(q_count * p * m_prefix_len) {
+         for(size_t lane = 0; lane != q_count * p; ++lane) {
+            BufferStuffer prefix(chain_prefix(lane));
+            prefix.append(identifier);
+            prefix.append(store_be(LMS_Tree_Node_Idx(first_q.get() + static_cast<uint32_t>(lane / p))));
+            prefix.append(store_be(static_cast<uint16_t>(lane % p)));
+            prefix.next(1)[0] = 0;
          }
       }
 
+      Batch_Chain_Generator(Hash_Engine& engine, const LMS_Identifier& identifier, LMS_Tree_Node_Idx q, uint16_t p) :
+            Batch_Chain_Generator(engine, identifier, q, 1, p) {}
+
+      void process(std::span<const uint16_t> lanes,
+                   uint8_t j,
+                   std::span<std::span<uint8_t>> outputs,
+                   std::span<std::span<const uint8_t>> inputs) {
+         m_prefix_spans.resize(lanes.size());
+         for(size_t c = 0; c != lanes.size(); ++c) {
+            const auto prefix = chain_prefix(lanes[c]);
+            prefix[m_prefix_len - 1] = j;
+            m_prefix_spans[c] = prefix;
+         }
+         m_engine.batch_hash(outputs, m_prefix_spans, inputs);
+      }
+
    private:
-      PseudorandomKeyGeneration m_gen;
+      std::span<uint8_t> chain_prefix(size_t lane) {
+         return std::span(m_prefixes).subspan(lane * m_prefix_len, m_prefix_len);
+      }
+
+      Hash_Engine& m_engine;
+      size_t m_prefix_len;
+      std::vector<uint8_t> m_prefixes;
+      std::vector<std::span<const uint8_t>> m_prefix_spans;
 };
 
 // RFC 8554 3.1.1
@@ -266,17 +291,29 @@ LMOTS_Private_Key::LMOTS_Private_Key(const LMOTS_Params& params,
                                      const LMS_Identifier& identifier,
                                      LMS_Tree_Node_Idx q,
                                      const LMS_Seed& seed) :
+      LMOTS_Private_Key(params, identifier, q, seed, *Hash_Engine::create_or_throw(params.hash_name())) {}
+
+LMOTS_Private_Key::LMOTS_Private_Key(const LMOTS_Params& params,
+                                     const LMS_Identifier& identifier,
+                                     LMS_Tree_Node_Idx q,
+                                     const LMS_Seed& seed,
+                                     Hash_Engine& engine) :
       OTS_Instance(params, identifier, q), m_seed(seed) {
-   PseudorandomKeyGeneration gen(identifier);
-   const auto hash = params.hash();
+   const uint16_t p = params.p();
 
-   gen.set_q(q.get());
-   gen.set_j(0xff);
-
-   for(uint16_t i = 0; i < params.p(); ++i) {
-      gen.set_i(i);
-      m_ots_sk.push_back(gen.gen<LMOTS_Node>(*hash, seed));
+   m_ots_sk.reserve(p);
+   std::vector<uint16_t> chains(p);
+   std::vector<std::span<uint8_t>> outputs(p);
+   std::vector<std::span<const uint8_t>> inputs(p);
+   for(uint16_t i = 0; i < p; ++i) {
+      m_ots_sk.emplace_back(params.n());
+      chains[i] = i;
+      outputs[i] = std::span<uint8_t>(m_ots_sk.back().get());
+      inputs[i] = std::span<const uint8_t>(seed.get());
    }
+
+   Batch_Chain_Generator chain_gen(engine, identifier, q, p);
+   chain_gen.process(chains, 0xff, outputs, inputs);
 }
 
 void LMOTS_Private_Key::sign(StrongSpan<LMOTS_Signature_Bytes> out_sig, const LMS_Message& msg) const {
@@ -294,13 +331,45 @@ void LMOTS_Private_Key::sign(StrongSpan<LMOTS_Signature_Bytes> out_sig, const LM
 
    const auto Q_with_cksm = gen_Q_with_cksm(params(), identifier(), q(), C, msg);
 
-   Chain_Generator chain_gen(identifier(), q());
-   for(uint16_t i = 0; i < params().p(); ++i) {
-      const auto y_i = sig_stuffer.next(params().n());
-      const uint8_t a = coef(Q_with_cksm, i, params());
-      chain_gen.process(*hash, i, 0, a, chain_input(i), y_i);
-   }
+   const uint16_t p = params().p();
+   const size_t n = params().n();
+   const auto y = sig_stuffer.next(p * n);
    BOTAN_ASSERT_NOMSG(sig_stuffer.full());
+
+   std::vector<uint8_t> a(p);
+   for(uint16_t i = 0; i < p; ++i) {
+      a[i] = coef(Q_with_cksm, i, params());
+      copy_mem(y.subspan(i * n, n), chain_input(i));
+   }
+
+   const auto engine = Hash_Engine::create_or_throw(params().hash_name());
+   Batch_Chain_Generator chain_gen(*engine, identifier(), q(), p);
+
+   std::vector<uint16_t> active;
+   std::vector<std::span<uint8_t>> outputs;
+   std::vector<std::span<const uint8_t>> inputs;
+   active.reserve(p);
+   outputs.reserve(p);
+   inputs.reserve(p);
+
+   // Chain i takes a[i] steps in total; step all unfinished chains together
+   for(uint8_t j = 0;; ++j) {
+      active.clear();
+      outputs.clear();
+      inputs.clear();
+      for(uint16_t i = 0; i < p; ++i) {
+         if(j < a[i]) {
+            active.push_back(i);
+            const auto node = y.subspan(i * n, n);
+            outputs.push_back(node);
+            inputs.push_back(node);
+         }
+      }
+      if(active.empty()) {
+         break;
+      }
+      chain_gen.process(active, j, outputs, inputs);
+   }
 }
 
 void LMOTS_Private_Key::derive_random_C(std::span<uint8_t> out, HashFunction& hash) const {
@@ -313,21 +382,95 @@ void LMOTS_Private_Key::derive_random_C(std::span<uint8_t> out, HashFunction& ha
    gen.gen(out, hash, m_seed);
 }
 
-LMOTS_Public_Key::LMOTS_Public_Key(const LMOTS_Private_Key& lmots_sk) : /* NOLINT(*-slicing) */ OTS_Instance(lmots_sk) {
+LMOTS_Public_Key::LMOTS_Public_Key(const LMOTS_Private_Key& lmots_sk) :
+      LMOTS_Public_Key(lmots_sk, *Hash_Engine::create_or_throw(lmots_sk.params().hash_name())) {}
+
+LMOTS_Public_Key::LMOTS_Public_Key(const LMOTS_Private_Key& lmots_sk, Hash_Engine& engine) :
+      /* NOLINT(*-slicing) */ OTS_Instance(lmots_sk) {
+   const uint16_t p = lmots_sk.params().p();
+   const size_t n = lmots_sk.params().n();
+
+   // Walk all chains to the top in lock-step
+   secure_vector<uint8_t> nodes(p * n);
+   std::vector<uint16_t> chains(p);
+   std::vector<std::span<uint8_t>> outputs(p);
+   std::vector<std::span<const uint8_t>> inputs(p);
+   for(uint16_t i = 0; i < p; ++i) {
+      chains[i] = i;
+      const auto node = std::span(nodes).subspan(i * n, n);
+      copy_mem(node, lmots_sk.chain_input(i));
+      outputs[i] = node;
+      inputs[i] = node;
+   }
+
+   Batch_Chain_Generator chain_gen(engine, lmots_sk.identifier(), lmots_sk.q(), p);
+   for(uint8_t j = 0; j < lmots_sk.params().coef_max(); ++j) {
+      chain_gen.process(chains, j, outputs, inputs);
+   }
+
    const auto pk_hash = lmots_sk.params().hash();
    pk_hash->update(lmots_sk.identifier());
    pk_hash->update(store_be(lmots_sk.q()));
    pk_hash->update(store_be(D_PBLC));
+   pk_hash->update(nodes);
+   m_K = pk_hash->final<LMOTS_K>();
+}
 
-   Chain_Generator chain_gen(lmots_sk.identifier(), lmots_sk.q());
-   const auto hash = lmots_sk.params().hash();
-   LMOTS_Node tmp(lmots_sk.params().n());
-   for(uint16_t i = 0; i < lmots_sk.params().p(); ++i) {
-      chain_gen.process(*hash, i, 0, lmots_sk.params().coef_max(), lmots_sk.chain_input(i), tmp);
-      pk_hash->update(tmp);
+void lmots_compute_pubkeys(std::span<uint8_t> out_ks,
+                           const LMOTS_Params& params,
+                           const LMS_Identifier& identifier,
+                           LMS_Tree_Node_Idx first_q,
+                           size_t count,
+                           const LMS_Seed& seed,
+                           Hash_Engine& engine) {
+   BOTAN_ASSERT_NOMSG(out_ks.size() == count * params.n());
+
+   const uint16_t p = params.p();
+   const size_t n = params.n();
+   const size_t lanes = count * p;
+   BOTAN_ASSERT_NOMSG(lanes <= 0xFFFF);
+
+   secure_vector<uint8_t> nodes(lanes * n);
+
+   std::vector<uint16_t> lane_ids(lanes);
+   std::vector<std::span<uint8_t>> outputs(lanes);
+   std::vector<std::span<const uint8_t>> inputs(lanes);
+   for(size_t l = 0; l != lanes; ++l) {
+      lane_ids[l] = static_cast<uint16_t>(l);
+      outputs[l] = std::span(nodes).subspan(l * n, n);
+      inputs[l] = std::span<const uint8_t>(seed.get());
    }
 
-   m_K = pk_hash->final<LMOTS_K>();
+   Batch_Chain_Generator chain_gen(engine, identifier, first_q, count, p);
+
+   // Derive the secret chain inputs (x[] in RFC 8554 4.2)
+   chain_gen.process(lane_ids, 0xff, outputs, inputs);
+
+   // Walk all chains of all instances to the top in lock-step
+   for(size_t l = 0; l != lanes; ++l) {
+      inputs[l] = outputs[l];
+   }
+   for(uint8_t j = 0; j < params.coef_max(); ++j) {
+      chain_gen.process(lane_ids, j, outputs, inputs);
+   }
+
+   // Compute each instance's K over its chain ends (RFC 8554 4.3)
+   const size_t k_prefix_len = identifier.size() + sizeof(uint32_t) + sizeof(uint16_t);
+   std::vector<uint8_t> k_prefixes(count * k_prefix_len);
+   std::vector<std::span<uint8_t>> k_outs(count);
+   std::vector<std::span<const uint8_t>> k_prefix_spans(count);
+   std::vector<std::span<const uint8_t>> k_nodes(count);
+   for(size_t i = 0; i != count; ++i) {
+      const auto prefix_span = std::span(k_prefixes).subspan(i * k_prefix_len, k_prefix_len);
+      BufferStuffer prefix(prefix_span);
+      prefix.append(identifier);
+      prefix.append(store_be(LMS_Tree_Node_Idx(first_q.get() + static_cast<uint32_t>(i))));
+      prefix.append(store_be(D_PBLC));
+      k_prefix_spans[i] = prefix_span;
+      k_outs[i] = out_ks.subspan(i * n, n);
+      k_nodes[i] = std::span(nodes).subspan(i * p * n, p * n);
+   }
+   engine.batch_hash(k_outs, k_prefix_spans, k_nodes);
 }
 
 LMOTS_K lmots_compute_pubkey_from_sig(const LMOTS_Signature& sig,
@@ -340,20 +483,50 @@ LMOTS_K lmots_compute_pubkey_from_sig(const LMOTS_Signature& sig,
 
    const auto Q_with_cksm = gen_Q_with_cksm(params, identifier, q, sig.C(), msg);
 
+   const uint16_t p = params.p();
+   const size_t n = params.n();
+
+   secure_vector<uint8_t> nodes(p * n);
+   std::vector<uint8_t> a(p);
+   for(uint16_t i = 0; i < p; ++i) {
+      a[i] = coef(Q_with_cksm, i, params);
+      copy_mem(std::span(nodes).subspan(i * n, n), sig.y(i));
+   }
+
+   const auto engine = Hash_Engine::create_or_throw(params.hash_name());
+   Batch_Chain_Generator chain_gen(*engine, identifier, q, p);
+
+   std::vector<uint16_t> active;
+   std::vector<std::span<uint8_t>> outputs;
+   std::vector<std::span<const uint8_t>> inputs;
+   active.reserve(p);
+   outputs.reserve(p);
+   inputs.reserve(p);
+
+   // Chain i continues from position a[i] up to the top
+   for(uint8_t j = 0; j < params.coef_max(); ++j) {
+      active.clear();
+      outputs.clear();
+      inputs.clear();
+      for(uint16_t i = 0; i < p; ++i) {
+         if(a[i] <= j) {
+            active.push_back(i);
+            const auto node = std::span(nodes).subspan(i * n, n);
+            outputs.push_back(node);
+            inputs.push_back(node);
+         }
+      }
+      if(!active.empty()) {
+         chain_gen.process(active, j, outputs, inputs);
+      }
+   }
+
    // Prefill the final hash object
    const auto pk_hash = params.hash();
    pk_hash->update(identifier);
    pk_hash->update(store_be(q));
    pk_hash->update(store_be(D_PBLC));
-
-   Chain_Generator chain_gen(identifier, q);
-   const auto hash = params.hash();
-   LMOTS_Node tmp(params.n());
-   for(uint16_t i = 0; i < params.p(); ++i) {
-      const uint8_t a = coef(Q_with_cksm, i, params);
-      chain_gen.process(*hash, i, a, params.coef_max(), sig.y(i), tmp);
-      pk_hash->update(tmp);
-   }
+   pk_hash->update(nodes);
    // Alg. 4b 4.
    return pk_hash->final<LMOTS_K>();
 }

--- a/src/lib/pubkey/hss_lms/lm_ots.h
+++ b/src/lib/pubkey/hss_lms/lm_ots.h
@@ -21,6 +21,7 @@ namespace Botan {
 
 class BufferSlicer;
 class HashFunction;
+class Hash_Engine;
 
 /**
  * @brief Seed of the LMS tree, used to generate the LM-OTS private keys.
@@ -270,6 +271,16 @@ class BOTAN_TEST_API LMOTS_Private_Key final : public OTS_Instance {
                         const LMS_Seed& seed);
 
       /**
+       * @brief As above, but using a caller-provided hash engine, allowing
+       * its reuse over many key derivations
+       */
+      LMOTS_Private_Key(const LMOTS_Params& params,
+                        const LMS_Identifier& identifier,
+                        LMS_Tree_Node_Idx q,
+                        const LMS_Seed& seed,
+                        Hash_Engine& engine);
+
+      /**
        * @brief The secret chain input at a given chain index. (x[] in RFC 8554 4.2).
        */
       const LMOTS_Node& chain_input(uint16_t chain_idx) const { return m_ots_sk.at(chain_idx); }
@@ -315,6 +326,12 @@ class BOTAN_TEST_API LMOTS_Public_Key final : public OTS_Instance {
       explicit LMOTS_Public_Key(const LMOTS_Private_Key& lmots_sk);
 
       /**
+       * @brief As above, but using a caller-provided hash engine, allowing
+       * its reuse over many key derivations
+       */
+      LMOTS_Public_Key(const LMOTS_Private_Key& lmots_sk, Hash_Engine& engine);
+
+      /**
        * @brief Construct a new LMOTS public key object using the bytes.
        *
        * Note that the passed params, identifier and
@@ -333,6 +350,20 @@ class BOTAN_TEST_API LMOTS_Public_Key final : public OTS_Instance {
    private:
       LMOTS_K m_K;
 };
+
+/**
+ * @brief Compute the public key hash values K (RFC 8554 4.3) of @p count
+ * consecutive LM-OTS instances beginning at @p first_q, deriving the
+ * instances' secrets from @p seed. The hashing is batched across all
+ * instances' chains.
+ */
+BOTAN_TEST_API void lmots_compute_pubkeys(std::span<uint8_t> out_ks,
+                                          const LMOTS_Params& params,
+                                          const LMS_Identifier& identifier,
+                                          LMS_Tree_Node_Idx first_q,
+                                          size_t count,
+                                          const LMS_Seed& seed,
+                                          Hash_Engine& engine);
 
 /**
  * @brief Compute a public key candidate for an OTS-signature-message pair and the OTS instance parameters.

--- a/src/lib/pubkey/hss_lms/lms.cpp
+++ b/src/lib/pubkey/hss_lms/lms.cpp
@@ -13,6 +13,7 @@
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/buffer_stuffer.h>
 #include <botan/internal/concat_util.h>
+#include <botan/internal/hash_engine.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/tree_hash.h>
 
@@ -84,11 +85,35 @@ void lms_gen_leaf(StrongSpan<LMS_Tree_Node> out,
    hash.final(out);
 }
 
-auto lms_gen_leaf_func(const LMS_PrivateKey& lms_sk) {
-   return [hash = lms_sk.lms_params().hash(), lms_sk](StrongSpan<LMS_Tree_Node> out, const TreeAddress& tree_address) {
-      auto lmots_sk = LMOTS_Private_Key(lms_sk.lmots_params(), lms_sk.identifier(), tree_address.q(), lms_sk.seed());
-      auto lmots_pk = LMOTS_Public_Key(lmots_sk);
-      lms_gen_leaf(out, lmots_pk, tree_address, *hash);
+auto lms_gen_leaves_func(const LMS_PrivateKey& lms_sk) {
+   // The hash engine is created once here and reused for all leaves
+   return [engine = Hash_Engine::create_or_throw(lms_sk.lmots_params().hash_name()), lms_sk](
+             std::span<uint8_t> out, LMS_Tree_Node_Idx first_idx, size_t count) {
+      const size_t m = lms_sk.lms_params().m();
+      const auto& identifier = lms_sk.identifier();
+
+      // The OTS public key hashes of all requested leaves
+      std::vector<uint8_t> ks(count * m);
+      lmots_compute_pubkeys(ks, lms_sk.lmots_params(), identifier, first_idx, count, lms_sk.seed(), *engine);
+
+      // Leaf node hash: H(I || u32str(r) || u16str(D_LEAF) || K)
+      const size_t prefix_len = identifier.size() + sizeof(uint32_t) + sizeof(uint16_t);
+      std::vector<uint8_t> prefixes(count * prefix_len);
+      std::vector<std::span<uint8_t>> outs(count);
+      std::vector<std::span<const uint8_t>> prefix_spans(count);
+      std::vector<std::span<const uint8_t>> k_spans(count);
+      for(size_t i = 0; i != count; ++i) {
+         const uint32_t r = (uint32_t(1) << lms_sk.lms_params().h()) + first_idx.get() + static_cast<uint32_t>(i);
+         const auto prefix_span = std::span(prefixes).subspan(i * prefix_len, prefix_len);
+         BufferStuffer prefix(prefix_span);
+         prefix.append(identifier);
+         prefix.append(store_be(r));
+         prefix.append(store_be(D_LEAF));
+         prefix_spans[i] = prefix_span;
+         outs[i] = out.subspan(i * m, m);
+         k_spans[i] = std::span(ks).subspan(i * m, m);
+      }
+      engine->batch_hash(outs, prefix_spans, k_spans);
    };
 }
 
@@ -97,7 +122,7 @@ void lms_treehash(StrongSpan<LMS_Tree_Node> out_root,
                   std::optional<LMS_Tree_Node_Idx> leaf_idx,
                   const LMS_PrivateKey& lms_sk) {
    auto hash_pair_func = get_hash_pair_func_for_identifier(lms_sk.lms_params(), lms_sk.identifier());
-   auto gen_leaf = lms_gen_leaf_func(lms_sk);
+   auto gen_leaves = lms_gen_leaves_func(lms_sk);
    TreeAddress lms_tree_address(lms_sk.lms_params().h());
 
    treehash(out_root,
@@ -107,7 +132,7 @@ void lms_treehash(StrongSpan<LMS_Tree_Node> out_root,
             LMS_TreeLayerIndex(lms_sk.lms_params().h()),
             0,
             std::move(hash_pair_func),
-            std::move(gen_leaf),
+            std::move(gen_leaves),
             lms_tree_address);
 }
 

--- a/src/lib/utils/tree_hash/tree_hash.h
+++ b/src/lib/utils/tree_hash/tree_hash.h
@@ -59,12 +59,11 @@ concept tree_hash_node_pair = concepts::tree_node_index<NodeIdx> && concepts::tr
                                  { func(out, address, a, b) };
                               };
 
-template <typename T, typename NodeIdx, typename LayerIdx, typename Address, typename NodeSS>
-concept tree_gen_leaf = concepts::tree_node_index<NodeIdx> && concepts::tree_layer_index<LayerIdx> &&
-                        concepts::tree_address<Address, LayerIdx, NodeIdx> && concepts::strong_span<NodeSS> &&
-                        requires(T func, NodeSS out, const Address& address) {
-                           { func(out, address) };
-                        };
+template <typename T, typename NodeIdx>
+concept tree_gen_leaves =
+   concepts::tree_node_index<NodeIdx> && requires(T func, std::span<uint8_t> out, NodeIdx first_idx, size_t count) {
+      { func(out, first_idx, count) };
+   };
 
 }  // namespace concepts
 
@@ -95,9 +94,11 @@ concept tree_gen_leaf = concepts::tree_node_index<NodeIdx> && concepts::tree_lay
  * @param total_tree_height The height of the merkle tree to construct.
  * @param idx_offset If we compute a subtree this marks the index of the leftmost leaf node in the bottom layer
  * @param node_pair_hash The function to process two child nodes to compute their parent node.
- * @param gen_leaf The logic to create a leaf node given the address in the tree. Probably this function
- *                 creates a one-time/few-time-signature's public key which is hashed to be the leaf node.
- * @param tree_address The address that is passed to gen_leaf or node_pair hash. This function will update the
+ * @param gen_leaves The logic to create a batch of consecutive leaf nodes, given the index of the
+ *                   first leaf (including the tree's index offset) and the leaf count. Probably this
+ *                   function creates one-time/few-time-signatures' public keys which are hashed to
+ *                   be the leaf nodes.
+ * @param tree_address The address that is passed to node_pair hash. This function will update the
  *                     address accordings to the currently processed node. This object may contain further
  *                     algorithm specific information, like the position of this merkle tree in a hypertree.
  */
@@ -115,7 +116,7 @@ inline void treehash(
    TreeLayerIndex total_tree_height,
    uint32_t idx_offset,
    concepts::tree_hash_node_pair<TreeNodeIndex, TreeLayerIndex, Address, StrongSpan<TreeNode>> auto node_pair_hash,
-   concepts::tree_gen_leaf<TreeNodeIndex, TreeLayerIndex, Address, StrongSpan<TreeNode>> auto gen_leaf,
+   concepts::tree_gen_leaves<TreeNodeIndex> auto gen_leaves,
    Address& tree_address) {
    BOTAN_ASSERT_NOMSG(out_root.size() == node_size);
    BOTAN_ASSERT(out_auth_path.has_value() == leaf_idx.has_value(),
@@ -129,12 +130,21 @@ inline void treehash(
 
    TreeNode current_node(node_size);  // Current logical node
 
+   // Leaves are created in batches to enable batched hashing. Both the
+   // batch size and the leaf count are powers of two, so batches are
+   // always full.
+   const uint32_t leaves_per_batch = std::min<uint32_t>(uint32_t(1) << total_tree_height.get(), 32);
+   std::vector<uint8_t> leaves(leaves_per_batch * node_size);
+
    // Traverse the tree from the left-most leaf, matching siblings and up until
    // the root (Post-order traversal). Collect the adjacent nodes to build
    // the authentication path along the way.
    for(TreeNodeIndex idx(0); true; ++idx) {
-      tree_address.set_address(TreeLayerIndex(0), idx + idx_offset);
-      gen_leaf(StrongSpan<TreeNode>(current_node), tree_address);
+      const uint32_t batch_pos = idx.get() % leaves_per_batch;
+      if(batch_pos == 0) {
+         gen_leaves(std::span(leaves), idx + idx_offset, leaves_per_batch);
+      }
+      copy_mem(current_node, std::span(leaves).subspan(batch_pos * node_size, node_size));
 
       // Now combine the freshly generated right node with previously generated
       // left ones


### PR DESCRIPTION
On a Tiger Lake system with AVX-512, improvement vs master:

```
+ 782.3% improvement in HSS-LMS-SHAKE-256(256),HW(10,1) keygen
+ 780.8% improvement in HSS-LMS-SHAKE-256(256),HW(10,1) sign
+ 739.8% improvement in HSS-LMS-SHAKE-256(192),HW(10,1) sign
+ 736.5% improvement in HSS-LMS-SHAKE-256(192),HW(10,1) keygen
+ 489.4% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) sign
+ 486.5% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) keygen
+ 384.6% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) sign
+ 380.8% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) sign
+ 380.4% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) keygen
+ 377.4% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) keygen
+ 367.5% improvement in HSS-LMS-SHA-256,HW(10,1) keygen
+ 366.2% improvement in HSS-LMS-SHA-256,HW(10,1) sign
+ 73.8% improvement in HSS-LMS-SHAKE-256(192),HW(10,1) verify
+ 45.2% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) verify
+ 38.5% improvement in HSS-LMS-SHA-256,HW(10,1) verify
+ 35.0% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) verify
+ 31.1% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) verify
- 7.8% regression in HSS-LMS-SHAKE-256(256),HW(10,1) verify
```
