### PR TITLE
Use Hash_Engine batching in SLH-DSA

### DIFF
--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/info.txt
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/info.txt
@@ -28,4 +28,5 @@ sp_xmss.h
 <requires>
 pubkey
 hash
+hash_engine
 </requires>

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_fors.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_fors.cpp
@@ -78,9 +78,39 @@ SphincsTreeNode fors_sign_and_pkgen(StrongSpan<ForsSignature> sig_out,
    BufferStuffer roots(roots_buffer);
    BufferStuffer sig(sig_out);
 
-   // Buffer to hold the FORS leaves during tree traversal
-   // (Avoids a secure_vector allocation/deallocation in the hot path)
-   ForsLeafSecret fors_leaf_secret(params.n());
+   // Scratch space for batched leaf generation, reused across subtrees
+   std::vector<Sphincs_Address> leaf_addrs;
+   secure_vector<uint8_t> leaf_secrets;
+   std::vector<std::span<uint8_t>> secret_spans;
+   std::vector<std::span<const uint8_t>> csecret_spans;
+   std::vector<std::span<uint8_t>> leaf_spans;
+
+   // Each leaf is the hash of a secret derived from the leaf's address
+   const GenerateLeavesFunction fors_gen_leaves = [&](std::span<uint8_t> out, TreeNodeIndex first_idx, uint32_t count) {
+      leaf_addrs.assign(count, fors_tree_addr);
+      leaf_secrets.resize(count * params.n());
+      secret_spans.resize(count);
+      csecret_spans.resize(count);
+      leaf_spans.resize(count);
+
+      for(uint32_t j = 0; j != count; ++j) {
+         leaf_addrs[j]
+            .set_type(Sphincs_Address_Type::ForsKeyGeneration)
+            .set_tree_height(TreeLayerIndex(0))
+            .set_tree_index(first_idx + j);
+         secret_spans[j] = std::span(leaf_secrets).subspan(j * params.n(), params.n());
+         csecret_spans[j] = secret_spans[j];
+         leaf_spans[j] = out.subspan(j * params.n(), params.n());
+      }
+
+      hashes.PRF_batch(secret_spans, secret_seed, leaf_addrs);
+
+      for(uint32_t j = 0; j != count; ++j) {
+         leaf_addrs[j].set_type(Sphincs_Address_Type::ForsTree);
+      }
+
+      hashes.T_batch(leaf_spans, leaf_addrs, csecret_spans);
+   };
 
    // For each of the k FORS subtrees: Compute the secret leaf, the authentication path
    // and the trees' root and append the signature respectively
@@ -98,17 +128,6 @@ SphincsTreeNode fors_sign_and_pkgen(StrongSpan<ForsSignature> sig_out,
       // Compute the authentication path and root for this leaf node
       fors_tree_addr.set_type(Sphincs_Address_Type::ForsTree);
 
-      const GenerateLeafFunction fors_gen_leaf = [&](StrongSpan<SphincsTreeNode> out_root,
-                                                     TreeNodeIndex address_index) {
-         fors_tree_addr.set_tree_index(address_index);
-         fors_tree_addr.set_type(Sphincs_Address_Type::ForsKeyGeneration);
-
-         hashes.PRF(fors_leaf_secret, secret_seed, fors_tree_addr);
-
-         fors_tree_addr.set_type(Sphincs_Address_Type::ForsTree);
-         hashes.T(out_root, fors_tree_addr, fors_leaf_secret);
-      };
-
       treehash(roots.next<SphincsTreeNode>(params.n()),
                sig.next<SphincsAuthenticationPath>(params.a() * params.n()),
                params,
@@ -116,7 +135,7 @@ SphincsTreeNode fors_sign_and_pkgen(StrongSpan<ForsSignature> sig_out,
                indices[i],
                idx_offset,
                params.a(),
-               fors_gen_leaf,
+               fors_gen_leaves,
                fors_tree_addr);
    }
 

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hash.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hash.cpp
@@ -13,6 +13,7 @@
 #include <botan/hash.h>
 #include <botan/sp_parameters.h>
 #include <botan/internal/buffer_slicer.h>
+#include <botan/internal/hash_engine.h>
 #include <memory>
 
 #if defined(BOTAN_HAS_SPHINCS_PLUS_SHAKE_BASE)
@@ -28,6 +29,37 @@ namespace Botan {
 Sphincs_Hash_Functions::Sphincs_Hash_Functions(const Sphincs_Parameters& sphincs_params,
                                                const SphincsPublicSeed& pub_seed) :
       m_sphincs_params(sphincs_params), m_pub_seed(pub_seed) {}
+
+void Sphincs_Hash_Functions::T_batch(std::span<std::span<uint8_t>> outputs,
+                                     std::span<const Sphincs_Address> addresses,
+                                     std::span<std::span<const uint8_t>> inputs) {
+   BOTAN_ASSERT_NOMSG(outputs.size() == addresses.size() && addresses.size() == inputs.size());
+
+   if(addresses.empty()) {
+      return;
+   }
+
+   auto& engine = tweak_hash_engine(inputs[0].size());
+
+   const size_t adrs_len = address_encoding_len();
+   m_adrs_buf.resize(addresses.size() * adrs_len);
+   m_adrs_spans.resize(addresses.size());
+
+   for(size_t i = 0; i != addresses.size(); ++i) {
+      const auto adrs = std::span(m_adrs_buf).subspan(i * adrs_len, adrs_len);
+      encode_address(adrs, addresses[i]);
+      m_adrs_spans[i] = adrs;
+   }
+
+   engine.batch_hash(outputs, m_adrs_spans, inputs);
+}
+
+void Sphincs_Hash_Functions::PRF_batch(std::span<std::span<uint8_t>> outputs,
+                                       const SphincsSecretSeed& sk_seed,
+                                       std::span<const Sphincs_Address> addresses) {
+   m_prf_inputs.assign(addresses.size(), std::span<const uint8_t>(sk_seed.get()));
+   T_batch(outputs, addresses, m_prf_inputs);
+}
 
 std::unique_ptr<Sphincs_Hash_Functions> Sphincs_Hash_Functions::create(const Sphincs_Parameters& sphincs_params,
                                                                        const SphincsPublicSeed& pub_seed) {

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hash.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_hash.h
@@ -16,6 +16,8 @@
 
 namespace Botan {
 
+class Hash_Engine;
+
 /**
  * A collection of pseudorandom hash functions required for SLH-DSA
  * computations. See FIPS 205, Section 11.2.1 and 11.2.2.
@@ -75,6 +77,24 @@ class BOTAN_TEST_API Sphincs_Hash_Functions /* NOLINT(*-special-member-functions
          T(out, address, sk_seed);
       }
 
+      /**
+      * Batched variant of T with a single input buffer per lane
+      *
+      * Computes outputs[i] = T(addresses[i], inputs[i]). All inputs must
+      * have identical length. outputs[i] may alias inputs[i], as used for
+      * stepping WOTS+ chains in place.
+      */
+      void T_batch(std::span<std::span<uint8_t>> outputs,
+                   std::span<const Sphincs_Address> addresses,
+                   std::span<std::span<const uint8_t>> inputs);
+
+      /**
+      * Batched variant of PRF: outputs[i] = PRF(sk_seed, addresses[i])
+      */
+      void PRF_batch(std::span<std::span<uint8_t>> outputs,
+                     const SphincsSecretSeed& sk_seed,
+                     std::span<const Sphincs_Address> addresses);
+
       virtual std::string msg_hash_function_name() const = 0;
 
    protected:
@@ -95,12 +115,33 @@ class BOTAN_TEST_API Sphincs_Hash_Functions /* NOLINT(*-special-member-functions
        */
       virtual HashFunction& tweak_hash(const Sphincs_Address& address, size_t input_length) = 0;
 
+      /**
+      * @return engine for batched tweaked hashing of inputs of the given length
+      */
+      virtual Hash_Engine& tweak_hash_engine(size_t input_length) = 0;
+
+      /**
+      * @return byte length of the address encoding used for tweaked hashing
+      */
+      virtual size_t address_encoding_len() const = 0;
+
+      /**
+      * Write the encoding of @p address used for tweaked hashing to @p out
+      */
+      virtual void encode_address(std::span<uint8_t> out, const Sphincs_Address& address) const = 0;
+
       virtual std::vector<uint8_t> H_msg_digest(StrongSpan<const SphincsMessageRandomness> r,
                                                 const SphincsTreeNode& root,
                                                 const SphincsMessageInternal& message) = 0;
 
       const Sphincs_Parameters& m_sphincs_params;  // NOLINT(*non-private-member-variable*)
       const SphincsPublicSeed& m_pub_seed;         // NOLINT(*non-private-member-variable*)
+
+   private:
+      // Scratch space for batched hashing
+      std::vector<uint8_t> m_adrs_buf;
+      std::vector<std::span<const uint8_t>> m_adrs_spans;
+      std::vector<std::span<const uint8_t>> m_prf_inputs;
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.cpp
@@ -21,7 +21,7 @@ void treehash(StrongSpan<SphincsTreeNode> out_root,
               std::optional<TreeNodeIndex> leaf_idx,
               uint32_t idx_offset,
               uint32_t total_tree_height,
-              const GenerateLeafFunction& gen_leaf,
+              const GenerateLeavesFunction& gen_leaves,
               Sphincs_Address& tree_address) {
    BOTAN_ASSERT_NOMSG(out_root.size() == params.n());
    BOTAN_ASSERT_NOMSG(out_auth_path.size() == params.n() * total_tree_height);
@@ -29,7 +29,11 @@ void treehash(StrongSpan<SphincsTreeNode> out_root,
    const TreeNodeIndex max_idx(uint32_t((1 << total_tree_height) - 1));
 
    std::vector<uint8_t> stack(total_tree_height * params.n());
-   SphincsTreeNode current_node(params.n());  // Current logical node
+
+   // Leaves are created in batches to enable batched hashing. Both the batch
+   // size and the leaf count are powers of two, so batches are always full.
+   const uint32_t leaves_per_batch = std::min<uint32_t>(uint32_t(1) << total_tree_height, 128);
+   std::vector<uint8_t> leaves(leaves_per_batch * params.n());
 
    /* Traverse the tree from the left-most leaf, matching siblings and up until
    * the root (Post-order traversal). Collect the adjacent nodes (A) to build
@@ -42,8 +46,12 @@ void treehash(StrongSpan<SphincsTreeNode> out_root,
    *   1X  2A  4   5
    */
    for(TreeNodeIndex idx(0); true; ++idx) {
-      tree_address.set_tree_height(TreeLayerIndex(0));
-      gen_leaf(current_node, idx + idx_offset);
+      const uint32_t batch_pos = idx.get() % leaves_per_batch;
+      if(batch_pos == 0) {
+         gen_leaves(leaves, idx + idx_offset, leaves_per_batch);
+      }
+      // Current logical node, evolved in place as siblings are combined
+      const auto current_node = std::span(leaves).subspan(batch_pos * params.n(), params.n());
 
       // Now combine the freshly generated right node with previously generated
       // left ones

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_treehash.h
@@ -22,13 +22,19 @@ namespace Botan {
 class Sphincs_Address;
 class Sphincs_Hash_Functions;
 
-using GenerateLeafFunction = std::function<void(StrongSpan<SphincsTreeNode> /* leaf out parameter */, TreeNodeIndex)>;
+/**
+ * Creates the nodes of @p count consecutive leaves, starting at the leaf with
+ * address index @p first, into the output buffer. Implementations must fully
+ * specify the hash addresses used for the leaves.
+ */
+using GenerateLeavesFunction =
+   std::function<void(std::span<uint8_t> /* leaves out parameter */, TreeNodeIndex /* first */, uint32_t /* count */)>;
 
 /**
  * Implements a generic Merkle tree hash. Will be used for both FORS and XMSS
  * signatures.
- * @p gen_leaf is used to create leaf nodes in the respective trees.
- * Additionally XMSS uses the gen_leaf logic to store the WOTS Signature in the
+ * @p gen_leaves is used to create batches of leaf nodes in the respective trees.
+ * Additionally XMSS uses the gen_leaves logic to store the WOTS Signature in the
  * main SLH-DSA signature. The @p leaf_idx is the index of leaf to sign. If
  * only the root node must be computed (without a signature), the @p leaf_idx is
  * set to std::nullopt.
@@ -40,7 +46,7 @@ BOTAN_TEST_API void treehash(StrongSpan<SphincsTreeNode> out_root,
                              std::optional<TreeNodeIndex> leaf_idx,
                              uint32_t idx_offset,
                              uint32_t tree_height,
-                             const GenerateLeafFunction& gen_leaf,
+                             const GenerateLeavesFunction& gen_leaves,
                              Sphincs_Address& tree_address);
 
 /**

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.cpp
@@ -8,35 +8,12 @@
 
 #include <botan/internal/sp_wots.h>
 
-#include <botan/internal/buffer_slicer.h>
-#include <botan/internal/buffer_stuffer.h>
+#include <botan/mem_ops.h>
+#include <botan/internal/loadstor.h>
 #include <botan/internal/sp_hash.h>
 
 namespace Botan {
 namespace {
-
-/**
- * @brief FIPS 205, Algorithm 5: chain
- *
- * Computes a WOTS+ hash chain for @p steps steps beginning with value
- * @p wots_chain_key at index @p start.
- */
-void chain(StrongSpan<WotsPublicKeyNode> out,
-           StrongSpan<const WotsNode> wots_chain_key,
-           WotsHashIndex start,
-           uint8_t steps,
-           Sphincs_Address& addr,
-           Sphincs_Hash_Functions& hashes,
-           const Sphincs_Parameters& params) {
-   // Initialize out with the value at position 'start'.
-   std::copy(wots_chain_key.begin(), wots_chain_key.end(), out.begin());
-
-   // Iterate 'steps' calls to the hash function.
-   for(WotsHashIndex i = start; i < (start + steps) && i < params.w(); i++) {
-      addr.set_hash_address(i);
-      hashes.T(out, addr, out);
-   }
-}
 
 /**
  * FIPS 205, Algorithm 4: base_2^b for WOTS+
@@ -103,37 +80,58 @@ std::vector<WotsHashIndex> chain_lengths(const SphincsTreeNode& msg, const Sphin
 
 WotsPublicKey wots_public_key_from_signature(const SphincsTreeNode& hashed_message,
                                              StrongSpan<const WotsSignature> signature,
-                                             Sphincs_Address& address,
+                                             const Sphincs_Address& address,
                                              const Sphincs_Parameters& params,
                                              Sphincs_Hash_Functions& hashes) {
    const std::vector<WotsHashIndex> lengths = chain_lengths(hashed_message, params);
-   WotsPublicKey pk_buffer(params.wots_len() * params.n());
-   BufferSlicer sig(signature);
-   BufferStuffer pk(pk_buffer);
+   const size_t len = params.wots_len();
+   const size_t n = params.n();
 
-   for(WotsChainIndex i(0); i < params.wots_len(); i++) {
-      address.set_chain_address(i);
+   // The chains start with the nodes in the signature
+   WotsPublicKey pk_buffer(len * n);
+   std::copy(signature.begin(), signature.end(), pk_buffer.begin());
+   const std::span<uint8_t> pk_bytes(pk_buffer.get());
 
-      // params.w() can be one of {4, 8, 256}
-      const WotsHashIndex start_index = lengths[i.get()];
-      const uint8_t steps_to_take = static_cast<uint8_t>(params.w() - 1) - start_index.get();
+   std::vector<Sphincs_Address> chain_addrs(len, address);
+   for(size_t i = 0; i != len; ++i) {
+      chain_addrs[i].set_chain_address(WotsChainIndex(static_cast<uint32_t>(i)));
+   }
 
-      chain(pk.next<WotsPublicKeyNode>(params.n()),
-            sig.take<WotsNode>(params.n()),
-            start_index,
-            steps_to_take,
-            address,
-            hashes,
-            params);
+   std::vector<Sphincs_Address> addrs;
+   std::vector<std::span<uint8_t>> outs;
+   std::vector<std::span<const uint8_t>> ins;
+   addrs.reserve(len);
+   outs.reserve(len);
+   ins.reserve(len);
+
+   // Walk the chains in lock-step; chain i joins in once the step counter
+   // reaches its position in the signature
+   for(WotsHashIndex k(0); k < params.w() - 1; k++) {
+      addrs.clear();
+      outs.clear();
+      ins.clear();
+
+      for(size_t i = 0; i != len; ++i) {
+         if(lengths[i] <= k) {
+            chain_addrs[i].set_hash_address(k);
+            addrs.push_back(chain_addrs[i]);
+            const auto node = pk_bytes.subspan(i * n, n);
+            outs.push_back(node);
+            ins.push_back(node);
+         }
+      }
+
+      hashes.T_batch(outs, addrs, ins);
    }
 
    return pk_buffer;
 }
 
 void wots_sign_and_pkgen(StrongSpan<WotsSignature> sig_out,
-                         StrongSpan<SphincsTreeNode> leaf_out,
+                         std::span<uint8_t> leaves_out,
                          const SphincsSecretSeed& secret_seed,
-                         TreeNodeIndex leaf_idx,
+                         TreeNodeIndex first_leaf_idx,
+                         size_t leaf_count,
                          std::optional<TreeNodeIndex> sign_leaf_idx,
                          const std::vector<WotsHashIndex>& wots_steps,
                          Sphincs_Address& leaf_addr,
@@ -143,59 +141,80 @@ void wots_sign_and_pkgen(StrongSpan<WotsSignature> sig_out,
    // `wots_steps` are needed only if `sign_leaf_idx` is set
    BOTAN_ASSERT_NOMSG(!sign_leaf_idx.has_value() || wots_steps.size() == params.wots_len());
    BOTAN_ASSERT_NOMSG(pk_addr.get_type() == Sphincs_Address_Type::WotsPublicKeyCompression);
+   BOTAN_ASSERT_NOMSG(leaves_out.size() == leaf_count * params.n());
 
-   const secure_vector<uint8_t> wots_sig;
-   WotsPublicKey wots_pk_buffer(params.wots_bytes());
+   const size_t len = params.wots_len();
+   const size_t n = params.n();
+   const size_t lanes = leaf_count * len;
 
-   BufferStuffer wots_pk(wots_pk_buffer);
-   BufferStuffer sig(sig_out);
+   // WOTS public key buffers of all leaves, one lane per chain
+   secure_vector<uint8_t> pk_buffers(leaf_count * params.wots_bytes());
 
-   leaf_addr.set_keypair_address(leaf_idx);
-   pk_addr.set_keypair_address(leaf_idx);
+   // The chains share their leaf's address except for their chain field
+   leaf_addr.set_type(Sphincs_Address_Type::WotsKeyGeneration);
+   leaf_addr.set_hash_address(WotsHashIndex(0));
 
-   for(WotsChainIndex i(0); i < params.wots_len(); i++) {
-      // If the current leaf is part of the signature wots_k stores the chain index
-      //   of the value necessary for the signature. Otherwise: nullopt (no signature)
-      const auto wots_k = [&]() -> std::optional<WotsHashIndex> {
-         if(sign_leaf_idx.has_value() && leaf_idx == sign_leaf_idx.value()) {
-            return wots_steps[i.get()];
-         } else {
-            return std::nullopt;
-         }
-      }();
-
-      // Start with the secret seed
-      leaf_addr.set_chain_address(i);
-      leaf_addr.set_hash_address(WotsHashIndex(0));
-      leaf_addr.set_type(Sphincs_Address_Type::WotsKeyGeneration);
-
-      auto buffer_s = wots_pk.next<WotsNode>(params.n());
-
-      hashes.PRF(buffer_s, secret_seed, leaf_addr);
-
-      leaf_addr.set_type(Sphincs_Address_Type::WotsHash);
-
-      // Iterates down the WOTS chain
-      for(WotsHashIndex k(0);; k++) {
-         // Check if this is the value that needs to be saved as a part of the WOTS signature
-         if(wots_k.has_value() && k == wots_k.value()) {
-            std::copy(buffer_s.begin(), buffer_s.end(), sig.next<WotsNode>(params.n()).begin());
-         }
-
-         // Check if the top of the chain was hit
-         if(k == params.w() - 1) {
-            break;
-         }
-
-         // Iterate one step on the chain
-         leaf_addr.set_hash_address(k);
-
-         hashes.T(buffer_s, leaf_addr, buffer_s);
+   std::vector<Sphincs_Address> addrs;
+   addrs.reserve(lanes);
+   std::vector<std::span<uint8_t>> nodes(lanes);
+   std::vector<std::span<const uint8_t>> cnodes(lanes);
+   for(size_t j = 0; j != leaf_count; ++j) {
+      leaf_addr.set_keypair_address(first_leaf_idx + static_cast<uint32_t>(j));
+      for(size_t i = 0; i != len; ++i) {
+         addrs.push_back(leaf_addr);
+         addrs.back().set_chain_address(WotsChainIndex(static_cast<uint32_t>(i)));
+         const auto node = std::span(pk_buffers).subspan((j * len + i) * n, n);
+         nodes[j * len + i] = node;
+         cnodes[j * len + i] = node;
       }
    }
 
-   // Do the final thash to generate the public keys
-   hashes.T(leaf_out, pk_addr, wots_pk_buffer);
+   // Start each chain with its secret seed
+   hashes.PRF_batch(nodes, secret_seed, addrs);
+
+   for(auto& addr : addrs) {
+      addr.set_type(Sphincs_Address_Type::WotsHash);
+   }
+
+   const bool signing_in_batch = sign_leaf_idx.has_value() && sign_leaf_idx.value() >= first_leaf_idx &&
+                                 sign_leaf_idx.value() < first_leaf_idx + static_cast<uint32_t>(leaf_count);
+   const size_t sign_j = signing_in_batch ? static_cast<size_t>(sign_leaf_idx.value().get() - first_leaf_idx.get()) : 0;
+
+   // Iterate down all chains of all leaves in lock-step
+   for(WotsHashIndex k(0);; k++) {
+      // Check for values that need to be saved as a part of the WOTS signature
+      if(signing_in_batch) {
+         for(size_t i = 0; i != len; ++i) {
+            if(wots_steps[i] == k) {
+               copy_mem(sig_out.get().subspan(i * n, n), nodes[sign_j * len + i]);
+            }
+         }
+      }
+
+      // Check if the top of the chains was hit
+      if(k == params.w() - 1) {
+         break;
+      }
+
+      for(auto& addr : addrs) {
+         addr.set_hash_address(k);
+      }
+
+      hashes.T_batch(nodes, addrs, cnodes);
+   }
+
+   // Do the final thashes compressing each leaf's WOTS public key
+   std::vector<Sphincs_Address> pk_addrs;
+   pk_addrs.reserve(leaf_count);
+   std::vector<std::span<uint8_t>> leaf_outs(leaf_count);
+   std::vector<std::span<const uint8_t>> pk_spans(leaf_count);
+   for(size_t j = 0; j != leaf_count; ++j) {
+      pk_addr.set_keypair_address(first_leaf_idx + static_cast<uint32_t>(j));
+      pk_addrs.push_back(pk_addr);
+      leaf_outs[j] = leaves_out.subspan(j * n, n);
+      pk_spans[j] = std::span(pk_buffers).subspan(j * params.wots_bytes(), params.wots_bytes());
+   }
+   hashes.T_batch(leaf_outs, pk_addrs, pk_spans);
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_wots.h
@@ -27,11 +27,17 @@ class Sphincs_Parameters;
  * (Winternitz OTS). It is meant to be used inside SLH-DSA and does not aim to
  * be applicable for other use cases. If this function is not used in a signing
  * operation (i.e. @p sign_leaf_idx is not set), @p wots_steps may be empty.
+ *
+ * Computes the WOTS public key leaves for @p leaf_count consecutive leaves
+ * starting at @p first_leaf_idx into @p leaves_out, batching the hash
+ * invocations across all leaves' chains. If @p sign_leaf_idx falls into
+ * this range, its WOTS signature is written to @p sig_out in passing.
  */
 BOTAN_TEST_API void wots_sign_and_pkgen(StrongSpan<WotsSignature> sig_out,
-                                        StrongSpan<SphincsTreeNode> leaf_out,
+                                        std::span<uint8_t> leaves_out,
                                         const SphincsSecretSeed& secret_seed,
-                                        TreeNodeIndex leaf_idx,
+                                        TreeNodeIndex first_leaf_idx,
+                                        size_t leaf_count,
                                         std::optional<TreeNodeIndex> sign_leaf_idx,
                                         const std::vector<WotsHashIndex>& wots_steps,
                                         Sphincs_Address& leaf_addr,
@@ -48,7 +54,7 @@ BOTAN_TEST_API void wots_sign_and_pkgen(StrongSpan<WotsSignature> sig_out,
  */
 BOTAN_TEST_API WotsPublicKey wots_public_key_from_signature(const SphincsTreeNode& hashed_message,
                                                             StrongSpan<const WotsSignature> signature,
-                                                            Sphincs_Address& address,
+                                                            const Sphincs_Address& address,
                                                             const Sphincs_Parameters& params,
                                                             Sphincs_Hash_Functions& hashes);
 

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.cpp
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sp_xmss.cpp
@@ -43,14 +43,31 @@ SphincsTreeNode xmss_sign_and_pkgen(StrongSpan<SphincsXmssSignature> out_sig,
 
    pk_addr.set_type(Sphincs_Address_Type::WotsPublicKeyCompression);
 
-   const GenerateLeafFunction xmss_gen_leaf = [&](StrongSpan<SphincsTreeNode> out_root, TreeNodeIndex address_index) {
-      wots_sign_and_pkgen(
-         wots_bytes_s, out_root, secret_seed, address_index, idx_leaf, steps, leaf_addr, pk_addr, params, hashes);
-   };
+   // Each leaf is a full WOTS+ key generation; the hashing is batched over
+   // all chains of a group of leaves at once. The group size bounds the
+   // WOTS public key scratch while still offering wide hash batches.
+   const GenerateLeavesFunction xmss_gen_leaves =
+      [&](std::span<uint8_t> out_leaves, TreeNodeIndex first_idx, uint32_t count) {
+         constexpr uint32_t leaf_group = 128;
+         for(uint32_t j = 0; j < count; j += leaf_group) {
+            const uint32_t leaves = std::min(leaf_group, count - j);
+            wots_sign_and_pkgen(wots_bytes_s,
+                                out_leaves.subspan(j * params.n(), leaves * params.n()),
+                                secret_seed,
+                                first_idx + j,
+                                leaves,
+                                idx_leaf,
+                                steps,
+                                leaf_addr,
+                                pk_addr,
+                                params,
+                                hashes);
+         }
+      };
 
    SphincsTreeNode next_root(params.n());
    BOTAN_ASSERT_NOMSG(tree_addr.get_type() == Sphincs_Address_Type::HashTree);
-   treehash(next_root, auth_path_s, params, hashes, idx_leaf, 0, params.xmss_tree_height(), xmss_gen_leaf, tree_addr);
+   treehash(next_root, auth_path_s, params, hashes, idx_leaf, 0, params.xmss_tree_height(), xmss_gen_leaves, tree_addr);
 
    return next_root;
 }

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus_sha2_base/sp_hash_sha2.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus_sha2_base/sp_hash_sha2.h
@@ -12,6 +12,8 @@
 #include <botan/internal/sp_hash.h>
 
 #include <botan/internal/concat_util.h>
+#include <botan/internal/fmt.h>
+#include <botan/internal/hash_engine.h>
 #include <botan/internal/hmac.h>
 #include <botan/internal/mgf1.h>
 #include <botan/internal/sha2_32.h>
@@ -40,6 +42,18 @@ class Sphincs_Hash_Functions_Sha2 : public Sphincs_Hash_Functions {
          hash.update(padded_pub_seed);
          hash.update(address.to_bytes_compressed());
          return hash;
+      }
+
+      Hash_Engine& tweak_hash_engine(size_t input_length) override {
+         auto& engine = (input_length > m_sphincs_params.n()) ? m_engine_x : m_engine_256;
+         return *engine;
+      }
+
+      size_t address_encoding_len() const override { return 22; }
+
+      void encode_address(std::span<uint8_t> out, const Sphincs_Address& address) const override {
+         const auto adrs = address.to_bytes_compressed();
+         copy_mem(out.data(), adrs.data(), adrs.size());
       }
 
       std::vector<uint8_t> H_msg_digest(StrongSpan<const SphincsMessageRandomness> r,
@@ -86,6 +100,18 @@ class Sphincs_Hash_Functions_Sha2 : public Sphincs_Hash_Functions {
          } else {
             m_sha_256 = std::make_unique<SHA_256>();
          }
+
+         // Batch engines for the same tweaked hashes. The padded pub seed
+         // prefix is exactly one hash block, so the engines can precompute
+         // its midstate once.
+         const size_t n_bits = m_sphincs_params.n() * 8;
+
+         const std::string hash_256 = (m_sphincs_params.n() < 32) ? fmt("Truncated(SHA-256,{})", n_bits) : "SHA-256";
+         m_engine_256 = Hash_Engine::create_or_throw(hash_256, m_padded_pub_seed_256);
+
+         const std::string hash_x =
+            (m_sphincs_params.n() == 16) ? fmt("Truncated(SHA-256,{})", n_bits) : fmt("Truncated(SHA-512,{})", n_bits);
+         m_engine_x = Hash_Engine::create_or_throw(hash_x, m_padded_pub_seed_x);
       }
 
       void PRF_msg(StrongSpan<SphincsMessageRandomness> out,
@@ -110,6 +136,9 @@ class Sphincs_Hash_Functions_Sha2 : public Sphincs_Hash_Functions {
       std::unique_ptr<HashFunction> m_sha_x;
       /// Non truncated SHA-X hash
       std::unique_ptr<HashFunction> m_sha_x_full;
+
+      std::unique_ptr<Hash_Engine> m_engine_256;
+      std::unique_ptr<Hash_Engine> m_engine_x;
 
       std::vector<uint8_t> m_padded_pub_seed_256;
       std::vector<uint8_t> m_padded_pub_seed_x;

--- a/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus_shake_base/sp_hash_shake.h
+++ b/src/lib/pubkey/sphincsplus/sphincsplus_common/sphincsplus_shake_base/sp_hash_shake.h
@@ -11,6 +11,8 @@
 
 #include <botan/internal/sp_hash.h>
 
+#include <botan/internal/fmt.h>
+#include <botan/internal/hash_engine.h>
 #include <botan/internal/shake.h>
 
 namespace Botan {
@@ -25,6 +27,18 @@ class Sphincs_Hash_Functions_Shake : public Sphincs_Hash_Functions {
          m_hash.update(m_pub_seed);
          m_hash.update(address.to_bytes());
          return m_hash;
+      }
+
+      Hash_Engine& tweak_hash_engine(size_t input_length) override {
+         BOTAN_UNUSED(input_length);
+         return *m_engine;
+      }
+
+      size_t address_encoding_len() const override { return 32; }
+
+      void encode_address(std::span<uint8_t> out, const Sphincs_Address& address) const override {
+         const auto adrs = address.to_bytes();
+         copy_mem(out.data(), adrs.data(), adrs.size());
       }
 
       std::vector<uint8_t> H_msg_digest(StrongSpan<const SphincsMessageRandomness> r,
@@ -43,7 +57,9 @@ class Sphincs_Hash_Functions_Shake : public Sphincs_Hash_Functions {
       Sphincs_Hash_Functions_Shake(const Sphincs_Parameters& sphincs_params, const SphincsPublicSeed& pub_seed) :
             Sphincs_Hash_Functions(sphincs_params, pub_seed),
             m_hash(sphincs_params.n() * 8),
-            m_h_msg_hash(8 * sphincs_params.h_msg_digest_bytes()) {}
+            m_h_msg_hash(8 * sphincs_params.h_msg_digest_bytes()),
+            m_engine(Hash_Engine::create_or_throw(fmt("SHAKE-256({})", sphincs_params.n() * 8),
+                                                  std::span<const uint8_t>(pub_seed.get()))) {}
 
       void PRF_msg(StrongSpan<SphincsMessageRandomness> out,
                    StrongSpan<const SphincsSecretPRF> sk_prf,
@@ -61,6 +77,7 @@ class Sphincs_Hash_Functions_Shake : public Sphincs_Hash_Functions {
    private:
       SHAKE_256 m_hash;
       SHAKE_256 m_h_msg_hash;
+      std::unique_ptr<Hash_Engine> m_engine;
 };
 
 }  // namespace Botan

--- a/src/tests/test_sphincsplus_wots.cpp
+++ b/src/tests/test_sphincsplus_wots.cpp
@@ -93,9 +93,10 @@ class SPHINCS_Plus_WOTS_Test final : public Text_Based_Test {
          Botan::WotsSignature sig_out(params.n() * params.wots_len());
          Botan::SphincsTreeNode hashed_pk_out(params.n());
          wots_sign_and_pkgen(Botan::StrongSpan<Botan::WotsSignature>(sig_out),
-                             Botan::StrongSpan<Botan::SphincsTreeNode>(hashed_pk_out),
+                             std::span<uint8_t>(hashed_pk_out.get()),
                              secret_seed,
                              leaf_idx,
+                             1 /* leaf_count */,
                              leaf_idx,
                              wots_steps,
                              leaf_addr,


### PR DESCRIPTION
Improvement vs master on a Tiger Lake system which supports AVX-512

```
+ 788.7% improvement in SLH-DSA-SHA2-192s keygen
+ 765.5% improvement in SLH-DSA-SHAKE-256s keygen
+ 754.6% improvement in SLH-DSA-SHAKE-192s keygen
+ 753.0% improvement in SLH-DSA-SHA2-128s keygen
+ 721.8% improvement in SLH-DSA-SHAKE-128s keygen
+ 622.4% improvement in SLH-DSA-SHA2-256s keygen
+ 562.3% improvement in SLH-DSA-SHA2-128s sign
+ 539.0% improvement in SLH-DSA-SHAKE-128s sign
+ 535.1% improvement in SLH-DSA-SHAKE-256f keygen
+ 378.2% improvement in SLH-DSA-SHA2-256f keygen
+ 351.9% improvement in SLH-DSA-SHAKE-192s sign
+ 340.5% improvement in SLH-DSA-SHAKE-256f sign
+ 335.5% improvement in SLH-DSA-SHA2-192f keygen
+ 324.0% improvement in SLH-DSA-SHA2-128f keygen
+ 301.5% improvement in SLH-DSA-SHA2-128f sign
+ 282.4% improvement in SLH-DSA-SHAKE-256s sign
+ 239.8% improvement in SLH-DSA-SHAKE-192f keygen
+ 230.3% improvement in SLH-DSA-SHA2-192s sign
+ 201.4% improvement in SLH-DSA-SHA2-192f sign
+ 194.8% improvement in SLH-DSA-SHAKE-128f keygen
+ 184.3% improvement in SLH-DSA-SHAKE-128f sign
+ 182.5% improvement in SLH-DSA-SHA2-256f sign
+ 158.6% improvement in SLH-DSA-SHAKE-192f sign
+ 136.3% improvement in SLH-DSA-SHA2-256s sign
+ 131.9% improvement in SLH-DSA-SHA2-128f verify
+ 127.2% improvement in SLH-DSA-SHA2-128s verify
+ 126.1% improvement in SLH-DSA-SHA2-192f verify
+ 124.7% improvement in SLH-DSA-SHAKE-192f verify
+ 118.5% improvement in SLH-DSA-SHAKE-256f verify
+ 112.8% improvement in SLH-DSA-SHAKE-256s verify
+ 112.5% improvement in SLH-DSA-SHAKE-192s verify
+ 104.0% improvement in SLH-DSA-SHAKE-128f verify
+ 102.8% improvement in SLH-DSA-SHAKE-128s verify
+ 95.9% improvement in SLH-DSA-SHA2-256f verify
+ 91.3% improvement in SLH-DSA-SHA2-192s verify
+ 74.7% improvement in SLH-DSA-SHA2-256s verify
```