### PR TITLE
Use Hash_Engine batching in XMSS

### DIFF
--- a/src/lib/pubkey/xmss/info.txt
+++ b/src/lib/pubkey/xmss/info.txt
@@ -26,6 +26,7 @@ xmss_wots.h
 asn1
 rng
 hash
+hash_engine
 stateful_key_index
 trunc_hash
 </requires>

--- a/src/lib/pubkey/xmss/xmss_common_ops.cpp
+++ b/src/lib/pubkey/xmss/xmss_common_ops.cpp
@@ -8,6 +8,7 @@
 
 #include <botan/internal/xmss_common_ops.h>
 
+#include <botan/mem_ops.h>
 #include <botan/internal/xmss_hash.h>
 
 namespace Botan {
@@ -44,26 +45,119 @@ void XMSS_Common_Ops::randomize_tree_hash(secure_vector<uint8_t>& result,
 }
 
 void XMSS_Common_Ops::create_l_tree(secure_vector<uint8_t>& result,
-                                    wots_keysig_t pk,
+                                    const wots_keysig_t& pk,
                                     XMSS_Address adrs,
                                     const secure_vector<uint8_t>& seed,
                                     XMSS_Hash& hash,
                                     const XMSS_Parameters& params) {
+   const size_t n = params.element_size();
+   BOTAN_ASSERT_NOMSG(pk.size() == params.len());
+
+   secure_vector<uint8_t> flat(pk.size() * n);
+   for(size_t i = 0; i < pk.size(); ++i) {
+      BOTAN_ASSERT_NOMSG(pk[i].size() == n);
+      copy_mem(std::span(flat).subspan(i * n, n), pk[i]);
+   }
+
+   result.resize(n);
+   create_l_trees(result, flat, std::span(&adrs, 1), seed, hash, params);
+}
+
+void XMSS_Common_Ops::create_l_trees(std::span<uint8_t> leaves,
+                                     std::span<uint8_t> pks,
+                                     std::span<XMSS_Address> addrs,
+                                     std::span<const uint8_t> seed,
+                                     XMSS_Hash& hash,
+                                     const XMSS_Parameters& params) {
+   const size_t count = addrs.size();
+   const size_t n = params.element_size();
+   const size_t stride = params.len() * n;
+
+   BOTAN_ASSERT_NOMSG(leaves.size() == count * n);
+   BOTAN_ASSERT_NOMSG(pks.size() == count * stride);
+
+   if(count == 0) {
+      return;
+   }
+
+   const size_t adrs_len = addrs[0].size();
+
+   for(auto& adrs : addrs) {
+      adrs.set_tree_height(0);
+   }
+
+   // Scratch for one level's batched randomized tree hashes: per node
+   // pair the three PRF addresses (key, bitmask left/right), the key,
+   // and the masked concatenation of both child nodes
+   const size_t max_pairs = count * (params.len() / 2);
+   std::vector<uint8_t> adrs_buf(3 * max_pairs * adrs_len);
+   secure_vector<uint8_t> keys(max_pairs * n);
+   secure_vector<uint8_t> concat(max_pairs * 2 * n);
+
+   std::vector<std::span<uint8_t>> prf_outs(3 * max_pairs);
+   std::vector<std::span<const uint8_t>> prf_ins(3 * max_pairs);
+   std::vector<std::span<uint8_t>> h_outs(max_pairs);
+   std::vector<std::span<const uint8_t>> h_keys(max_pairs);
+   std::vector<std::span<const uint8_t>> h_ins(max_pairs);
+
+   auto node = [&](size_t k, size_t i) { return pks.subspan(k * stride + i * n, n); };
+
    size_t l = params.len();
-   adrs.set_tree_height(0);
 
    while(l > 1) {
-      for(size_t i = 0; i < l >> 1; i++) {
-         adrs.set_tree_index(static_cast<uint32_t>(i));
-         randomize_tree_hash(pk[i], pk[2 * i], pk[2 * i + 1], adrs, seed, hash, params);
+      const size_t pairs = l >> 1;
+      const size_t total = count * pairs;
+
+      // Compute the keys and both bitmasks of all of this level's node
+      // pairs with one PRF batch, the bitmasks landing in the buffer
+      // that the child nodes are then XORed into
+      for(size_t k = 0; k < count; k++) {
+         for(size_t i = 0; i < pairs; i++) {
+            const size_t p = k * pairs + i;
+            addrs[k].set_tree_index(static_cast<uint32_t>(i));
+            const auto adrs_lane = [&](size_t lane, XMSS_Address::Key_Mask mode) {
+               addrs[k].set_key_mask_mode(mode);
+               const auto dest = std::span(adrs_buf).subspan(lane * adrs_len, adrs_len);
+               copy_mem(dest, addrs[k].bytes());
+               prf_ins[lane] = dest;
+            };
+            adrs_lane(3 * p, XMSS_Address::Key_Mask::Key_Mode);
+            adrs_lane(3 * p + 1, XMSS_Address::Key_Mask::Mask_MSB_Mode);
+            adrs_lane(3 * p + 2, XMSS_Address::Key_Mask::Mask_LSB_Mode);
+
+            prf_outs[3 * p] = std::span(keys).subspan(p * n, n);
+            prf_outs[3 * p + 1] = std::span(concat).subspan(p * 2 * n, n);
+            prf_outs[3 * p + 2] = std::span(concat).subspan(p * 2 * n + n, n);
+         }
       }
+      hash.prf_batch(std::span(prf_outs).first(3 * total), seed, std::span(prf_ins).first(3 * total));
+
+      for(size_t k = 0; k < count; k++) {
+         for(size_t i = 0; i < pairs; i++) {
+            const size_t p = k * pairs + i;
+            xor_buf(std::span(concat).subspan(p * 2 * n, n), node(k, 2 * i));
+            xor_buf(std::span(concat).subspan(p * 2 * n + n, n), node(k, 2 * i + 1));
+            h_outs[p] = node(k, i);
+            h_keys[p] = std::span(keys).subspan(p * n, n);
+            h_ins[p] = std::span(concat).subspan(p * 2 * n, 2 * n);
+         }
+      }
+      hash.h_batch(std::span(h_outs).first(total), std::span(h_keys).first(total), std::span(h_ins).first(total));
+
       if((l & 0x01) == 0x01) {
-         pk[l >> 1] = pk[l - 1];
+         for(size_t k = 0; k < count; k++) {
+            copy_mem(node(k, l >> 1), node(k, l - 1));
+         }
       }
       l = (l >> 1) + (l & 0x01);
-      adrs.set_tree_height(adrs.get_tree_height() + 1);
+      for(auto& adrs : addrs) {
+         adrs.set_tree_height(adrs.get_tree_height() + 1);
+      }
    }
-   result = pk[0];
+
+   for(size_t k = 0; k < count; k++) {
+      copy_mem(leaves.subspan(k * n, n), node(k, 0));
+   }
 }
 
 }  // namespace Botan

--- a/src/lib/pubkey/xmss/xmss_common_ops.h
+++ b/src/lib/pubkey/xmss/xmss_common_ops.h
@@ -11,6 +11,7 @@
 #include <botan/secmem.h>
 #include <botan/xmss_parameters.h>
 #include <botan/internal/xmss_address.h>
+#include <span>
 #include <vector>
 
 namespace Botan {
@@ -68,11 +69,33 @@ class XMSS_Common_Ops {
        * @param[in] params parameters
       **/
       static void create_l_tree(secure_vector<uint8_t>& result,
-                                wots_keysig_t pk,
+                                const wots_keysig_t& pk,
                                 XMSS_Address adrs,
                                 const secure_vector<uint8_t>& seed,
                                 XMSS_Hash& hash,
                                 const XMSS_Parameters& params);
+
+      /**
+       * Algorithm 8: "ltree", applied to many WOTS+ public keys at once,
+       * batching the hash calls of each tree level across all keys.
+       *
+       * @param[out] leaves The compressed n-byte value of each key
+       * @param[in,out] pks The WOTS+ public keys, each len*n bytes,
+       *                contiguous. Destroyed by the computation.
+       * @param[in,out] addrs Per key, its L-tree address with the L-tree
+       *                address set. The tree height/index and key/mask
+       *                mode are modified.
+       * @param[in] seed The public seed
+       * @param[in] hash Instance of XMSS_Hash, that may only be used by the
+       *            thread executing create_l_trees.
+       * @param[in] params parameters
+      **/
+      static void create_l_trees(std::span<uint8_t> leaves,
+                                 std::span<uint8_t> pks,
+                                 std::span<XMSS_Address> addrs,
+                                 std::span<const uint8_t> seed,
+                                 XMSS_Hash& hash,
+                                 const XMSS_Parameters& params);
 };
 
 }  // namespace Botan

--- a/src/lib/pubkey/xmss/xmss_hash.h
+++ b/src/lib/pubkey/xmss/xmss_hash.h
@@ -9,7 +9,9 @@
 #define BOTAN_XMSS_HASH_H_
 
 #include <botan/hash.h>
+#include <botan/internal/hash_engine.h>
 
+#include <algorithm>
 #include <span>
 
 namespace Botan {
@@ -144,11 +146,83 @@ class XMSS_Hash final {
        **/
       secure_vector<uint8_t> h_msg_final();
 
+      /**
+       * Batched variant of prf with a shared key: outputs[i] = prf(key, data[i])
+       **/
+      void prf_batch(std::span<std::span<uint8_t>> outputs,
+                     std::span<const uint8_t> key,
+                     std::span<std::span<const uint8_t>> data) {
+         keyed_engine(0x03, key, m_prf_engine).batch_hash(outputs, data);
+      }
+
+      /**
+       * Batched variant of prf_keygen with a shared key: outputs[i] = prf_keygen(key, data[i])
+       **/
+      void prf_keygen_batch(std::span<std::span<uint8_t>> outputs,
+                            std::span<const uint8_t> key,
+                            std::span<std::span<const uint8_t>> data) {
+         keyed_engine(0x04, key, m_prf_keygen_engine).batch_hash(outputs, data);
+      }
+
+      /**
+       * Batched variant of f: outputs[i] = f(keys[i], data[i])
+       **/
+      void f_batch(std::span<std::span<uint8_t>> outputs,
+                   std::span<std::span<const uint8_t>> keys,
+                   std::span<std::span<const uint8_t>> data) {
+         if(!m_f_engine) {
+            std::vector<uint8_t> prefix(m_zero_padding);
+            prefix.push_back(0x00);
+            m_f_engine = Hash_Engine::create_or_throw(m_hash->name(), prefix);
+         }
+         m_f_engine->batch_hash(outputs, keys, data);
+      }
+
+      /**
+       * Batched variant of h: outputs[i] = h(keys[i], data[i])
+       **/
+      void h_batch(std::span<std::span<uint8_t>> outputs,
+                   std::span<std::span<const uint8_t>> keys,
+                   std::span<std::span<const uint8_t>> data) {
+         if(!m_h_engine) {
+            std::vector<uint8_t> prefix(m_zero_padding);
+            prefix.push_back(0x01);
+            m_h_engine = Hash_Engine::create_or_throw(m_hash->name(), prefix);
+         }
+         m_h_engine->batch_hash(outputs, keys, data);
+      }
+
       size_t output_length() const { return m_hash->output_length(); }
 
    private:
+      /// A batch engine whose prefix bakes in the (usually fixed) key,
+      /// making the prefix exactly one hash block for the n=32 parameter
+      /// sets, which allows a precomputed midstate
+      struct Keyed_Engine {
+            secure_vector<uint8_t> key;
+            std::unique_ptr<Hash_Engine> engine;
+      };
+
+      Hash_Engine& keyed_engine(uint8_t hash_id, std::span<const uint8_t> key, Keyed_Engine& slot) {
+         if(!slot.engine || slot.key.size() != key.size() || !std::equal(key.begin(), key.end(), slot.key.begin())) {
+            secure_vector<uint8_t> prefix(m_zero_padding.begin(), m_zero_padding.end());
+            prefix.push_back(hash_id);
+            prefix.insert(prefix.end(), key.begin(), key.end());
+            slot.key.assign(key.begin(), key.end());
+            slot.engine = Hash_Engine::create_or_throw(m_hash->name(), prefix);
+         }
+         return *slot.engine;
+      }
+
       std::unique_ptr<HashFunction> m_hash;
       std::unique_ptr<HashFunction> m_msg_hash;
+
+      /// Batch engines for prf, prf_keygen, f and h, created on first use.
+      /// Note that these are not copied by the copy constructor.
+      Keyed_Engine m_prf_engine;
+      Keyed_Engine m_prf_keygen_engine;
+      std::unique_ptr<Hash_Engine> m_f_engine;
+      std::unique_ptr<Hash_Engine> m_h_engine;
 
       /// Hash id prefixes (for domain separation) prepended to the hash input
       /// are big-endian representations with `hash_id_length` bytes. See the

--- a/src/lib/pubkey/xmss/xmss_privatekey.cpp
+++ b/src/lib/pubkey/xmss/xmss_privatekey.cpp
@@ -31,14 +31,18 @@
 #include <botan/internal/xmss_common_ops.h>
 #include <botan/internal/xmss_hash.h>
 #include <botan/internal/xmss_signature_operation.h>
-
-#if defined(BOTAN_HAS_THREAD_UTILS)
-   #include <botan/internal/thread_pool.h>
-#endif
+#include <botan/internal/xmss_wots.h>
+#include <algorithm>
 
 namespace Botan {
 
 namespace {
+
+/**
+* Number of leaves whose WOTS+ keys and L-trees are computed at once,
+* so that the hash calls of each step are batched across all of them
+*/
+constexpr size_t LEAF_BATCH = 128;
 
 // fall back to raw decoding for previous versions, which did not encode an OCTET STRING
 secure_vector<uint8_t> extract_raw_private_key(std::span<const uint8_t> key_bits, const XMSS_Parameters& xmss_params) {
@@ -80,13 +84,6 @@ class XMSS_Tree_Builder final {
                                        const XMSS_Address& adrs,
                                        XMSS_Hash& hash) const;
 
-      void tree_hash_subtree(secure_vector<uint8_t>& result,
-                             size_t start_idx,
-                             size_t target_node_height,
-                             XMSS_Address& adrs,
-                             XMSS_Hash& hash) const;
-
-      XMSS_WOTS_PublicKey wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
       XMSS_WOTS_PrivateKey wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const;
 
       const XMSS_Parameters& xmss_parameters() const { return m_xmss_params; }
@@ -94,6 +91,18 @@ class XMSS_Tree_Builder final {
       const secure_vector<uint8_t>& public_seed() const { return m_public_seed; }
 
    private:
+      /**
+      * Compute the leaves [start_idx, start_idx + count) of the tree into
+      * leaves (count * n bytes)
+      */
+      void compute_leaves(std::span<uint8_t> leaves, size_t start_idx, size_t count, XMSS_Hash& hash) const;
+
+      /**
+      * Derive the WOTS+ private keys of addrs.size() / len leaves into
+      * sks; addrs holds the OTS hash address of every chain of every leaf
+      */
+      void wots_private_keys(std::span<uint8_t> sks, std::span<const XMSS_Address> addrs, XMSS_Hash& hash) const;
+
       const XMSS_Parameters& m_xmss_params;
       XMSS_WOTS_Parameters m_wots_params;
       WOTS_Derivation_Method m_wots_derivation_method;
@@ -310,135 +319,41 @@ namespace {
 
 secure_vector<uint8_t> XMSS_Tree_Builder::tree_hash(size_t start_idx,
                                                     size_t target_node_height,
-                                                    const XMSS_Address& adrs,
+                                                    const XMSS_Address& adrs_in,
                                                     XMSS_Hash& hash) const {
    BOTAN_ASSERT_NOMSG(target_node_height <= 30);
    BOTAN_ASSERT((start_idx % (static_cast<size_t>(1) << target_node_height)) == 0,
                 "Start index must be divisible by 2^{target node height}.");
 
-#if defined(BOTAN_HAS_THREAD_UTILS)
-   // determine number of parallel tasks to split the tree_hashing into.
-
-   Thread_Pool& thread_pool = Thread_Pool::global_instance();
-
-   const size_t split_level = std::min(target_node_height, thread_pool.worker_count());
-
-   // skip parallelization overhead for leaf nodes.
-   if(split_level == 0) {
-      secure_vector<uint8_t> result;
-      XMSS_Address subtree_addr(adrs);
-      tree_hash_subtree(result, start_idx, target_node_height, subtree_addr, hash);
-      return result;
-   }
-
-   const size_t subtrees = static_cast<size_t>(1) << split_level;
-   const size_t last_idx = (static_cast<size_t>(1) << (target_node_height)) + start_idx;
-   const size_t offs = (last_idx - start_idx) / subtrees;
-   // this cast cannot overflow because target_node_height is limited
-   uint8_t level = static_cast<uint8_t>(split_level);  // current level in the tree
-
-   BOTAN_ASSERT((last_idx - start_idx) % subtrees == 0,
-                "Number of worker threads in tree_hash need to divide range "
-                "of calculated nodes.");
-
-   std::vector<secure_vector<uint8_t>> nodes(subtrees, secure_vector<uint8_t>(xmss_parameters().element_size()));
-   std::vector<XMSS_Address> node_addresses(subtrees, adrs);
-   std::vector<XMSS_Hash> xmss_hash(subtrees, hash);
-   std::vector<std::future<void>> work;
-
-   // Calculate multiple subtrees in parallel.
-   for(size_t i = 0; i < subtrees; i++) {
-      using tree_hash_subtree_fn_t =
-         void (XMSS_Tree_Builder::*)(secure_vector<uint8_t>&, size_t, size_t, XMSS_Address&, XMSS_Hash&) const;
-
-      const tree_hash_subtree_fn_t work_fn = &XMSS_Tree_Builder::tree_hash_subtree;
-
-      work.push_back(thread_pool.run(work_fn,
-                                     this,
-                                     std::ref(nodes[i]),
-                                     start_idx + i * offs,
-                                     target_node_height - split_level,
-                                     std::ref(node_addresses[i]),
-                                     std::ref(xmss_hash[i])));
-   }
-
-   for(auto& w : work) {
-      w.get();
-   }
-   work.clear();
-
-   // Parallelize the top tree levels horizontally
-   while(level-- > 1) {
-      std::vector<secure_vector<uint8_t>> ro_nodes(nodes.begin(),
-                                                   nodes.begin() + (static_cast<size_t>(1) << (level + 1)));
-
-      for(size_t i = 0; i < (static_cast<size_t>(1) << level); i++) {
-         BOTAN_ASSERT_NOMSG(xmss_hash.size() > i);
-
-         node_addresses[i].set_tree_height(static_cast<uint32_t>(target_node_height - (level + 1)));
-         node_addresses[i].set_tree_index((node_addresses[2 * i + 1].get_tree_index() - 1) >> 1);
-
-         work.push_back(thread_pool.run(&XMSS_Common_Ops::randomize_tree_hash,
-                                        std::ref(nodes[i]),
-                                        std::cref(ro_nodes[2 * i]),
-                                        std::cref(ro_nodes[2 * i + 1]),
-                                        node_addresses[i],
-                                        std::cref(this->public_seed()),
-                                        std::ref(xmss_hash[i]),
-                                        std::cref(xmss_parameters())));
-      }
-
-      for(auto& w : work) {
-         w.get();
-      }
-      work.clear();
-   }
-
-   // Avoid creation an extra thread to calculate root node.
-   node_addresses[0].set_tree_height(static_cast<uint32_t>(target_node_height - 1));
-   node_addresses[0].set_tree_index((node_addresses[1].get_tree_index() - 1) >> 1);
-   XMSS_Common_Ops::randomize_tree_hash(
-      nodes[0], nodes[0], nodes[1], node_addresses[0], this->public_seed(), hash, xmss_parameters());
-   return nodes[0];
-#else
-   secure_vector<uint8_t> result;
-   XMSS_Address subtree_addr(adrs);
-   tree_hash_subtree(result, start_idx, target_node_height, subtree_addr, hash);
-   return result;
-#endif
-}
-
-void XMSS_Tree_Builder::tree_hash_subtree(secure_vector<uint8_t>& result,
-                                          size_t start_idx,
-                                          size_t target_node_height,
-                                          XMSS_Address& adrs,
-                                          XMSS_Hash& hash) const {
+   const size_t n = xmss_parameters().element_size();
    const secure_vector<uint8_t>& seed = this->public_seed();
+   const size_t last_idx = (static_cast<size_t>(1) << target_node_height) + start_idx;
 
-   std::vector<secure_vector<uint8_t>> nodes(target_node_height + 1,
-                                             secure_vector<uint8_t>(xmss_parameters().element_size()));
+   const size_t batch = std::min<size_t>(LEAF_BATCH, last_idx - start_idx);
+   secure_vector<uint8_t> leaves(batch * n);
 
    // node stack, holds all nodes on stack and one extra "pending" node. This
    // temporary node referred to as "node" in the XMSS standard document stays
    // a pending element, meaning it is not regarded as element on the stack
    // until level is increased.
+   std::vector<secure_vector<uint8_t>> nodes(target_node_height + 1, secure_vector<uint8_t>(n));
    std::vector<uint8_t> node_levels(target_node_height + 1);
 
    uint8_t level = 0;  // current level on the node stack.
-   const size_t last_idx = (static_cast<size_t>(1) << target_node_height) + start_idx;
+
+   XMSS_Address adrs(adrs_in);
+   adrs.set_type(XMSS_Address::Type::Hash_Tree_Address);
 
    for(size_t i = start_idx; i < last_idx; i++) {
-      adrs.set_type(XMSS_Address::Type::OTS_Hash_Address);
-      adrs.set_ots_address(static_cast<uint32_t>(i));
+      const size_t b = (i - start_idx) % batch;
+      if(b == 0) {
+         const size_t count = std::min(batch, last_idx - i);
+         compute_leaves(std::span(leaves).first(count * n), i, count, hash);
+      }
 
-      const XMSS_WOTS_PublicKey pk = this->wots_public_key_for(adrs, hash);
-
-      adrs.set_type(XMSS_Address::Type::LTree_Address);
-      adrs.set_ltree_address(static_cast<uint32_t>(i));
-      XMSS_Common_Ops::create_l_tree(nodes[level], pk.key_data(), adrs, seed, hash, xmss_parameters());
+      copy_mem(nodes[level], std::span(leaves).subspan(b * n, n));
       node_levels[level] = 0;
 
-      adrs.set_type(XMSS_Address::Type::Hash_Tree_Address);
       adrs.set_tree_height(0);
       adrs.set_tree_index(static_cast<uint32_t>(i));
 
@@ -452,12 +367,82 @@ void XMSS_Tree_Builder::tree_hash_subtree(secure_vector<uint8_t>& result,
       }
       level++;  //push temporary node to stack
    }
-   result = nodes[level - 1];
+   return nodes[level - 1];
 }
 
-XMSS_WOTS_PublicKey XMSS_Tree_Builder::wots_public_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {
-   const auto private_key = wots_private_key_for(adrs, hash);
-   return XMSS_WOTS_PublicKey(m_wots_params, public_seed(), private_key, adrs, hash);
+void XMSS_Tree_Builder::compute_leaves(std::span<uint8_t> leaves,
+                                       size_t start_idx,
+                                       size_t count,
+                                       XMSS_Hash& hash) const {
+   const size_t n = xmss_parameters().element_size();
+   const size_t len = m_wots_params.len();
+
+   BOTAN_ASSERT_NOMSG(leaves.size() == count * n);
+
+   std::vector<XMSS_Address> ots_addrs(count * len, XMSS_Address(XMSS_Address::Type::OTS_Hash_Address));
+   for(size_t k = 0; k < count; ++k) {
+      for(size_t i = 0; i < len; ++i) {
+         ots_addrs[k * len + i].set_ots_address(static_cast<uint32_t>(start_idx + k));
+         ots_addrs[k * len + i].set_chain_address(static_cast<uint32_t>(i));
+      }
+   }
+
+   secure_vector<uint8_t> keys(count * len * n);
+   wots_private_keys(keys, ots_addrs, hash);
+
+   // Algorithm 4: "WOTS_genPK", transforming the private keys in place
+   const std::vector<uint8_t> from(count * len, 0);
+   const std::vector<uint8_t> to(count * len, static_cast<uint8_t>(m_wots_params.wots_parameter() - 1));
+   xmss_wots_chains(m_wots_params, keys, from, to, ots_addrs, public_seed(), hash);
+
+   std::vector<XMSS_Address> ltree_addrs(count, XMSS_Address(XMSS_Address::Type::LTree_Address));
+   for(size_t k = 0; k < count; ++k) {
+      ltree_addrs[k].set_ltree_address(static_cast<uint32_t>(start_idx + k));
+   }
+   XMSS_Common_Ops::create_l_trees(leaves, keys, ltree_addrs, public_seed(), hash, xmss_parameters());
+}
+
+void XMSS_Tree_Builder::wots_private_keys(std::span<uint8_t> sks,
+                                          std::span<const XMSS_Address> addrs,
+                                          XMSS_Hash& hash) const {
+   const size_t n = xmss_parameters().element_size();
+   const size_t len = m_wots_params.len();
+   const size_t count = addrs.size();
+
+   BOTAN_ASSERT_NOMSG(sks.size() == count * n && count % len == 0);
+
+   switch(m_wots_derivation_method) {
+      case WOTS_Derivation_Method::NIST_SP800_208: {
+         const size_t data_len = public_seed().size() + addrs[0].size();
+         std::vector<uint8_t> data_arena(count * data_len);
+
+         std::vector<std::span<uint8_t>> outputs(count);
+         std::vector<std::span<const uint8_t>> data(count);
+
+         for(size_t i = 0; i < count; ++i) {
+            const auto slot = std::span(data_arena).subspan(i * data_len, data_len);
+            copy_mem(slot.first(public_seed().size()), public_seed());
+            copy_mem(slot.subspan(public_seed().size()), addrs[i].bytes());
+
+            outputs[i] = sks.subspan(i * n, n);
+            data[i] = slot;
+         }
+
+         hash.prf_keygen_batch(outputs, m_private_seed, data);
+         return;
+      }
+      case WOTS_Derivation_Method::Botan2x: {
+         for(size_t k = 0; k < count / len; ++k) {
+            const XMSS_WOTS_PrivateKey sk(m_wots_params, m_private_seed, addrs[k * len], hash);
+            for(size_t i = 0; i < len; ++i) {
+               copy_mem(sks.subspan((k * len + i) * n, n), sk.key_data()[i]);
+            }
+         }
+         return;
+      }
+   }
+
+   throw Invalid_State("WOTS derivation method is out of the enum's range");
 }
 
 XMSS_WOTS_PrivateKey XMSS_Tree_Builder::wots_private_key_for(const XMSS_Address& adrs, XMSS_Hash& hash) const {

--- a/src/lib/pubkey/xmss/xmss_wots.cpp
+++ b/src/lib/pubkey/xmss/xmss_wots.cpp
@@ -14,7 +14,6 @@
 #include <botan/internal/xmss_wots.h>
 
 #include <botan/mem_ops.h>
-#include <botan/internal/concat_util.h>
 #include <botan/internal/xmss_address.h>
 #include <botan/internal/xmss_hash.h>
 #include <botan/internal/xmss_tools.h>
@@ -65,70 +64,154 @@ secure_vector<uint8_t> base_w_with_checksum(const XMSS_WOTS_Parameters& params, 
 }
 
 /**
- * Algorithm 2: Chaining Function.
+ * Algorithm 2 applied to the chains of a single WOTS+ key
  *
- * Takes an n-byte input string and transforms it into a the function
- * result iterating the cryptographic hash function "F" steps times on
- * the input x using the outputs of the PRNG "G".
- *
- * This overload is used in multithreaded scenarios, where it is
- * required to provide separate instances of XMSS_Hash to each
- * thread.
- *
- * @param params      The WOTS parameters to use
- * @param[out] result An n-byte input string, that will be transformed into
- *                    the chaining function result.
- * @param start_idx The start index.
- * @param steps A number of steps.
- * @param adrs An OTS Hash Address.
+ * @param params The WOTS parameters to use
+ * @param[in,out] nodes The chain nodes, transformed in place
+ * @param from Per chain, the first hash address to apply
+ * @param to Per chain, the hash address to stop at (exclusive)
+ * @param adrs The OTS hash address of the key
  * @param seed A seed.
- * @param hash Instance of XMSS_Hash, that may only by the thread
- *             executing chain.
+ * @param hash Instance of XMSS_Hash, that may only be used by the thread
+ *             executing chains.
  **/
-void chain(const XMSS_WOTS_Parameters& params,
-           secure_vector<uint8_t>& result,
-           size_t start_idx,
-           size_t steps,
-           XMSS_Address adrs,
-           std::span<const uint8_t> seed,
-           XMSS_Hash& hash) {
-   BOTAN_ASSERT_NOMSG(result.size() == hash.output_length());
-   BOTAN_ASSERT_NOMSG(start_idx + steps < params.wots_parameter());
-   secure_vector<uint8_t> prf_output(hash.output_length());
+void chains(const XMSS_WOTS_Parameters& params,
+            wots_keysig_t& nodes,
+            std::span<const uint8_t> from,
+            std::span<const uint8_t> to,
+            const XMSS_Address& adrs,
+            std::span<const uint8_t> seed,
+            XMSS_Hash& hash) {
+   const size_t len = nodes.size();
+   const size_t n = hash.output_length();
 
-   // Note that RFC 8391 defines this algorithm recursively (building up the
-   // iterations before any calculation) using 'steps' as the iterator and a
-   // recursion base with 'steps == 0'.
-   // Instead, we implement it iteratively using 'i' as iterator. This makes
-   // 'adrs.set_hash_address(i)' equivalent to 'ADRS.setHashAddress(i + s - 1)'.
-   for(size_t i = start_idx; i < (start_idx + steps) && i < params.wots_parameter(); i++) {
-      adrs.set_hash_address(static_cast<uint32_t>(i));
+   std::vector<XMSS_Address> addrs(len, adrs);
+   secure_vector<uint8_t> flat(len * n);
+   for(size_t i = 0; i < len; ++i) {
+      BOTAN_ASSERT_NOMSG(nodes[i].size() == n);
+      addrs[i].set_chain_address(static_cast<uint32_t>(i));
+      copy_mem(std::span(flat).subspan(i * n, n), nodes[i]);
+   }
 
-      // Calculate tmp XOR bitmask
-      adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Mask_Mode);
-      hash.prf(prf_output, seed, adrs.bytes());
-      xor_buf(result.data(), prf_output.data(), result.size());
+   xmss_wots_chains(params, flat, from, to, addrs, seed, hash);
 
-      // Calculate key
-      adrs.set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
-
-      // Calculate f(key, tmp XOR bitmask)
-      hash.prf(prf_output, seed, adrs.bytes());
-      hash.f(result, prf_output, result);
+   for(size_t i = 0; i < len; ++i) {
+      copy_mem(nodes[i], std::span(flat).subspan(i * n, n));
    }
 }
 
 }  // namespace
 
-XMSS_WOTS_PublicKey::XMSS_WOTS_PublicKey(XMSS_WOTS_Parameters params,
-                                         std::span<const uint8_t> public_seed,
-                                         const XMSS_WOTS_PrivateKey& private_key,
-                                         XMSS_Address adrs,
-                                         XMSS_Hash& hash) :
-      XMSS_WOTS_Base(params, private_key.key_data()) {
-   for(size_t i = 0; i < m_params.len(); ++i) {
-      adrs.set_chain_address(static_cast<uint32_t>(i));
-      chain(m_params, m_key_data[i], 0, m_params.wots_parameter() - 1, adrs, public_seed, hash);
+/*
+ * Note that RFC 8391 defines this algorithm recursively (building up the
+ * iterations before any calculation) using 'steps' as the iterator and a
+ * recursion base with 'steps == 0'.
+ * Instead, we implement it iteratively using 's' as iterator. This makes
+ * 'set_hash_address(s)' equivalent to 'ADRS.setHashAddress(i + s - 1)'.
+ */
+void xmss_wots_chains(const XMSS_WOTS_Parameters& params,
+                      std::span<uint8_t> nodes,
+                      std::span<const uint8_t> from,
+                      std::span<const uint8_t> to,
+                      std::span<XMSS_Address> addrs,
+                      std::span<const uint8_t> seed,
+                      XMSS_Hash& hash) {
+   const size_t count = addrs.size();
+   const size_t n = hash.output_length();
+
+   BOTAN_ASSERT_NOMSG(nodes.size() == count * n);
+   BOTAN_ASSERT_NOMSG(from.size() == count && to.size() == count);
+
+   for(size_t i = 0; i < count; ++i) {
+      BOTAN_ASSERT_NOMSG(to[i] < params.wots_parameter());
+   }
+
+   // Each step computes the bitmask and the key of every active chain
+   // with a single PRF batch. The addresses differ only in the key/mask
+   // mode, so a second set of addresses in mask mode is kept alongside.
+   std::vector<XMSS_Address> mask_addrs(addrs.begin(), addrs.end());
+   for(size_t i = 0; i < count; ++i) {
+      mask_addrs[i].set_key_mask_mode(XMSS_Address::Key_Mask::Mask_Mode);
+      addrs[i].set_key_mask_mode(XMSS_Address::Key_Mask::Key_Mode);
+   }
+
+   // Lane descriptors for the case that every chain is active; the
+   // bitmasks are lanes [0, count) and the keys lanes [count, 2*count).
+   // The address bytes are updated in place each step so the spans
+   // stay valid throughout. The filtered variants are subsets of these.
+   secure_vector<uint8_t> prf_outputs(2 * count * n);
+   std::vector<std::span<uint8_t>> all_prf_out(2 * count);
+   std::vector<std::span<const uint8_t>> all_prf_in(2 * count);
+   std::vector<std::span<uint8_t>> all_node(count);
+   std::vector<std::span<const uint8_t>> all_key(count);
+   std::vector<std::span<const uint8_t>> all_node_in(count);
+
+   for(size_t i = 0; i < count; ++i) {
+      all_prf_out[i] = std::span(prf_outputs).subspan(i * n, n);
+      all_prf_out[count + i] = std::span(prf_outputs).subspan((count + i) * n, n);
+      all_prf_in[i] = mask_addrs[i].bytes();
+      all_prf_in[count + i] = addrs[i].bytes();
+      all_node[i] = nodes.subspan(i * n, n);
+      all_key[i] = all_prf_out[count + i];
+      all_node_in[i] = all_node[i];
+   }
+
+   std::vector<size_t> active;
+   std::vector<std::span<uint8_t>> prf_out;
+   std::vector<std::span<const uint8_t>> prf_in;
+   std::vector<std::span<uint8_t>> node_out;
+   std::vector<std::span<const uint8_t>> keys;
+   std::vector<std::span<const uint8_t>> node_in;
+
+   for(size_t s = 0; s + 1 < params.wots_parameter(); ++s) {
+      active.clear();
+      for(size_t i = 0; i < count; ++i) {
+         if(from[i] <= s && s < to[i]) {
+            active.push_back(i);
+         }
+      }
+      if(active.empty()) {
+         continue;
+      }
+
+      for(const size_t i : active) {
+         addrs[i].set_hash_address(static_cast<uint32_t>(s));
+         mask_addrs[i].set_hash_address(static_cast<uint32_t>(s));
+      }
+
+      if(active.size() == count) {
+         hash.prf_batch(all_prf_out, seed, all_prf_in);
+
+         // Calculate tmp XOR bitmask, then f(key, tmp XOR bitmask)
+         for(size_t i = 0; i < count; ++i) {
+            xor_buf(all_node[i], all_prf_out[i]);
+         }
+         hash.f_batch(all_node, all_key, all_node_in);
+      } else {
+         prf_out.clear();
+         prf_in.clear();
+         node_out.clear();
+         keys.clear();
+         node_in.clear();
+
+         for(const size_t i : active) {
+            prf_out.push_back(all_prf_out[i]);
+            prf_in.push_back(all_prf_in[i]);
+         }
+         for(const size_t i : active) {
+            prf_out.push_back(all_prf_out[count + i]);
+            prf_in.push_back(all_prf_in[count + i]);
+         }
+         hash.prf_batch(prf_out, seed, prf_in);
+
+         for(const size_t i : active) {
+            xor_buf(all_node[i], all_prf_out[i]);
+            node_out.push_back(all_node[i]);
+            keys.push_back(all_key[i]);
+            node_in.push_back(all_node_in[i]);
+         }
+         hash.f_batch(node_out, keys, node_in);
+      }
    }
 }
 
@@ -140,17 +223,9 @@ XMSS_WOTS_PublicKey::XMSS_WOTS_PublicKey(XMSS_WOTS_Parameters params,
                                          XMSS_Hash& hash) :
       XMSS_WOTS_Base(params, std::move(signature)) {
    const secure_vector<uint8_t> msg_digest = base_w_with_checksum(m_params, msg);
+   const std::vector<uint8_t> to(m_params.len(), static_cast<uint8_t>(m_params.wots_parameter() - 1));
 
-   for(size_t i = 0; i < m_params.len(); i++) {
-      adrs.set_chain_address(static_cast<uint32_t>(i));
-      chain(m_params,
-            m_key_data[i],
-            msg_digest[i],
-            m_params.wots_parameter() - 1 - msg_digest[i],
-            adrs,
-            public_seed,
-            hash);
-   }
+   chains(m_params, m_key_data, msg_digest, to, adrs, public_seed, hash);
 }
 
 wots_keysig_t XMSS_WOTS_PrivateKey::sign(const secure_vector<uint8_t>& msg,
@@ -160,10 +235,8 @@ wots_keysig_t XMSS_WOTS_PrivateKey::sign(const secure_vector<uint8_t>& msg,
    const secure_vector<uint8_t> msg_digest = base_w_with_checksum(m_params, msg);
    auto sig = this->key_data();
 
-   for(size_t i = 0; i < m_params.len(); i++) {
-      adrs.set_chain_address(static_cast<uint32_t>(i));
-      chain(m_params, sig[i], 0, msg_digest[i], adrs, public_seed, hash);
-   }
+   const std::vector<uint8_t> from(m_params.len(), 0);
+   chains(m_params, sig, from, msg_digest, adrs, public_seed, hash);
 
    return sig;
 }
@@ -174,12 +247,31 @@ XMSS_WOTS_PrivateKey::XMSS_WOTS_PrivateKey(XMSS_WOTS_Parameters params,
                                            XMSS_Address adrs,
                                            XMSS_Hash& hash) :
       XMSS_WOTS_Base(params) {
-   m_key_data.resize(m_params.len());
-   for(size_t i = 0; i < m_params.len(); ++i) {
-      adrs.set_chain_address(static_cast<uint32_t>(i));
-      const auto data = concat<std::vector<uint8_t>>(public_seed, adrs.bytes());
-      hash.prf_keygen(m_key_data[i], private_seed, data);
+   const size_t len = m_params.len();
+   const size_t n = hash.output_length();
+
+   m_key_data.resize(len);
+
+   std::vector<XMSS_Address> addrs(len, adrs);
+   const size_t data_len = public_seed.size() + adrs.size();
+   std::vector<uint8_t> data_arena(len * data_len);
+
+   std::vector<std::span<uint8_t>> outputs(len);
+   std::vector<std::span<const uint8_t>> data(len);
+
+   for(size_t i = 0; i < len; ++i) {
+      addrs[i].set_chain_address(static_cast<uint32_t>(i));
+
+      const auto slot = std::span(data_arena).subspan(i * data_len, data_len);
+      copy_mem(slot.first(public_seed.size()), public_seed);
+      copy_mem(slot.subspan(public_seed.size()), addrs[i].bytes());
+
+      m_key_data[i].resize(n);
+      outputs[i] = std::span(m_key_data[i]);
+      data[i] = slot;
    }
+
+   hash.prf_keygen_batch(outputs, private_seed, data);
 }
 
 // Constructor for legacy XMSS_PrivateKeys

--- a/src/lib/pubkey/xmss/xmss_wots.h
+++ b/src/lib/pubkey/xmss/xmss_wots.h
@@ -12,6 +12,7 @@
 #include <botan/secmem.h>
 #include <botan/xmss_parameters.h>
 #include <botan/internal/xmss_address.h>
+#include <span>
 #include <vector>
 
 namespace Botan {
@@ -41,29 +42,6 @@ class XMSS_WOTS_Base {
  **/
 class XMSS_WOTS_PublicKey : public XMSS_WOTS_Base {
    public:
-      /**
-       * Algorithm 4: "WOTS_genPK"
-       * Initializes a Winternitz One Time Signature+ (WOTS+) Public Key's
-       * key data, with passed-in private key data using the WOTS chaining
-       * function.
-       *
-       * This overload is used in multithreaded scenarios, where it is
-       * required to provide separate instances of XMSS_Hash to each
-       * thread.
-       *
-       * @param params      The WOTS parameters to use
-       * @param public_seed The public seed for the public key generation
-       * @param private_key The private key to derive the public key from
-       * @param adrs        The address of the key to retrieve.
-       * @param hash        Instance of XMSS_Hash, that may only be used by the
-       *                    thread executing at.
-       **/
-      XMSS_WOTS_PublicKey(XMSS_WOTS_Parameters params,
-                          std::span<const uint8_t> public_seed,
-                          const XMSS_WOTS_PrivateKey& private_key,
-                          XMSS_Address adrs,
-                          XMSS_Hash& hash);
-
       /**
        * Creates a XMSS_WOTS_PublicKey from a message and signature using
        * Algorithm 6 WOTS_pkFromSig defined in the XMSS standard. This
@@ -156,6 +134,31 @@ class XMSS_WOTS_PrivateKey : public XMSS_WOTS_Base {
                          XMSS_Address adrs,
                          XMSS_Hash& hash);
 };
+
+/**
+ * Algorithm 2: Chaining Function, applied to many WOTS+ chains in lock-step.
+ *
+ * For each chain i the hash addresses [from[i], to[i]) are applied to
+ * the i'th n-byte node of nodes, batching the hash calls across all
+ * chains active in each step.
+ *
+ * @param params The WOTS parameters to use
+ * @param[in,out] nodes The chain nodes, transformed in place
+ * @param from Per chain, the first hash address to apply
+ * @param to Per chain, the hash address to stop at (exclusive)
+ * @param[in,out] addrs Per chain, its OTS hash address with the chain
+ *        address set. The hash address and key/mask mode are modified.
+ * @param seed The public seed
+ * @param hash Instance of XMSS_Hash, that may only be used by the thread
+ *        executing xmss_wots_chains.
+ **/
+void xmss_wots_chains(const XMSS_WOTS_Parameters& params,
+                      std::span<uint8_t> nodes,
+                      std::span<const uint8_t> from,
+                      std::span<const uint8_t> to,
+                      std::span<XMSS_Address> addrs,
+                      std::span<const uint8_t> seed,
+                      XMSS_Hash& hash);
 
 }  // namespace Botan
 


### PR DESCRIPTION
Larger change, due to removing the thread pool support from XMSS itself and instead pushing all of the work to `Hash_Engine`

Improvement vs master on a Tiger Lake system (AVX-512, 4 cores + HT):

```
+ 559.8% improvement in XMSS-SHA2_10_256 keygen
+ 494.1% improvement in XMSS-SHA2_10_256 sign
+ 404.7% improvement in XMSS-SHA2_10_512 keygen
+ 350.2% improvement in XMSS-SHA2_10_512 sign
+ 349.6% improvement in XMSS-SHA2_10_512 verify
+ 211.8% improvement in XMSS-SHAKE_10_256 keygen
+ 210.5% improvement in XMSS-SHAKE_10_256 sign
+ 147.8% improvement in XMSS-SHAKE_10_256 verify
+ 144.1% improvement in XMSS-SHA2_10_256 verify
+ 122.3% improvement in XMSS-SHAKE_10_512 verify
+ 113.3% improvement in XMSS-SHAKE_10_512 keygen
+ 101.6% improvement in XMSS-SHAKE_10_512 sign
```