### PR TITLE
Add multi-buffer SHA-256 Hash_Engine

### DIFF
--- a/src/lib/hash_engine/hash_engine.cpp
+++ b/src/lib/hash_engine/hash_engine.cpp
@@ -11,6 +11,10 @@
 #include <botan/hash.h>
 #include <algorithm>
 
+#if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32)
+   #include <botan/internal/hash_engine_sha2_32.h>
+#endif
+
 #if defined(BOTAN_HAS_THREAD_UTILS)
    #include <botan/internal/rounding.h>
    #include <botan/internal/thread_pool.h>
@@ -57,7 +61,11 @@ class Base_Hash_Engine final : public Hash_Engine {
 std::unique_ptr<Hash_Engine> make_base_engine(std::string_view hash_fn,
                                               std::span<const uint8_t> common_prefix,
                                               std::string_view provider) {
-   // SIMD specific dispatch added here later
+#if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32)
+   if(auto engine = create_sha2_32_mb_engine(hash_fn, common_prefix, provider)) {
+      return engine;
+   }
+#endif
 
    if(provider.empty() || provider == "base") {
       if(auto hash = HashFunction::create(hash_fn)) {
@@ -90,6 +98,8 @@ class Threaded_Hash_Engine final : public Hash_Engine {
 
       size_t parallelism() const override { return std::max<size_t>(max_threads(), 1) * m_engines[0]->parallelism(); }
 
+      size_t uncached_prefix_bytes() const override { return m_engines[0]->uncached_prefix_bytes(); }
+
       void batch_hash(std::span<std::span<uint8_t>> outputs,
                       std::span<std::span<const uint8_t>> inputs1,
                       std::span<std::span<const uint8_t>> inputs2) override {
@@ -103,7 +113,7 @@ class Threaded_Hash_Engine final : public Hash_Engine {
          // Both inputs and outputs count towards the work estimate; for
          // XOFs with long outputs squeezing dominates. The +64 approximates
          // padding and finalization overhead.
-         const size_t per_hash_bytes = common_prefix().size() + inputs1[0].size() +
+         const size_t per_hash_bytes = m_engines[0]->uncached_prefix_bytes() + inputs1[0].size() +
                                        (inputs2.empty() ? 0 : inputs2[0].size()) + output_length() + 64;
 
          // Chunk work to not spread too thinly since just queuing the work
@@ -118,7 +128,10 @@ class Threaded_Hash_Engine final : public Hash_Engine {
             return;
          }
 
-         const size_t threads = std::min({max_threads(), count, by_bytes});
+         // A SIMD engine hashes a group of lanes at once, so there is no
+         // point in more threads than groups
+         const size_t lanes = m_engines[0]->parallelism();
+         const size_t threads = std::min({max_threads(), (count + lanes - 1) / lanes, by_bytes});
 
          if(threads <= 1) {
             m_engines[0]->batch_hash(outputs, inputs1, inputs2);

--- a/src/lib/hash_engine/hash_engine.h
+++ b/src/lib/hash_engine/hash_engine.h
@@ -40,6 +40,12 @@ class BOTAN_TEST_API Hash_Engine {
       virtual size_t parallelism() const = 0;
 
       /**
+      * @return bytes of the common prefix hashed again for each message,
+      * rather than being covered by a precomputed state
+      */
+      virtual size_t uncached_prefix_bytes() const { return common_prefix().size(); }
+
+      /**
       * Hash many inputs
       *
       * Computes H(common_prefix || inputs[i]) into outputs[i]. Each input

--- a/src/lib/hash_engine/hash_engine_mdx.h
+++ b/src/lib/hash_engine/hash_engine_mdx.h
@@ -1,0 +1,270 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HASH_ENGINE_MDX_H_
+#define BOTAN_HASH_ENGINE_MDX_H_
+
+#include <botan/assert.h>
+#include <botan/mem_ops.h>
+#include <botan/internal/hash_engine.h>
+#include <botan/internal/int_utils.h>
+#include <botan/internal/loadstor.h>
+#include <algorithm>
+#include <array>
+#include <concepts>
+
+namespace Botan {
+
+/**
+* Generic multi-buffer engine for big-endian Merkle-Damgard hashes
+*
+* The states buffer passed to the compression function holds the 8
+* chaining variables for each lane, as little-endian words in
+* variable-major order (all lanes of A, then all lanes of B, ...).
+* blocks[l] points to the first of nblocks contiguous blocks for lane l.
+*
+* The extract function transposes the states into digests, which holds
+* the full (untruncated) big-endian digest of each lane in lane order.
+*/
+template <std::unsigned_integral W>
+class MDx_MB_Engine final : public Hash_Engine {
+   public:
+      using compress_fn = void (*)(uint8_t* states, const uint8_t* const* blocks, size_t nblocks);
+      using extract_fn = void (*)(const uint8_t* states, uint8_t* digests);
+
+      MDx_MB_Engine(std::string_view name,
+                    size_t output_length,
+                    std::span<const uint8_t> common_prefix,
+                    std::string_view provider,
+                    size_t lanes,
+                    size_t block_bytes,
+                    size_t ctr_bytes,
+                    std::span<const W> midstate,
+                    compress_fn compress,
+                    extract_fn extract) :
+            Hash_Engine(common_prefix),
+            m_name(name),
+            m_provider(provider),
+            m_output_length(output_length),
+            m_lanes(lanes),
+            m_block_bytes(block_bytes),
+            m_ctr_bytes(ctr_bytes),
+            m_prefix_full_bytes(common_prefix.size() - common_prefix.size() % block_bytes),
+            m_compress(compress),
+            m_extract(extract),
+            m_initial_states(8 * lanes * sizeof(W)),
+            m_states(8 * lanes * sizeof(W)),
+            m_digests(8 * lanes * sizeof(W)),
+            m_ptrs(lanes) {
+         BOTAN_ASSERT_NOMSG(midstate.size() == 8);
+
+         for(size_t j = 0; j != 8; ++j) {
+            for(size_t l = 0; l != m_lanes; ++l) {
+               store_le(midstate[j], &m_initial_states[(j * m_lanes + l) * sizeof(W)]);
+            }
+         }
+      }
+
+      std::string name() const override { return m_name; }
+
+      std::string provider() const override { return m_provider; }
+
+      size_t output_length() const override { return m_output_length; }
+
+      size_t parallelism() const override { return m_lanes; }
+
+      size_t uncached_prefix_bytes() const override { return common_prefix().size() - m_prefix_full_bytes; }
+
+      void batch_hash(std::span<std::span<uint8_t>> outputs,
+                      std::span<std::span<const uint8_t>> inputs1,
+                      std::span<std::span<const uint8_t>> inputs2) override {
+         check_batch_args(outputs, inputs1, inputs2);
+
+         const size_t count = inputs1.size();
+         if(count == 0) {
+            return;
+         }
+
+         // The logical stream hashed for lane i is
+         //   rem || inputs1[i] || inputs2[i] || padding
+         // where rem is the part of the prefix not covered by the midstate
+         const auto rem = common_prefix().subspan(m_prefix_full_bytes);
+         const size_t r = rem.size();
+         const size_t len1 = inputs1[0].size();
+         const size_t len2 = inputs2.empty() ? 0 : inputs2[0].size();
+
+         // Checked so that the padded length and the offsets derived from
+         // it cannot wrap for huge inputs, which matters on 32-bit targets
+         const auto padded_end = checked_add(r, len1, len2, 1 + m_ctr_bytes + (m_block_bytes - 1));
+         BOTAN_ARG_CHECK(padded_end.has_value(), "Hash_Engine::batch_hash inputs too long");
+
+         const size_t stream_len = r + len1 + len2;
+         const size_t blocks = *padded_end / m_block_bytes;
+         const size_t padded_len = m_block_bytes * blocks;
+         const uint64_t total_bits = 8 * static_cast<uint64_t>(common_prefix().size() + len1 + len2);
+
+         // Ranges of blocks lying entirely within one input are hashed
+         // directly from the caller's buffers. All other blocks are
+         // assembled in scratch, each in its own slot, since everything
+         // in them except the input bytes is the same for every lane.
+         const size_t d1_lo = (r + m_block_bytes - 1) / m_block_bytes;
+         const size_t d1_hi = (r + len1) / m_block_bytes;
+         const size_t d2_lo = (r + len1 + m_block_bytes - 1) / m_block_bytes;
+         const size_t d2_hi = (r + len1 + len2) / m_block_bytes;
+
+         std::array<Step, MAX_STEPS> steps{};
+         size_t nsteps = 0;
+         size_t scratch_blocks = 0;
+
+         for(size_t b = 0; b < blocks;) {
+            BOTAN_ASSERT_NOMSG(nsteps < MAX_STEPS);
+            Step& step = steps[nsteps++];
+
+            if(b >= d1_lo && b < d1_hi) {
+               step = Step{Step::Direct1, b, d1_hi, 0};
+            } else if(b >= d2_lo && b < d2_hi) {
+               step = Step{Step::Direct2, b, d2_hi, 0};
+            } else {
+               size_t e = blocks;
+               if(b < d1_lo && d1_lo < d1_hi) {
+                  e = std::min(e, d1_lo);
+               }
+               if(b < d2_lo && d2_lo < d2_hi) {
+                  e = std::min(e, d2_lo);
+               }
+               step = Step{Step::Scratch, b, e, scratch_blocks};
+               scratch_blocks += e - b;
+            }
+
+            b = step.hi;
+         }
+
+         const size_t lane_stride = scratch_blocks * m_block_bytes;
+         if(m_scratch.size() < m_lanes * lane_stride) {
+            m_scratch.resize(m_lanes * lane_stride);
+         }
+         auto scratch = [&](size_t lane, const Step& step) {
+            return &m_scratch[lane * lane_stride + step.slot * m_block_bytes];
+         };
+
+         // Write the lane invariant parts of the scratch blocks: the
+         // prefix remainder, the padding byte, zeros and the counter
+         for(size_t i = 0; i != nsteps; ++i) {
+            const Step& step = steps[i];
+            if(step.kind != Step::Scratch) {
+               continue;
+            }
+            const size_t lo = step.lo * m_block_bytes;
+            const size_t hi = step.hi * m_block_bytes;
+
+            for(size_t l = 0; l != m_lanes; ++l) {
+               uint8_t* dest = scratch(l, step);
+               clear_mem(dest, hi - lo);
+               copy_overlap(dest, lo, hi, rem, 0);
+               if(stream_len >= lo && stream_len < hi) {
+                  dest[stream_len - lo] = 0x80;
+               }
+               // Low 8 bytes of the counter; any high bytes stay zero
+               if(hi == padded_len) {
+                  store_be(total_bits, dest + (padded_len - 8 - lo));
+               }
+            }
+         }
+
+         for(size_t base = 0; base < count; base += m_lanes) {
+            // Excess lanes of the last batch just recompute the final message
+            auto lane_idx = [&](size_t l) { return std::min(base + l, count - 1); };
+
+            copy_mem(m_states, m_initial_states);
+
+            for(size_t i = 0; i != nsteps; ++i) {
+               const Step& step = steps[i];
+               const size_t lo = step.lo * m_block_bytes;
+               const size_t hi = step.hi * m_block_bytes;
+
+               if(step.kind == Step::Direct1) {
+                  for(size_t l = 0; l != m_lanes; ++l) {
+                     m_ptrs[l] = inputs1[lane_idx(l)].data() + (lo - r);
+                  }
+               } else if(step.kind == Step::Direct2) {
+                  for(size_t l = 0; l != m_lanes; ++l) {
+                     m_ptrs[l] = inputs2[lane_idx(l)].data() + (lo - r - len1);
+                  }
+               } else {
+                  for(size_t l = 0; l != m_lanes; ++l) {
+                     uint8_t* dest = scratch(l, step);
+                     copy_overlap(dest, lo, hi, inputs1[lane_idx(l)], r);
+                     if(!inputs2.empty()) {
+                        copy_overlap(dest, lo, hi, inputs2[lane_idx(l)], r + len1);
+                     }
+                     m_ptrs[l] = dest;
+                  }
+               }
+
+               m_compress(m_states.data(), m_ptrs.data(), step.hi - step.lo);
+            }
+
+            m_extract(m_states.data(), m_digests.data());
+
+            const size_t used_lanes = std::min(m_lanes, count - base);
+            for(size_t l = 0; l != used_lanes; ++l) {
+               copy_mem(outputs[base + l].first(m_output_length),
+                        std::span(m_digests).subspan(l * DIGEST_BYTES, m_output_length));
+            }
+         }
+      }
+
+   private:
+      static constexpr size_t DIGEST_BYTES = 8 * sizeof(W);
+
+      /**
+      * One range of blocks [lo, hi) of the padded stream, either hashed
+      * directly from the first or second input, or from scratch slot
+      * slot onwards
+      */
+      struct Step {
+            enum Kind : uint8_t { Direct1, Direct2, Scratch };
+
+            Kind kind;
+            size_t lo;
+            size_t hi;
+            size_t slot;
+      };
+
+      // At most scratch, direct1, scratch, direct2, scratch
+      static constexpr size_t MAX_STEPS = 5;
+
+      /**
+      * Copy the part of src (which starts at offset in the stream) that
+      * lies within the stream bytes [lo, hi) to dest
+      */
+      static void copy_overlap(uint8_t* dest, size_t lo, size_t hi, std::span<const uint8_t> src, size_t offset) {
+         const size_t i0 = std::max(lo, offset);
+         const size_t i1 = std::min(hi, offset + src.size());
+         if(i0 < i1) {
+            copy_mem(dest + (i0 - lo), src.data() + (i0 - offset), i1 - i0);
+         }
+      }
+
+      std::string m_name;
+      std::string m_provider;
+      size_t m_output_length;
+      size_t m_lanes;
+      size_t m_block_bytes;
+      size_t m_ctr_bytes;
+      size_t m_prefix_full_bytes;
+      compress_fn m_compress;
+      extract_fn m_extract;
+      secure_vector<uint8_t> m_initial_states;
+      secure_vector<uint8_t> m_states;
+      secure_vector<uint8_t> m_digests;
+      secure_vector<uint8_t> m_scratch;
+      std::vector<const uint8_t*> m_ptrs;
+};
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32.cpp
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32.cpp
@@ -1,0 +1,86 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/hash_engine_sha2_32.h>
+
+#include <botan/assert.h>
+#include <botan/internal/hash_engine_mdx.h>
+#include <botan/internal/scan_name.h>
+#include <botan/internal/sha2_32.h>
+
+#if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX2) || defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX512)
+   #define BOTAN_HASH_ENGINE_SHA2_32_HAS_IMPL
+   #include <botan/internal/cpuid.h>
+#endif
+
+namespace Botan {
+
+std::unique_ptr<Hash_Engine> create_sha2_32_mb_engine(std::string_view hash_fn,
+                                                      std::span<const uint8_t> common_prefix,
+                                                      std::string_view provider) {
+#if defined(BOTAN_HASH_ENGINE_SHA2_32_HAS_IMPL)
+   size_t output_length = 0;
+
+   const SCAN_Name req(hash_fn);
+   if(req.algo_name() == "SHA-256" && req.arg_count() == 0) {
+      output_length = 32;
+   } else if(req.algo_name() == "Truncated" && req.arg_count() == 2 && req.arg(0) == "SHA-256") {
+      const size_t bits = req.arg_as_integer(1);
+      if(bits == 0 || bits % 8 != 0 || bits > 256) {
+         return nullptr;
+      }
+      output_length = bits / 8;
+   } else {
+      return nullptr;
+   }
+
+   SHA_256::digest_type midstate;
+   SHA_256::init(midstate);
+   const size_t full_bytes = common_prefix.size() - common_prefix.size() % SHA_256::block_bytes;
+   if(full_bytes > 0) {
+      SHA_256::compress_digest(midstate, common_prefix.first(full_bytes), full_bytes / SHA_256::block_bytes);
+   }
+
+   auto make_engine = [&](std::string_view feat,
+                          size_t lanes,
+                          MDx_MB_Engine<uint32_t>::compress_fn compress,
+                          MDx_MB_Engine<uint32_t>::extract_fn extract) {
+      return std::make_unique<MDx_MB_Engine<uint32_t>>(hash_fn,
+                                                       output_length,
+                                                       common_prefix,
+                                                       feat,
+                                                       lanes,
+                                                       SHA_256::block_bytes,
+                                                       SHA_256::ctr_bytes,
+                                                       midstate,
+                                                       compress,
+                                                       extract);
+   };
+
+   #if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX512)
+   if(auto feat = CPUID::check(CPUID::Feature::AVX512)) {
+      if(provider.empty() || provider == *feat) {
+         return make_engine(*feat, 16, sha2_32_mb_compress_x16, sha2_32_mb_extract_x16);
+      }
+   }
+   #endif
+
+   #if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX2)
+   if(auto feat = CPUID::check(CPUID::Feature::AVX2)) {
+      if(provider.empty() || provider == *feat) {
+         return make_engine(*feat, 8, sha2_32_mb_compress_x8, sha2_32_mb_extract_x8);
+      }
+   }
+   #endif
+
+   return nullptr;
+#else
+   BOTAN_UNUSED(hash_fn, common_prefix, provider);
+   return nullptr;
+#endif
+}
+
+}  // namespace Botan

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32.h
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32.h
@@ -1,0 +1,49 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#ifndef BOTAN_HASH_ENGINE_SHA2_32_H_
+#define BOTAN_HASH_ENGINE_SHA2_32_H_
+
+#include <botan/internal/hash_engine.h>
+
+namespace Botan {
+
+/**
+* Create a multi-buffer SHA-256 Hash_Engine
+*
+* Returns nullptr if the hash is not SHA-256 (possibly truncated), if
+* the requested provider does not match, or if no SIMD implementation
+* is usable on this CPU.
+*/
+std::unique_ptr<Hash_Engine> create_sha2_32_mb_engine(std::string_view hash_fn,
+                                                      std::span<const uint8_t> common_prefix,
+                                                      std::string_view provider);
+
+/*
+* Multi-buffer SHA-256 compression functions
+*
+* The states buffer holds the 8 chaining variables for each lane, as
+* little-endian words in variable-major order (all lanes of A, then all
+* lanes of B, ...). blocks[l] points to the first of nblocks contiguous
+* 64 byte blocks for lane l.
+*
+* The extract functions transpose the states into the 32 byte big-endian
+* digest of each lane, stored contiguously in lane order.
+*/
+
+#if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX2)
+void sha2_32_mb_compress_x8(uint8_t* states, const uint8_t* const* blocks, size_t nblocks);
+void sha2_32_mb_extract_x8(const uint8_t* states, uint8_t* digests);
+#endif
+
+#if defined(BOTAN_HAS_HASH_ENGINE_SHA2_32_AVX512)
+void sha2_32_mb_compress_x16(uint8_t* states, const uint8_t* const* blocks, size_t nblocks);
+void sha2_32_mb_extract_x16(const uint8_t* states, uint8_t* digests);
+#endif
+
+}  // namespace Botan
+
+#endif

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx2/hash_engine_sha2_32_avx2.cpp
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx2/hash_engine_sha2_32_avx2.cpp
@@ -1,0 +1,143 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/hash_engine_sha2_32.h>
+
+#include <botan/internal/isa_extn.h>
+#include <botan/internal/simd_8x32.h>
+
+namespace Botan {
+
+namespace {
+
+BOTAN_FN_ISA_AVX2 BOTAN_FORCE_INLINE void rnd(const SIMD_8x32& A,
+                                              const SIMD_8x32& B,
+                                              const SIMD_8x32& C,
+                                              SIMD_8x32& D,
+                                              const SIMD_8x32& E,
+                                              const SIMD_8x32& F,
+                                              const SIMD_8x32& G,
+                                              SIMD_8x32& H,
+                                              const SIMD_8x32& W,
+                                              uint32_t K) {
+   const auto T1 = H + E.sigma1() + SIMD_8x32::choose(E, F, G) + SIMD_8x32::splat(K) + W;
+   const auto T2 = A.sigma0() + SIMD_8x32::majority(A, B, C);
+   D += T1;
+   H = T1 + T2;
+}
+
+BOTAN_FN_ISA_AVX2 BOTAN_FORCE_INLINE SIMD_8x32 next_w(SIMD_8x32 W[16], size_t i) {
+   const auto& w15 = W[(i + 1) % 16];
+   const auto& w2 = W[(i + 14) % 16];
+   const auto s0 = w15.rotr<7>() ^ w15.rotr<18>() ^ w15.shr<3>();
+   const auto s1 = w2.rotr<17>() ^ w2.rotr<19>() ^ w2.shr<10>();
+   W[i] += s0 + s1 + W[(i + 9) % 16];
+   return W[i];
+}
+
+}  // namespace
+
+BOTAN_FN_ISA_AVX2 void sha2_32_mb_compress_x8(uint8_t* states, const uint8_t* const* blocks, size_t nblocks) {
+   alignas(64) const uint32_t SHA256_K[64] = {
+      0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+      0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+      0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC, 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+      0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7, 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+      0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13, 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+      0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3, 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+      0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5, 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+      0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208, 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2};
+
+   SIMD_8x32 S[8];
+   for(size_t j = 0; j != 8; ++j) {
+      S[j] = SIMD_8x32::load_le(states + 32 * j);
+   }
+
+   for(size_t n = 0; n != nblocks; ++n) {
+      // Initialized directly from the loads, since default construction
+      // would zero the whole array first
+      auto load_w = [&](size_t l, size_t off) { return SIMD_8x32::load_be(blocks[l] + 64 * n + off); };
+      SIMD_8x32 W[16] = {load_w(0, 0),
+                         load_w(1, 0),
+                         load_w(2, 0),
+                         load_w(3, 0),
+                         load_w(4, 0),
+                         load_w(5, 0),
+                         load_w(6, 0),
+                         load_w(7, 0),
+                         load_w(0, 32),
+                         load_w(1, 32),
+                         load_w(2, 32),
+                         load_w(3, 32),
+                         load_w(4, 32),
+                         load_w(5, 32),
+                         load_w(6, 32),
+                         load_w(7, 32)};
+      SIMD_8x32::transpose(W[0], W[1], W[2], W[3], W[4], W[5], W[6], W[7]);
+      SIMD_8x32::transpose(W[8], W[9], W[10], W[11], W[12], W[13], W[14], W[15]);
+
+      SIMD_8x32 A = S[0];
+      SIMD_8x32 B = S[1];
+      SIMD_8x32 C = S[2];
+      SIMD_8x32 D = S[3];
+      SIMD_8x32 E = S[4];
+      SIMD_8x32 F = S[5];
+      SIMD_8x32 G = S[6];
+      SIMD_8x32 H = S[7];
+
+      for(size_t t = 0; t != 16; t += 8) {
+         rnd(A, B, C, D, E, F, G, H, W[t + 0], SHA256_K[t + 0]);
+         rnd(H, A, B, C, D, E, F, G, W[t + 1], SHA256_K[t + 1]);
+         rnd(G, H, A, B, C, D, E, F, W[t + 2], SHA256_K[t + 2]);
+         rnd(F, G, H, A, B, C, D, E, W[t + 3], SHA256_K[t + 3]);
+         rnd(E, F, G, H, A, B, C, D, W[t + 4], SHA256_K[t + 4]);
+         rnd(D, E, F, G, H, A, B, C, W[t + 5], SHA256_K[t + 5]);
+         rnd(C, D, E, F, G, H, A, B, W[t + 6], SHA256_K[t + 6]);
+         rnd(B, C, D, E, F, G, H, A, W[t + 7], SHA256_K[t + 7]);
+      }
+
+      for(size_t t = 16; t != 64; t += 8) {
+         rnd(A, B, C, D, E, F, G, H, next_w(W, (t + 0) % 16), SHA256_K[t + 0]);
+         rnd(H, A, B, C, D, E, F, G, next_w(W, (t + 1) % 16), SHA256_K[t + 1]);
+         rnd(G, H, A, B, C, D, E, F, next_w(W, (t + 2) % 16), SHA256_K[t + 2]);
+         rnd(F, G, H, A, B, C, D, E, next_w(W, (t + 3) % 16), SHA256_K[t + 3]);
+         rnd(E, F, G, H, A, B, C, D, next_w(W, (t + 4) % 16), SHA256_K[t + 4]);
+         rnd(D, E, F, G, H, A, B, C, next_w(W, (t + 5) % 16), SHA256_K[t + 5]);
+         rnd(C, D, E, F, G, H, A, B, next_w(W, (t + 6) % 16), SHA256_K[t + 6]);
+         rnd(B, C, D, E, F, G, H, A, next_w(W, (t + 7) % 16), SHA256_K[t + 7]);
+      }
+
+      S[0] += A;
+      S[1] += B;
+      S[2] += C;
+      S[3] += D;
+      S[4] += E;
+      S[5] += F;
+      S[6] += G;
+      S[7] += H;
+   }
+
+   for(size_t j = 0; j != 8; ++j) {
+      S[j].store_le(states + 32 * j);
+   }
+}
+
+BOTAN_FN_ISA_AVX2 void sha2_32_mb_extract_x8(const uint8_t* states, uint8_t* digests) {
+   SIMD_8x32 S[8];
+   for(size_t j = 0; j != 8; ++j) {
+      S[j] = SIMD_8x32::load_le(states + 32 * j);
+   }
+
+   // Each S[j] holds word j of all 8 lanes; the transpose turns that
+   // into the 8 words of each lane
+   SIMD_8x32::transpose(S[0], S[1], S[2], S[3], S[4], S[5], S[6], S[7]);
+
+   for(size_t l = 0; l != 8; ++l) {
+      S[l].store_be(digests + 32 * l);
+   }
+}
+
+}  // namespace Botan

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx2/info.txt
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx2/info.txt
@@ -1,0 +1,16 @@
+<internal_defines>
+HASH_ENGINE_SHA2_32_AVX2 -> 20260705
+</internal_defines>
+
+<module_info>
+name -> "Multi-buffer SHA-256 using AVX2"
+</module_info>
+
+<isa>
+avx2
+</isa>
+
+<requires>
+cpuid
+simd_8x32
+</requires>

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx512/hash_engine_sha2_32_avx512.cpp
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx512/hash_engine_sha2_32_avx512.cpp
@@ -1,0 +1,171 @@
+/*
+* (C) 2026 Jack Lloyd
+*
+* Botan is released under the Simplified BSD License (see license.txt)
+*/
+
+#include <botan/internal/hash_engine_sha2_32.h>
+
+#include <botan/internal/isa_extn.h>
+#include <botan/internal/simd_avx512.h>
+
+namespace Botan {
+
+namespace {
+
+BOTAN_FN_ISA_AVX512 BOTAN_FORCE_INLINE void rnd(const SIMD_16x32& A,
+                                                const SIMD_16x32& B,
+                                                const SIMD_16x32& C,
+                                                SIMD_16x32& D,
+                                                const SIMD_16x32& E,
+                                                const SIMD_16x32& F,
+                                                const SIMD_16x32& G,
+                                                SIMD_16x32& H,
+                                                const SIMD_16x32& W,
+                                                uint32_t K) {
+   const auto T1 = H + E.sigma1() + SIMD_16x32::choose(E, F, G) + SIMD_16x32::splat(K) + W;
+   const auto T2 = A.sigma0() + SIMD_16x32::majority(A, B, C);
+   D += T1;
+   H = T1 + T2;
+}
+
+template <size_t I>
+BOTAN_FN_ISA_AVX512 BOTAN_FORCE_INLINE SIMD_16x32 next_w(SIMD_16x32 W[16]) {
+   const auto& w15 = W[(I + 1) % 16];
+   const auto& w2 = W[(I + 14) % 16];
+   const auto s0 = w15.rotr<7>() ^ w15.rotr<18>() ^ w15.shr<3>();
+   const auto s1 = w2.rotr<17>() ^ w2.rotr<19>() ^ w2.shr<10>();
+   W[I] += s0 + s1 + W[(I + 9) % 16];
+   return W[I];
+}
+
+/**
+* Store each 128-bit quarter of v separately, quarter q to out + q * stride
+*/
+BOTAN_FN_ISA_AVX512 BOTAN_FORCE_INLINE void store_quarters(const SIMD_16x32& v, uint8_t* out, size_t stride) {
+   _mm_storeu_si128(reinterpret_cast<__m128i*>(out), _mm512_castsi512_si128(v.raw()));
+   _mm_storeu_si128(reinterpret_cast<__m128i*>(out + stride), _mm512_extracti32x4_epi32(v.raw(), 1));
+   _mm_storeu_si128(reinterpret_cast<__m128i*>(out + 2 * stride), _mm512_extracti32x4_epi32(v.raw(), 2));
+   _mm_storeu_si128(reinterpret_cast<__m128i*>(out + 3 * stride), _mm512_extracti32x4_epi32(v.raw(), 3));
+}
+
+}  // namespace
+
+BOTAN_FN_ISA_AVX512 void sha2_32_mb_compress_x16(uint8_t* states, const uint8_t* const* blocks, size_t nblocks) {
+   alignas(64) const uint32_t SHA256_K[64] = {
+      0x428A2F98, 0x71374491, 0xB5C0FBCF, 0xE9B5DBA5, 0x3956C25B, 0x59F111F1, 0x923F82A4, 0xAB1C5ED5,
+      0xD807AA98, 0x12835B01, 0x243185BE, 0x550C7DC3, 0x72BE5D74, 0x80DEB1FE, 0x9BDC06A7, 0xC19BF174,
+      0xE49B69C1, 0xEFBE4786, 0x0FC19DC6, 0x240CA1CC, 0x2DE92C6F, 0x4A7484AA, 0x5CB0A9DC, 0x76F988DA,
+      0x983E5152, 0xA831C66D, 0xB00327C8, 0xBF597FC7, 0xC6E00BF3, 0xD5A79147, 0x06CA6351, 0x14292967,
+      0x27B70A85, 0x2E1B2138, 0x4D2C6DFC, 0x53380D13, 0x650A7354, 0x766A0ABB, 0x81C2C92E, 0x92722C85,
+      0xA2BFE8A1, 0xA81A664B, 0xC24B8B70, 0xC76C51A3, 0xD192E819, 0xD6990624, 0xF40E3585, 0x106AA070,
+      0x19A4C116, 0x1E376C08, 0x2748774C, 0x34B0BCB5, 0x391C0CB3, 0x4ED8AA4A, 0x5B9CCA4F, 0x682E6FF3,
+      0x748F82EE, 0x78A5636F, 0x84C87814, 0x8CC70208, 0x90BEFFFA, 0xA4506CEB, 0xBEF9A3F7, 0xC67178F2};
+   SIMD_16x32 S[8];
+   for(size_t j = 0; j != 8; ++j) {
+      S[j] = SIMD_16x32::load_le(states + 64 * j);
+   }
+
+   for(size_t n = 0; n != nblocks; ++n) {
+      // Initialized directly from the loads, since default construction
+      // would zero the whole array first
+      auto load_w = [&](size_t l) { return SIMD_16x32::load_be(blocks[l] + 64 * n); };
+      SIMD_16x32 W[16] = {load_w(0),
+                          load_w(1),
+                          load_w(2),
+                          load_w(3),
+                          load_w(4),
+                          load_w(5),
+                          load_w(6),
+                          load_w(7),
+                          load_w(8),
+                          load_w(9),
+                          load_w(10),
+                          load_w(11),
+                          load_w(12),
+                          load_w(13),
+                          load_w(14),
+                          load_w(15)};
+      SIMD_16x32::transpose(
+         W[0], W[1], W[2], W[3], W[4], W[5], W[6], W[7], W[8], W[9], W[10], W[11], W[12], W[13], W[14], W[15]);
+
+      SIMD_16x32 A = S[0];
+      SIMD_16x32 B = S[1];
+      SIMD_16x32 C = S[2];
+      SIMD_16x32 D = S[3];
+      SIMD_16x32 E = S[4];
+      SIMD_16x32 F = S[5];
+      SIMD_16x32 G = S[6];
+      SIMD_16x32 H = S[7];
+
+      // Every index into W is a constant so that it can stay in registers
+      rnd(A, B, C, D, E, F, G, H, W[0], SHA256_K[0]);
+      rnd(H, A, B, C, D, E, F, G, W[1], SHA256_K[1]);
+      rnd(G, H, A, B, C, D, E, F, W[2], SHA256_K[2]);
+      rnd(F, G, H, A, B, C, D, E, W[3], SHA256_K[3]);
+      rnd(E, F, G, H, A, B, C, D, W[4], SHA256_K[4]);
+      rnd(D, E, F, G, H, A, B, C, W[5], SHA256_K[5]);
+      rnd(C, D, E, F, G, H, A, B, W[6], SHA256_K[6]);
+      rnd(B, C, D, E, F, G, H, A, W[7], SHA256_K[7]);
+      rnd(A, B, C, D, E, F, G, H, W[8], SHA256_K[8]);
+      rnd(H, A, B, C, D, E, F, G, W[9], SHA256_K[9]);
+      rnd(G, H, A, B, C, D, E, F, W[10], SHA256_K[10]);
+      rnd(F, G, H, A, B, C, D, E, W[11], SHA256_K[11]);
+      rnd(E, F, G, H, A, B, C, D, W[12], SHA256_K[12]);
+      rnd(D, E, F, G, H, A, B, C, W[13], SHA256_K[13]);
+      rnd(C, D, E, F, G, H, A, B, W[14], SHA256_K[14]);
+      rnd(B, C, D, E, F, G, H, A, W[15], SHA256_K[15]);
+
+      for(size_t t = 16; t != 64; t += 16) {
+         rnd(A, B, C, D, E, F, G, H, next_w<0>(W), SHA256_K[t + 0]);
+         rnd(H, A, B, C, D, E, F, G, next_w<1>(W), SHA256_K[t + 1]);
+         rnd(G, H, A, B, C, D, E, F, next_w<2>(W), SHA256_K[t + 2]);
+         rnd(F, G, H, A, B, C, D, E, next_w<3>(W), SHA256_K[t + 3]);
+         rnd(E, F, G, H, A, B, C, D, next_w<4>(W), SHA256_K[t + 4]);
+         rnd(D, E, F, G, H, A, B, C, next_w<5>(W), SHA256_K[t + 5]);
+         rnd(C, D, E, F, G, H, A, B, next_w<6>(W), SHA256_K[t + 6]);
+         rnd(B, C, D, E, F, G, H, A, next_w<7>(W), SHA256_K[t + 7]);
+         rnd(A, B, C, D, E, F, G, H, next_w<8>(W), SHA256_K[t + 8]);
+         rnd(H, A, B, C, D, E, F, G, next_w<9>(W), SHA256_K[t + 9]);
+         rnd(G, H, A, B, C, D, E, F, next_w<10>(W), SHA256_K[t + 10]);
+         rnd(F, G, H, A, B, C, D, E, next_w<11>(W), SHA256_K[t + 11]);
+         rnd(E, F, G, H, A, B, C, D, next_w<12>(W), SHA256_K[t + 12]);
+         rnd(D, E, F, G, H, A, B, C, next_w<13>(W), SHA256_K[t + 13]);
+         rnd(C, D, E, F, G, H, A, B, next_w<14>(W), SHA256_K[t + 14]);
+         rnd(B, C, D, E, F, G, H, A, next_w<15>(W), SHA256_K[t + 15]);
+      }
+
+      S[0] += A;
+      S[1] += B;
+      S[2] += C;
+      S[3] += D;
+      S[4] += E;
+      S[5] += F;
+      S[6] += G;
+      S[7] += H;
+   }
+
+   for(size_t j = 0; j != 8; ++j) {
+      S[j].store_le(states + 64 * j);
+   }
+}
+
+BOTAN_FN_ISA_AVX512 void sha2_32_mb_extract_x16(const uint8_t* states, uint8_t* digests) {
+   SIMD_16x32 S[8];
+   for(size_t j = 0; j != 8; ++j) {
+      S[j] = SIMD_16x32::load_le(states + 64 * j).bswap();
+   }
+
+   // Each S[j] holds word j of all 16 lanes. The 4-way transpose works
+   // within each 128-bit quarter, so afterwards quarter q of S[k] holds
+   // words 0..3 of lane 4*q+k, and quarter q of S[4+k] its words 4..7.
+   SIMD_16x32::transpose(S[0], S[1], S[2], S[3]);
+   SIMD_16x32::transpose(S[4], S[5], S[6], S[7]);
+
+   for(size_t k = 0; k != 4; ++k) {
+      store_quarters(S[k], digests + 32 * k, 128);
+      store_quarters(S[4 + k], digests + 32 * k + 16, 128);
+   }
+}
+
+}  // namespace Botan

--- a/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx512/info.txt
+++ b/src/lib/hash_engine/hash_engine_sha2_32/hash_engine_sha2_32_avx512/info.txt
@@ -1,0 +1,16 @@
+<internal_defines>
+HASH_ENGINE_SHA2_32_AVX512 -> 20260705
+</internal_defines>
+
+<module_info>
+name -> "Multi-buffer SHA-256 using AVX-512"
+</module_info>
+
+<isa>
+avx512
+</isa>
+
+<requires>
+cpuid
+simd_avx512
+</requires>

--- a/src/lib/hash_engine/hash_engine_sha2_32/info.txt
+++ b/src/lib/hash_engine/hash_engine_sha2_32/info.txt
@@ -1,16 +1,16 @@
 <internal_defines>
-HASH_ENGINES -> 20260813
+HASH_ENGINE_SHA2_32 -> 20260705
 </internal_defines>
 
 <module_info>
-name -> "Hash Engine"
+name -> "Multi-buffer SHA-256 Hash Engine"
 </module_info>
 
 <requires>
-hash
+hash_engine
+sha2_32
 </requires>
 
 <header:internal>
-hash_engine.h
-hash_engine_mdx.h
+hash_engine_sha2_32.h
 </header:internal>


### PR DESCRIPTION
Including AVX2 and AVX512 implementations

Improvements relative to the basic (just threads) `Hash_Engine` integrations in #5870 #5868 #5866 on Tiger Lake, Clang 22:

```
+ 144.0% improvement in XMSS-SHA2_10_256 keygen
+ 112.5% improvement in XMSS-SHA2_10_256 verify
+ 112.0% improvement in XMSS-SHA2_10_256 sign
+ 201.2% improvement in SLH-DSA-SHA2-128f keygen
+ 191.1% improvement in SLH-DSA-SHA2-128f sign
+ 130.6% improvement in SLH-DSA-SHA2-128s keygen
+ 113.3% improvement in SLH-DSA-SHA2-192f keygen
+ 107.1% improvement in SLH-DSA-SHA2-192s keygen
+ 106.6% improvement in SLH-DSA-SHA2-128s sign
+ 95.7% improvement in SLH-DSA-SHA2-256s keygen
+ 95.1% improvement in SLH-DSA-SHA2-192f verify
+ 91.3% improvement in SLH-DSA-SHA2-128s verify
+ 89.0% improvement in SLH-DSA-SHA2-128f verify
+ 74.7% improvement in SLH-DSA-SHA2-192s verify
+ 66.2% improvement in SLH-DSA-SHA2-256f verify
+ 63.7% improvement in SLH-DSA-SHA2-192f sign
+ 58.4% improvement in SLH-DSA-SHA2-192s sign
+ 53.7% improvement in SLH-DSA-SHA2-256s verify
+ 49.8% improvement in SLH-DSA-SHA2-256f keygen
+ 41.6% improvement in SLH-DSA-SHA2-256s sign
+ 36.8% improvement in SLH-DSA-SHA2-256f sign
+ 50.3% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) sign
+ 47.8% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) keygen
+ 39.8% improvement in HSS-LMS-SHA-256,HW(10,1) keygen
+ 36.3% improvement in HSS-LMS-SHA-256,HW(10,1) sign
+ 34.2% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) sign
+ 34.2% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) keygen
+ 31.4% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) keygen
+ 30.8% improvement in HSS-LMS-Truncated(SHA-256,192),HW(10,1) verify
+ 28.9% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) sign
+ 17.7% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1),HW(10,1) verify
+ 9.9% improvement in HSS-LMS-SHA-256,HW(10,1),HW(10,1) verify
+ 7.8% improvement in HSS-LMS-SHA-256,HW(10,1) verify
```