### PR TITLE
Avoid deadlock risk in Thread_Pool

### DIFF
--- a/src/lib/hash_engine/hash_engine.h
+++ b/src/lib/hash_engine/hash_engine.h
@@ -81,8 +81,7 @@ class BOTAN_TEST_API Hash_Engine {
       * @param provider if set, use this specific implementation
       *
       * The default provider splits sufficiently large batches over the
-      * global Thread_Pool, which is created on the first such batch. Do
-      * not call batch_hash from within a task running on that pool.
+      * global Thread_Pool, which is created on the first such batch.
       *
       * Throws Lookup_Error if the hash function or requested provider is
       * not available

--- a/src/lib/utils/thread_utils/thread_pool.cpp
+++ b/src/lib/utils/thread_utils/thread_pool.cpp
@@ -17,6 +17,9 @@ namespace Botan {
 
 namespace {
 
+/// The pool whose worker this thread is, if any
+thread_local Thread_Pool* g_pool_of_this_worker = nullptr;  // NOLINT(*-avoid-non-const-global-variables)
+
 std::optional<size_t> global_thread_pool_size() {
    std::string var;
    if(OS::read_env_variable(var, "BOTAN_THREAD_POOL_SIZE")) {
@@ -112,7 +115,15 @@ void Thread_Pool::queue_thunk(const std::function<void()>& work) {
       throw Invalid_State("Cannot add work after thread pool has shut down");
    }
 
-   if(m_workers.empty()) {
+   /*
+   * Immediately execute tasks which are queued from within one of the pool's
+   * own worker threads. Otherwise there is risk of deadlock.
+   *
+   * This could be improved, with a bit more complexity, by a "helping join";
+   * instead of just blocking, the thread runs any queued tasks until the one it
+   * is waiting on has completed.
+   */
+   if(m_workers.empty() || g_pool_of_this_worker == this) {
       lock.unlock();
       return work();
    }
@@ -122,6 +133,8 @@ void Thread_Pool::queue_thunk(const std::function<void()>& work) {
 }
 
 void Thread_Pool::worker_thread() {
+   g_pool_of_this_worker = this;
+
    for(;;) {
       std::function<void()> task;
 

--- a/src/tests/test_thread_utils.cpp
+++ b/src/tests/test_thread_utils.cpp
@@ -57,7 +57,44 @@ Test::Result thread_pool() {
    return result;
 }
 
+Test::Result thread_pool_nested() {
+   Test::Result result("Thread_Pool nested");
+
+   // A small pool, so that without the immediate execution of tasks
+   // queued by the pool's own workers, all workers would block in the
+   // inner get() with the inner tasks stuck behind them in the queue
+   Botan::Thread_Pool pool(2);
+
+   auto fan_out = [&pool](size_t i) -> size_t {
+      std::vector<std::future<size_t>> inner;
+      inner.reserve(4);
+      for(size_t j = 0; j != 4; ++j) {
+         inner.push_back(pool.run([i, j]() -> size_t { return i * 4 + j; }));
+      }
+
+      size_t sum = 0;
+      for(auto& fut : inner) {
+         sum += fut.get();
+      }
+      return sum;
+   };
+
+   std::vector<std::future<size_t>> outer;
+   for(size_t i = 0; i != 16; ++i) {
+      outer.push_back(pool.run(fan_out, i));
+   }
+
+   for(size_t i = 0; i != outer.size(); ++i) {
+      result.test_sz_eq("Expected nested sum", outer[i].get(), 16 * i + 6);
+   }
+
+   pool.shutdown();
+
+   return result;
+}
+
 BOTAN_REGISTER_TEST_FN("utils", "thread_pool", thread_pool);
+BOTAN_REGISTER_TEST_FN("utils", "thread_pool_nested", thread_pool_nested);
 
 }  // namespace
 


### PR DESCRIPTION
If a task executing in the thread pool recursively called something which itself queued a task on the same thread pool, there was risk of a deadlock.

For now resolve this in the easy way; if we detect such a recursive invocation just execute the work immediately rather than queuing it. In such scenarios (with our usage) there probably is already enough work available so more complicated solutions probably are not necessary.