### PR TITLE
fix implib output directory for gcc/mingw

### DIFF
--- a/src/build-data/cc/gcc.txt
+++ b/src/build-data/cc/gcc.txt
@@ -61,7 +61,7 @@ solaris -> "{cxx} -shared -fPIC -Wl,-h,{soname_abi}"
 aix     -> "{cxx} -shared -fPIC"
 openbsd -> "{cxx} -shared -fPIC"
 
-mingw   -> "{cxx} -shared -Wl,--out-implib,{shared_lib_name}.a"
+mingw   -> "{cxx} -shared -Wl,--out-implib,{out_dir}/{shared_lib_name}.a"
 </so_link_commands>
 
 <isa_flags>


### PR DESCRIPTION
The `--out-implib` linker option needs to include the output path for the import library; otherwise, the import library always goes to the current directory. This is important for the installer, which expects the import library to be in the build directory.