### PR TITLE
Convert all BigInt integer divisions to constant time

### DIFF
--- a/src/cli/perf_math.cpp
+++ b/src/cli/perf_math.cpp
@@ -75,35 +75,26 @@ class PerfTest_MpDiv final : public PerfTest {
             const std::string bit_descr = std::to_string(n_bits) + "/" + std::to_string(q_bits);
 
             auto div_timer = config.make_timer("BigInt div " + bit_descr);
-            auto ct_div_timer = config.make_timer("BigInt ct_div " + bit_descr);
 
             Botan::BigInt y;
             Botan::BigInt x;
-            const Botan::secure_vector<Botan::word> ws;
 
-            Botan::BigInt q1;
-            Botan::BigInt r1;
-            Botan::BigInt q2;
-            Botan::BigInt r2;
+            Botan::BigInt q;
+            Botan::BigInt r;
 
-            while(ct_div_timer->under(runtime_per_size)) {
+            while(div_timer->under(runtime_per_size)) {
                x.randomize(config.rng(), n_bits);
                y.randomize(config.rng(), q_bits);
 
                div_timer->start();
-               Botan::vartime_divide(x, y, q1, r1);
+               Botan::ct_divide(x, y, q, r);
                div_timer->stop();
 
-               ct_div_timer->start();
-               Botan::ct_divide(x, y, q2, r2);
-               ct_div_timer->stop();
-
-               BOTAN_ASSERT_EQUAL(q1, q2, "Quotient ok");
-               BOTAN_ASSERT_EQUAL(r1, r2, "Remainder ok");
+               BOTAN_ASSERT_NOMSG(r < y);
+               BOTAN_ASSERT_NOMSG(q * y + r == x);
             }
 
             config.record_result(*div_timer);
-            config.record_result(*ct_div_timer);
          }
       }
 };
@@ -119,10 +110,9 @@ class PerfTest_MpDiv10 final : public PerfTest {
             const std::string bit_descr = std::to_string(n_bits) + "/10";
 
             auto div_timer = config.make_timer("BigInt div " + bit_descr);
-            auto ct_div_timer = config.make_timer("BigInt ct_div " + bit_descr);
+            auto div_word_timer = config.make_timer("BigInt div_word " + bit_descr);
 
             Botan::BigInt x;
-            const Botan::secure_vector<Botan::word> ws;
 
             const auto ten = Botan::BigInt::from_word(10);
             Botan::BigInt q1;
@@ -130,23 +120,23 @@ class PerfTest_MpDiv10 final : public PerfTest {
             Botan::BigInt q2;
             Botan::word r2 = 0;
 
-            while(ct_div_timer->under(runtime_per_size)) {
+            while(div_timer->under(runtime_per_size)) {
                x.randomize(config.rng(), n_bits);
 
                div_timer->start();
-               Botan::vartime_divide(x, ten, q1, r1);
+               Botan::ct_divide(x, ten, q1, r1);
                div_timer->stop();
 
-               ct_div_timer->start();
+               div_word_timer->start();
                Botan::ct_divide_word(x, 10, q2, r2);
-               ct_div_timer->stop();
+               div_word_timer->stop();
 
                BOTAN_ASSERT_EQUAL(q1, q2, "Quotient ok");
                BOTAN_ASSERT_EQUAL(r1, r2, "Remainder ok");
             }
 
             config.record_result(*div_timer);
-            config.record_result(*ct_div_timer);
+            config.record_result(*div_word_timer);
          }
       }
 };
@@ -180,14 +170,14 @@ class PerfTest_BnRedc final : public PerfTest {
             auto mod_p = Botan::Barrett_Reduction::for_public_modulus(p);
 
             auto barrett_timer = config.make_timer(bit_str + "Barrett redc");
-            auto knuth_timer = config.make_timer(bit_str + "Knuth redc");
+            auto mod_op_timer = config.make_timer(bit_str + "operator% redc");
             auto ct_modulo_timer = config.make_timer(bit_str + "ct_modulo");
 
             while(ct_modulo_timer->under(runtime)) {
                const Botan::BigInt x(config.rng(), p.bits() * 2 - 1);
 
                const Botan::BigInt r1 = barrett_timer->run([&] { return mod_p.reduce(x); });
-               const Botan::BigInt r2 = knuth_timer->run([&] { return x % p; });
+               const Botan::BigInt r2 = mod_op_timer->run([&] { return x % p; });
                const Botan::BigInt r3 = ct_modulo_timer->run([&] { return Botan::ct_modulo(x, p); });
 
                BOTAN_ASSERT(r1 == r2, "Computed different results");
@@ -195,7 +185,7 @@ class PerfTest_BnRedc final : public PerfTest {
             }
 
             config.record_result(*barrett_timer);
-            config.record_result(*knuth_timer);
+            config.record_result(*mod_op_timer);
             config.record_result(*ct_modulo_timer);
          }
       }

--- a/src/fuzzer/divide.cpp
+++ b/src/fuzzer/divide.cpp
@@ -17,9 +17,8 @@ void fuzz(std::span<const uint8_t> in) {
    static Botan::BigInt y;
    static Botan::BigInt q;
    static Botan::BigInt r;
-   static Botan::BigInt ct_q;
-   static Botan::BigInt ct_r;
    static Botan::BigInt z;
+   static Botan::BigInt ct_q;
 
    x = Botan::BigInt::from_bytes(in.subspan(0, in.size() / 2));
    y = Botan::BigInt::from_bytes(in.subspan(in.size() / 2, in.size() - in.size() / 2));
@@ -28,7 +27,7 @@ void fuzz(std::span<const uint8_t> in) {
       return;
    }
 
-   Botan::vartime_divide(x, y, q, r);
+   Botan::ct_divide(x, y, q, r);
 
    FUZZER_ASSERT_TRUE(r < y);
 
@@ -36,26 +35,24 @@ void fuzz(std::span<const uint8_t> in) {
 
    FUZZER_ASSERT_EQUAL(z, x);
 
-   Botan::ct_divide(x, y, ct_q, ct_r);
+   // Now divide by just low word of y, cross-checking the word division
+   // against the general division
 
-   FUZZER_ASSERT_EQUAL(q, ct_q);
-   FUZZER_ASSERT_EQUAL(r, ct_r);
-
-   // Now divide by just low word of y
-
-   y = y.word_at(0);
-   if(y == 0) {
+   const Botan::word yw = y.word_at(0);
+   if(yw == 0) {
       return;
    }
 
-   Botan::vartime_divide(x, y, q, r);
+   y = Botan::BigInt::from_word(yw);
+
+   Botan::ct_divide(x, y, q, r);
 
    FUZZER_ASSERT_TRUE(r < y);
    z = q * y + r;
    FUZZER_ASSERT_EQUAL(z, x);
 
    Botan::word rw = 0;
-   Botan::ct_divide_word(x, y.word_at(0), ct_q, rw);
+   Botan::ct_divide_word(x, yw, ct_q, rw);
    FUZZER_ASSERT_EQUAL(ct_q, q);
    FUZZER_ASSERT_EQUAL(rw, r.word_at(0));
 }

--- a/src/lib/codec/base58/base58.cpp
+++ b/src/lib/codec/base58/base58.cpp
@@ -103,12 +103,12 @@ constexpr std::pair<uint8_t, word> divmod_58(word x) {
 * base58 conversion radix, returning the remainder
 */
 word ct_divmod_base58radix(std::span<word> x) {
-   constexpr divide_precomp<word> radix_div(base58_conversion_radix());
+   constexpr auto radix58_div = divide_precomp<word>::setup(base58_conversion_radix());
 
    word rem = 0;
 
    for(size_t i = x.size(); i > 0; --i) {
-      const auto [q, r] = radix_div.divmod_2to1(rem, x[i - 1]);
+      const auto [q, r] = radix58_div.divmod_2to1_ct(rem, x[i - 1]);
       x[i - 1] = q;
       rem = r;
    }

--- a/src/lib/ffi/ffi_mp.cpp
+++ b/src/lib/ffi/ffi_mp.cpp
@@ -211,7 +211,7 @@ int botan_mp_mul(botan_mp_t result, const botan_mp_t x, const botan_mp_t y) {
 int botan_mp_div(botan_mp_t quotient, botan_mp_t remainder, const botan_mp_t x, const botan_mp_t y) {
    return BOTAN_FFI_VISIT(quotient, [=](auto& q) {
       Botan::BigInt r;
-      Botan::vartime_divide(safe_get(x), safe_get(y), q, r);
+      Botan::ct_divide(safe_get(x), safe_get(y), q, r);
       safe_get(remainder) = r;
    });
 }

--- a/src/lib/math/bigint/big_ops2.cpp
+++ b/src/lib/math/bigint/big_ops2.cpp
@@ -246,7 +246,7 @@ word BigInt::operator%=(word mod) {
    if(is_power_of_2(mod)) {
       remainder = (word_at(0) & (mod - 1));
    } else {
-      const divide_precomp redc_mod(mod);
+      const auto redc_mod = divide_precomp<word>::setup_vartime(mod);
       const size_t sw = sig_words();
       for(size_t i = sw; i > 0; --i) {
          remainder = redc_mod.mod_2to1(remainder, word_at(i - 1));

--- a/src/lib/math/bigint/big_ops3.cpp
+++ b/src/lib/math/bigint/big_ops3.cpp
@@ -110,7 +110,7 @@ BigInt operator/(const BigInt& x, const BigInt& y) {
 
    BigInt q;
    BigInt r;
-   vartime_divide(x, y, q, r);
+   ct_divide(x, y, q, r);
    return q;
 }
 
@@ -148,7 +148,7 @@ BigInt operator%(const BigInt& n, const BigInt& mod) {
 
    BigInt q;
    BigInt r;
-   vartime_divide(n, mod, q, r);
+   ct_divide(n, mod, q, r);
    return r;
 }
 
@@ -169,7 +169,7 @@ word operator%(const BigInt& n, word mod) {
    if(n.signum() >= 0 && is_power_of_2(mod)) {
       remainder = (n.word_at(0) & (mod - 1));
    } else {
-      const divide_precomp redc_mod(mod);
+      const auto redc_mod = divide_precomp<word>::setup_vartime(mod);
       const size_t sw = n.sig_words();
       for(size_t i = sw; i > 0; --i) {
          remainder = redc_mod.mod_2to1(remainder, n.word_at(i - 1));

--- a/src/lib/math/bigint/divide.cpp
+++ b/src/lib/math/bigint/divide.cpp
@@ -1,6 +1,6 @@
 /*
 * Division Algorithms
-* (C) 1999-2007,2012,2018,2021 Jack Lloyd
+* (C) 1999-2007,2012,2018,2021,2026 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -8,6 +8,7 @@
 #include <botan/internal/divide.h>
 
 #include <botan/exceptn.h>
+#include <botan/internal/bit_ops.h>
 #include <botan/internal/ct_utils.h>
 #include <botan/internal/mp_core.h>
 
@@ -31,23 +32,147 @@ void sign_fixup(const BigInt& x, const BigInt& y, BigInt& q, BigInt& r) {
    }
 }
 
-inline bool division_check_vartime(word q, word y2, word y1, word x3, word x2, word x1) {
-   /*
-   Compute (y3,y2,y1) = (y2,y1) * q
-   and return true if (y3,y2,y1) > (x3,x2,x1)
-   */
-
+/*
+* Computes (y3,y2,y1) = (y2,y1) * q and returns a mask which is set
+* if (y3,y2,y1) > (x3,x2,x1)
+*/
+inline CT::Mask<word> division_check_ct(word q, word y2, word y1, word x3, word x2, word x1) {
    word y3 = 0;
    y1 = word_madd2(q, y1, &y3);
    y2 = word_madd2(q, y2, &y3);
 
-   if(x3 != y3) {
-      return (y3 > x3);
+   const auto gt3 = CT::Mask<word>::is_gt(y3, x3);
+   const auto eq3 = CT::Mask<word>::is_equal(y3, x3);
+   const auto gt2 = CT::Mask<word>::is_gt(y2, x2);
+   const auto eq2 = CT::Mask<word>::is_equal(y2, x2);
+   const auto gt1 = CT::Mask<word>::is_gt(y1, x1);
+
+   return gt3 | (eq3 & (gt2 | (eq2 & gt1)));
+}
+
+/*
+* Word-serial constant time unsigned division
+*
+* Sets q = |x| / |y| and r = |x| % |y|, using schoolbook long division
+* (HAC Algorithm 14.20) with a quotient digit estimate from a
+* precomputed reciprocal of the normalized divisor, and with the digit
+* selection, corrections, and add-back all computed as masked updates.
+*
+* All control flow and memory indexing depends only on the word lengths
+* of x and y, which are treated as public. The normalization shift
+* depends on the bit length of y's top word, but is used only as a
+* shift count or mask input, never for control flow or indexing.
+*/
+void ct_divide_impl(BigInt& q_out, BigInt& r_out, const BigInt& x, const BigInt& y) {
+   constexpr size_t WB = WordInfo<word>::bits;
+
+   const size_t x_words = x.sig_words();
+   const size_t y_words = y.sig_words();
+   BOTAN_ASSERT_NOMSG(y_words > 0);
+
+   if(x_words < y_words) {
+      // Here |x| < |y| so q = 0 and r = |x|
+      r_out = x.abs();
+      q_out = BigInt::zero();
+      return;
    }
-   if(x2 != y2) {
-      return (y2 > x2);
+
+   const size_t r_words = x_words + 1;
+   const size_t q_words = x_words - y_words + 1;
+
+   // The number of leading zero bits of y, in [0,WB)
+   const word s = static_cast<word>(WB) - static_cast<word>(high_bit(CT::value_barrier(y._data()[y_words - 1])));
+   const auto s_mask = CT::Mask<word>::expand(s);
+   const word s_comp = s_mask.if_set_return(static_cast<word>(WB) - s);
+
+   secure_vector<word> yn(y_words);
+   secure_vector<word> rw(r_words);
+   secure_vector<word> qw(q_words);
+
+   // Normalize: yn = |y| << s (which sets the top bit of yn) and rw = |x| << s;
+   // shifting y stays within y_words words, shifting x adds at most one word
+   word carry = 0;
+   for(size_t i = 0; i != y_words; ++i) {
+      const word w = y._data()[i];
+      yn[i] = (w << s) | carry;
+      carry = s_mask.if_set_return(w >> s_comp);
    }
-   return (y1 > x1);
+
+   carry = 0;
+   for(size_t i = 0; i != x_words; ++i) {
+      const word w = x._data()[i];
+      rw[i] = (w << s) | carry;
+      carry = s_mask.if_set_return(w >> s_comp);
+   }
+   rw[x_words] = carry;
+
+   const auto div_by_yn = divide_precomp<word>::setup(CT::value_barrier(yn[y_words - 1]));
+
+   if(y_words == 1) {
+      /*
+      * 2/1 word-serial division. The initial remainder is the shift-out
+      * carry, which is less than 2^s and so less than the divisor.
+      */
+      word r = rw[x_words];
+      for(size_t i = x_words; i > 0; --i) {
+         const auto [qi, ri] = div_by_yn.divmod_2to1_ct(r, rw[i - 1]);
+         qw[i - 1] = qi;
+         r = ri;
+      }
+
+      rw[0] = r >> s;
+   } else {
+      const word yn1 = yn[y_words - 1];
+      const word yn2 = yn[y_words - 2];
+
+      for(size_t i = q_words; i > 0; --i) {
+         const size_t j = i - 1;  // current window is rw[j ... j + y_words]
+
+         const word u2 = rw[j + y_words];
+         const word u1 = rw[j + y_words - 1];
+         const word u0 = rw[j + y_words - 2];
+
+         /*
+         * Estimate the quotient digit from the top two words of the window.
+         * The window invariant gives u2 <= yn1; if u2 == yn1 the 2/1
+         * division precondition does not hold, and instead the digit
+         * estimate is the maximum word value.
+         */
+         const auto top_eq = CT::Mask<word>::is_equal(u2, yn1);
+         const word q_est = div_by_yn.divmod_2to1_ct(u2, u1).first;
+         word qhat = top_eq.select(WordInfo<word>::max, q_est);
+
+         // Per HAC 14.23, this correction is required at most twice
+         qhat -= division_check_ct(qhat, yn1, yn2, u2, u1, u0).if_set_return(1);
+         qhat -= division_check_ct(qhat, yn1, yn2, u2, u1, u0).if_set_return(1);
+
+         // Subtract qhat * yn from the window
+         const word bw = bigint_submul(&rw[j], yn.data(), y_words, qhat);
+         word borrow = 0;
+         rw[j + y_words] = word_sub(u2, bw, &borrow);
+
+         // If the digit was still one too large, the subtraction
+         // underflowed; add back and decrement the digit
+         const word cb = bigint_cnd_add(borrow, &rw[j], yn.data(), y_words);
+         rw[j + y_words] += cb;
+         qhat -= borrow;
+
+         qw[j] = qhat;
+      }
+
+      // The remainder is in rw[0:y_words], still shifted left by s, and
+      // rw[y_words] is zero
+      for(size_t i = 0; i != y_words; ++i) {
+         rw[i] = (rw[i] >> s) | s_mask.if_set_return(CT::value_barrier(rw[i + 1]) << s_comp);
+      }
+   }
+
+   BigInt q = BigInt::_from_words(qw);
+   rw.resize(y_words);
+   BigInt r = BigInt::_from_words(rw);
+
+   r_out = std::move(r);
+   q_out = std::move(q);
 }
 
 }  // namespace
@@ -57,29 +182,9 @@ void ct_divide(const BigInt& x, const BigInt& y, BigInt& q_out, BigInt& r_out) {
       throw Invalid_Argument("ct_divide: cannot divide by zero");
    }
 
-   const size_t x_words = x.sig_words();
-   const size_t y_words = y.sig_words();
-
-   const size_t x_bits = x.bits();
-
-   const size_t r_words = y_words + 1;
-
-   BigInt q = BigInt::with_capacity(x_words);
-   BigInt r = BigInt::with_capacity(r_words);
-   BigInt t = BigInt::with_capacity(r_words);  // a temporary
-
-   for(size_t i = 0; i != x_bits; ++i) {
-      const size_t b = x_bits - 1 - i;
-      const bool x_b = x.get_bit(b);
-
-      bigint_shl1(r.mutable_data(), r_words, r_words, 1);
-      r.conditionally_set_bit(0, x_b);
-
-      const bool r_gte_y = bigint_sub3(t.mutable_data(), r._data(), r_words, y._data(), y_words) == 0;
-
-      q.conditionally_set_bit(b, r_gte_y);
-      bigint_cnd_swap(static_cast<word>(r_gte_y), r.mutable_data(), t.mutable_data(), r_words);
-   }
+   BigInt q;
+   BigInt r;
+   ct_divide_impl(q, r, x, y);
 
    sign_fixup(x, y, q, r);
    r_out = r;
@@ -91,38 +196,9 @@ BigInt ct_divide_pow2k(size_t k, const BigInt& y) {
    BOTAN_ARG_CHECK(y.signum() >= 0, "Negative divisor not supported");
    BOTAN_ARG_CHECK(k > 1, "Invalid k");
 
-   const size_t x_bits = k + 1;
-   const size_t y_bits = y.bits();
-
-   if(x_bits < y_bits) {
-      return BigInt::zero();
-   }
-
-   BOTAN_ASSERT_NOMSG(y_bits >= 1);
-   const size_t x_words = (x_bits + WordInfo<word>::bits - 1) / WordInfo<word>::bits;
-   const size_t y_words = y.sig_words();
-
-   BigInt q = BigInt::with_capacity(x_words);
-   BigInt r = BigInt::with_capacity(y_words + 1);
-   BigInt t = BigInt::with_capacity(y_words + 1);  // a temporary
-
-   r.set_bit(y_bits - 1);
-   for(size_t i = y_bits - 1; i != x_bits; ++i) {
-      const size_t b = x_bits - 1 - i;
-
-      if(i >= y_bits) {
-         bigint_shl1(r.mutable_data(), r.size(), r.size(), 1);
-      }
-
-      const bool r_gte_y = bigint_sub3(t.mutable_data(), r._data(), r.size(), y._data(), y_words) == 0;
-
-      q.conditionally_set_bit(b, r_gte_y);
-
-      bigint_cnd_swap(static_cast<word>(r_gte_y), r.mutable_data(), t.mutable_data(), y_words + 1);
-   }
-
-   // No need for sign fixup
-
+   BigInt q;
+   BigInt r;
+   ct_divide_impl(q, r, BigInt::power_of_2(k), y);
    return q;
 }
 
@@ -132,24 +208,21 @@ void ct_divide_word(const BigInt& x, word y, BigInt& q_out, word& r_out) {
    }
 
    const size_t x_words = x.sig_words();
-   const size_t x_bits = x.bits();
 
-   BigInt q = BigInt::with_capacity(x_words);
+   // The divisor is public here; setup is variable time in it
+   const auto div_y = divide_precomp<word>::setup_vartime(y);
+
+   secure_vector<word> qw(x_words);
    word r = 0;
 
-   for(size_t i = 0; i != x_bits; ++i) {
-      const size_t b = x_bits - 1 - i;
-      const bool x_b = x.get_bit(b);
-
-      const auto r_carry = CT::Mask<word>::expand_top_bit(r);
-
-      r <<= 1;
-      r += static_cast<word>(x_b);
-
-      const auto r_gte_y = CT::Mask<word>::is_gte(r, y) | r_carry;
-      q.conditionally_set_bit(b, r_gte_y.as_bool());
-      r = r_gte_y.select(r - y, r);
+   // Each step depends on r < y, which holds since r is a remainder mod y
+   for(size_t i = x_words; i > 0; --i) {
+      const auto [qi, ri] = div_y.divmod_2to1_vartime(r, x._data()[i - 1]);
+      qw[i - 1] = qi;
+      r = ri;
    }
+
+   BigInt q = BigInt::_from_words(qw);
 
    if(x.signum() < 0) {
       q.flip_sign();
@@ -175,21 +248,12 @@ word ct_mod_word(const BigInt& x, word y) {
    BOTAN_ARG_CHECK(x.signum() >= 0, "The argument x must be non-negative");
    BOTAN_ARG_CHECK(y != 0, "Cannot divide by zero");
 
-   const size_t x_bits = x.bits();
+   // The divisor is public here; setup is variable time in it
+   const auto div_y = divide_precomp<word>::setup_vartime(y);
 
    word r = 0;
-
-   for(size_t i = 0; i != x_bits; ++i) {
-      const size_t b = x_bits - 1 - i;
-      const bool x_b = x.get_bit(b);
-
-      const auto r_carry = CT::Mask<word>::expand_top_bit(r);
-
-      r <<= 1;
-      r += static_cast<word>(x_b);
-
-      const auto r_gte_y = CT::Mask<word>::is_gte(r, y) | r_carry;
-      r = r_gte_y.select(r - y, r);
+   for(size_t i = x.sig_words(); i > 0; --i) {
+      r = div_y.mod_2to1(r, x._data()[i - 1]);
    }
 
    return r;
@@ -200,25 +264,9 @@ BigInt ct_modulo(const BigInt& x, const BigInt& y) {
       throw Invalid_Argument("ct_modulo requires y > 0");
    }
 
-   const size_t y_words = y.sig_words();
-   const size_t r_words = y_words + 1;
-
-   const size_t x_bits = x.bits();
-
-   BigInt r = BigInt::with_capacity(r_words);
-   BigInt t = BigInt::with_capacity(r_words);
-
-   for(size_t i = 0; i != x_bits; ++i) {
-      const size_t b = x_bits - 1 - i;
-      const bool x_b = x.get_bit(b);
-
-      bigint_shl1(r.mutable_data(), r_words, r_words, 1);
-      r.conditionally_set_bit(0, x_b);
-
-      const bool r_gte_y = bigint_sub3(t.mutable_data(), r._data(), r_words, y._data(), y_words) == 0;
-
-      bigint_cnd_swap(static_cast<word>(r_gte_y), r.mutable_data(), t.mutable_data(), r_words);
-   }
+   BigInt q;
+   BigInt r;
+   ct_divide_impl(q, r, x, y);
 
    if(x.signum() < 0) {
       if(r.signum() != 0) {
@@ -227,198 +275,6 @@ BigInt ct_modulo(const BigInt& x, const BigInt& y) {
    }
 
    return r;
-}
-
-BigInt vartime_divide_pow2k(size_t k, const BigInt& y_arg) {
-   constexpr size_t WB = WordInfo<word>::bits;
-
-   BOTAN_ARG_CHECK(y_arg.signum() != 0, "Cannot divide by zero");
-   BOTAN_ARG_CHECK(y_arg.signum() >= 0, "Negative divisor not supported");
-   BOTAN_ARG_CHECK(k > 1, "Invalid k");
-
-   BigInt y = y_arg;
-
-   const size_t y_words = y.sig_words();
-
-   BOTAN_ASSERT_NOMSG(y_words > 0);
-
-   // Calculate shifts needed to normalize y with high bit set
-   const size_t shifts = y.top_bits_free();
-
-   if(shifts > 0) {
-      y <<= shifts;
-   }
-
-   BigInt r;
-   r.set_bit(k + shifts);  // (2^k) << shifts
-
-   // we know y has not changed size, since we only shifted up to set high bit
-   const size_t t = y_words - 1;
-   const size_t n = std::max(y_words, r.sig_words()) - 1;
-
-   BOTAN_ASSERT_NOMSG(n >= t);
-
-   BigInt q = BigInt::zero();
-   q.grow_to(n - t + 1);
-
-   word* q_words = q.mutable_data();
-
-   BigInt shifted_y = y << (WB * (n - t));
-
-   // Set q_{n-t} to number of times r > shifted_y
-   secure_vector<word> ws;
-   q_words[n - t] = r.reduce_below(shifted_y, ws);
-
-   const word y_t0 = y.word_at(t);
-   const word y_t1 = y.word_at(t - 1);
-   BOTAN_DEBUG_ASSERT((y_t0 >> (WB - 1)) == 1);
-
-   const divide_precomp div_y_t0(y_t0);
-
-   for(size_t i = n; i != t; --i) {
-      const word x_i0 = r.word_at(i);
-      const word x_i1 = r.word_at(i - 1);
-      const word x_i2 = r.word_at(i - 2);
-
-      word qit = (x_i0 == y_t0) ? WordInfo<word>::max : div_y_t0.div_2to1(x_i0, x_i1);
-
-      // Per HAC 14.23, this operation is required at most twice
-      for(size_t j = 0; j != 2; ++j) {
-         if(division_check_vartime(qit, y_t0, y_t1, x_i0, x_i1, x_i2)) {
-            BOTAN_ASSERT_NOMSG(qit > 0);
-            qit--;
-         } else {
-            break;
-         }
-      }
-
-      shifted_y >>= WB;
-      // Now shifted_y == y << (WB * (i-t-1))
-
-      /*
-      * Special case qit == 0 and qit == 1 which occurs relatively often here due to a
-      * combination of the fixed 2^k and in many cases the typical structure of
-      * public moduli (as this function is called by Barrett_Reduction::for_public_modulus).
-      *
-      * Over the test suite, about 5% of loop iterations have qit == 1 and 10% have qit == 0
-      */
-
-      if(qit != 0) {
-         if(qit == 1) {
-            r -= shifted_y;
-         } else {
-            r -= qit * shifted_y;
-         }
-
-         if(r.signum() < 0) {
-            BOTAN_ASSERT_NOMSG(qit > 0);
-            qit--;
-            r += shifted_y;
-            BOTAN_ASSERT_NOMSG(r.signum() >= 0);
-         }
-      }
-
-      q_words[i - t - 1] = qit;
-   }
-
-   return q;
-}
-
-/*
-* Solve x = q * y + r
-*
-* See Handbook of Applied Cryptography algorithm 14.20
-*/
-void vartime_divide(const BigInt& x, const BigInt& y_arg, BigInt& q_out, BigInt& r_out) {
-   constexpr size_t WB = WordInfo<word>::bits;
-
-   if(y_arg.is_zero()) {
-      throw Invalid_Argument("vartime_divide: cannot divide by zero");
-   }
-
-   const size_t y_words = y_arg.sig_words();
-
-   BOTAN_ASSERT_NOMSG(y_words > 0);
-
-   BigInt y = y_arg;
-
-   BigInt r = x;
-   BigInt q = BigInt::zero();
-   secure_vector<word> ws;
-
-   r.set_sign(BigInt::Positive);
-   y.set_sign(BigInt::Positive);
-
-   // Calculate shifts needed to normalize y with high bit set
-   const size_t shifts = y.top_bits_free();
-
-   if(shifts > 0) {
-      y <<= shifts;
-      r <<= shifts;
-   }
-
-   // we know y has not changed size, since we only shifted up to set high bit
-   const size_t t = y_words - 1;
-   const size_t n = std::max(y_words, r.sig_words()) - 1;  // r may have changed size however
-
-   BOTAN_ASSERT_NOMSG(n >= t);
-
-   q.grow_to(n - t + 1);
-
-   word* q_words = q.mutable_data();
-
-   BigInt shifted_y = y << (WB * (n - t));
-
-   // Set q_{n-t} to number of times r > shifted_y
-   q_words[n - t] = r.reduce_below(shifted_y, ws);
-
-   const word y_t0 = y.word_at(t);
-   const word y_t1 = y.word_at(t - 1);
-   BOTAN_DEBUG_ASSERT((y_t0 >> (WB - 1)) == 1);
-
-   const divide_precomp div_y_t0(y_t0);
-
-   for(size_t i = n; i != t; --i) {
-      const word x_i0 = r.word_at(i);
-      const word x_i1 = r.word_at(i - 1);
-      const word x_i2 = r.word_at(i - 2);
-
-      word qit = (x_i0 == y_t0) ? WordInfo<word>::max : div_y_t0.div_2to1(x_i0, x_i1);
-
-      // Per HAC 14.23, this operation is required at most twice
-      for(size_t j = 0; j != 2; ++j) {
-         if(division_check_vartime(qit, y_t0, y_t1, x_i0, x_i1, x_i2)) {
-            BOTAN_ASSERT_NOMSG(qit > 0);
-            qit--;
-         } else {
-            break;
-         }
-      }
-
-      shifted_y >>= WB;
-      // Now shifted_y == y << (WB * (i-t-1))
-
-      if(qit != 0) {
-         r -= qit * shifted_y;
-         if(r.signum() < 0) {
-            BOTAN_ASSERT_NOMSG(qit > 0);
-            qit--;
-            r += shifted_y;
-            BOTAN_ASSERT_NOMSG(r.signum() >= 0);
-         }
-      }
-
-      q_words[i - t - 1] = qit;
-   }
-
-   if(shifts > 0) {
-      r >>= shifts;
-   }
-
-   sign_fixup(x, y_arg, q, r);
-
-   r_out = r;
-   q_out = q;
 }
 
 }  // namespace Botan

--- a/src/lib/math/bigint/divide.h
+++ b/src/lib/math/bigint/divide.h
@@ -1,6 +1,6 @@
 /*
 * Division
-* (C) 1999-2007 Jack Lloyd
+* (C) 1999-2007,2026 Jack Lloyd
 *
 * Botan is released under the Simplified BSD License (see license.txt)
 */
@@ -13,20 +13,11 @@
 namespace Botan {
 
 /**
-* BigInt Division
-* @param x an integer
-* @param y a non-zero integer
-* @param q will be set to x / y
-* @param r will be set to x % y
-*/
-BOTAN_TEST_API
-void vartime_divide(const BigInt& x, const BigInt& y, BigInt& q, BigInt& r);
-
-/**
-* BigInt division, const time variant
+* BigInt division
 *
 * This runs with control flow independent of the values of x/y.
-* Warning: the loop bounds still leak the sizes of x and y.
+*
+* Warning: the sizes and signs of x and y still leak.
 *
 * @param x an integer
 * @param y a non-zero integer
@@ -37,7 +28,7 @@ BOTAN_TEST_API
 void ct_divide(const BigInt& x, const BigInt& y, BigInt& q, BigInt& r);
 
 /**
-* BigInt division, const time variant, 2^k variant
+* BigInt division, 2^k variant
 *
 * This runs with control flow independent of the value of y.
 * This function leaks the value of k and the length of y.
@@ -51,21 +42,7 @@ BOTAN_TEST_API
 BigInt ct_divide_pow2k(size_t k, const BigInt& y);
 
 /**
-* BigInt division, variable time, 2^k variant
-*
-* This is identical to ct_divide_pow2k in functionality,
-* but leaks both k and y to side channels, so it should only
-* be used with public inputs.
-*
-* @param k an integer
-* @param y a positive integer
-* @return q equal to 2**k / y
-*/
-BOTAN_TEST_API
-BigInt vartime_divide_pow2k(size_t k, const BigInt& y);
-
-/**
-* BigInt division, const time variant
+* BigInt division
 *
 * This runs with control flow independent of the values of x/y.
 * Warning: the loop bounds still leak the sizes of x and y.
@@ -84,8 +61,9 @@ inline BigInt ct_divide(const BigInt& x, const BigInt& y) {
 /**
 * Constant time division
 *
-* This runs with control flow independent of the values of x/y.
-* Warning: the loop bounds still leaks the size of x.
+* This runs with control flow independent of the value of x.
+* The divisor y is treated as a public value.
+* Warning: the loop bounds still leak the size of x.
 *
 * @param x an integer
 * @param y a non-zero integer
@@ -98,8 +76,9 @@ void ct_divide_word(const BigInt& x, word y, BigInt& q, word& r);
 /**
 * Constant time division
 *
-* This runs with control flow independent of the values of x/y.
-* Warning: the loop bounds still leaks the size of x.
+* This runs with control flow independent of the value of x.
+* The divisor y is treated as a public value.
+* Warning: the loop bounds still leak the size of x.
 *
 * @param x an integer
 * @param y a non-zero word
@@ -110,8 +89,9 @@ BigInt ct_divide_word(const BigInt& x, word y);
 /**
 * BigInt word modulo, const time variant
 *
-* This runs with control flow independent of the values of x/y.
-* Warning: the loop bounds still leaks the size of x.
+* This runs with control flow independent of the value of x.
+* The divisor y is treated as a public value.
+* Warning: the loop bounds still leak the size of x.
 *
 * @param x a positive integer
 * @param y a non-zero word

--- a/src/lib/math/mp/mp_core.h
+++ b/src/lib/math/mp/mp_core.h
@@ -431,6 +431,26 @@ inline constexpr void bigint_linmul3(W z[], const W x[], size_t x_size, W y) {
 }
 
 /**
+* Compute z[0:N] = z[0:N] - q * y[0:N]
+*
+* Returns the borrow out, a full word value which the caller must
+* subtract from z[N]
+*/
+template <WordType W>
+inline constexpr auto bigint_submul(W z[], const W y[], size_t N, W q) -> W {
+   W mul_carry = 0;
+   W borrow = 0;
+
+   for(size_t i = 0; i != N; ++i) {
+      const W t = word_madd2(y[i], q, &mul_carry);
+      z[i] = word_sub(z[i], t, &borrow);
+   }
+
+   // Both mul_carry <= W_max - 1 and borrow <= 1, so this cannot overflow
+   return mul_carry + borrow;
+}
+
+/**
 * Compare x and y
 * Return -1 if x < y
 * Return 0 if x == y
@@ -630,6 +650,34 @@ constexpr W reciprocal_word(W D) {
 }
 
 /**
+* Compute the same reciprocal as reciprocal_word, but running
+* in constant time.
+*
+* Requires that D is normalized (ie with its top bit set)
+*/
+template <WordType W>
+constexpr W reciprocal_word_ct(W D) {
+   BOTAN_DEBUG_ASSERT((D & WordInfo<W>::top_bit) != 0);
+
+   // Bit serial long division of ((~D) || (2^b - 1)) / D, with all of the
+   // conditional logic of the reciprocal_word fallback computed via masks
+   W remainder = static_cast<W>(~D);
+   W quotient = 0;
+
+   for(size_t i = 0; i != WordInfo<W>::bits; ++i) {
+      const auto carry = CT::Mask<W>::expand_top_bit(remainder);
+      remainder = static_cast<W>((remainder << 1) | 1);
+      quotient <<= 1;
+
+      const auto sub = carry | CT::Mask<W>::is_gte(remainder, D);
+      remainder -= sub.if_set_return(D);
+      quotient |= sub.if_set_return(1);
+   }
+
+   return quotient;
+}
+
+/**
 * Setup for word level division/modulo operations
 *
 * The general case uses a reciprocal of the normalized divisor,
@@ -644,11 +692,20 @@ constexpr W reciprocal_word(W D) {
 template <WordType W>
 class divide_precomp final {
    public:
-      explicit constexpr divide_precomp(W divisor) : m_divisor(divisor) {
-         BOTAN_ARG_CHECK(m_divisor != 0, "Division by zero");
-         m_shift = WordInfo<W>::bits - std::bit_width(m_divisor);
-         m_norm_divisor = m_divisor << m_shift;
-         m_reciprocal = reciprocal_word(m_norm_divisor);
+      // The caller must guarantee not to use divisor == 0
+      static constexpr divide_precomp setup_vartime(W divisor) {
+         const size_t shift = WordInfo<W>::bits - std::bit_width(divisor);
+         const W norm_divisor = divisor << shift;
+         const W reciprocal = reciprocal_word(norm_divisor);
+         return divide_precomp(divisor, shift, norm_divisor, reciprocal);
+      }
+
+      // The caller must guarantee not to use divisor == 0
+      static constexpr divide_precomp setup(W divisor) {
+         const size_t shift = WordInfo<W>::bits - std::bit_width(divisor);
+         const W norm_divisor = divisor << shift;
+         const W reciprocal = reciprocal_word_ct(norm_divisor);
+         return divide_precomp(divisor, shift, norm_divisor, reciprocal);
       }
 
       // Return quotient and remainder of (n1 || n0) divided by d
@@ -656,7 +713,10 @@ class divide_precomp final {
       // This assumes n1 < d so that the quotient fits in a word and
       // will produce incorrect output if n1 >= d, since in that case
       // the quotient exceeds the word size.
-      inline constexpr std::pair<W, W> divmod_2to1(W n1, W n0) const {
+      //
+      // This is constant time with respect to n1/n0 but leaks information
+      // about the divisor
+      inline constexpr std::pair<W, W> divmod_2to1_vartime(W n1, W n0) const {
          if(m_divisor == WordInfo<W>::max) {
             const W q = div_2to1_max_d(n1, n0);
             const W r = static_cast<W>(n0 + q);
@@ -670,6 +730,15 @@ class divide_precomp final {
             return std::make_pair(q, r);
          }
 
+         return divmod_2to1_ct(n1, n0);
+      }
+
+      // Return quotient and remainder of (n1 || n0) divided by d
+      //
+      // This assumes n1 < d so that the quotient fits in a word and
+      // will produce incorrect output if n1 >= d, since in that case
+      // the quotient exceeds the word size.
+      inline constexpr std::pair<W, W> divmod_2to1_ct(W n1, W n0) const {
          /*
          * Scale the numerator to match the normalized divisor; the scaling cancels
          * in the quotient and is removed from the remainder by the final shift.
@@ -694,20 +763,29 @@ class divide_precomp final {
       // Return floor((n1 || n0) / d)
       //
       // This assumes n1 < d so that the quotient fits in a word
-      inline constexpr W div_2to1(W n1, W n0) const { return this->divmod_2to1(n1, n0).first; }
+      //
+      // This is constant time with respect to n1/n0 but leaks information about d
+      inline constexpr W div_2to1(W n1, W n0) const { return this->divmod_2to1_vartime(n1, n0).first; }
 
       // Return (n1 || n0) % d
       //
       // This assumes n1 < d
-      inline constexpr W mod_2to1(W n1, W n0) const { return this->divmod_2to1(n1, n0).second; }
+      //
+      // This is constant time with respect to n1/n0 but leaks information about d
+      inline constexpr W mod_2to1(W n1, W n0) const { return this->divmod_2to1_vartime(n1, n0).second; }
 
    private:
+      constexpr divide_precomp(W divisor, size_t shift, W norm_divisor, W reciprocal) :
+            m_divisor(divisor), m_shift(shift), m_norm_divisor(norm_divisor), m_reciprocal(reciprocal) {}
+
       /*
       * 2/1 division of (u1 || u0) by the normalized divisor D given its
       * reciprocal v, returning quotient and remainder. Requires u1 < D.
       *
-      * Algorithm 4 of Möller and Granlund, with the conditional
-      * corrections computed as masked updates.
+      * Algorithm 4 of Möller and Granlund "Improved Division by Invariant
+      * Integers", with the conditional corrections computed as masked updates.
+      *
+      * Runs in constant time with respect to u1 and u0.
       */
       static constexpr std::pair<W, W> div2by1_preinv(W u1, W u0, W D, W v) {
          // Steps 1-3: <q1,q0> = v*u1; <q1,q0> += <u1,u0>; q1 += 1

--- a/src/lib/math/numbertheory/barrett.cpp
+++ b/src/lib/math/numbertheory/barrett.cpp
@@ -31,13 +31,7 @@ Barrett_Reduction Barrett_Reduction::for_secret_modulus(const BigInt& mod) {
 }
 
 Barrett_Reduction Barrett_Reduction::for_public_modulus(const BigInt& mod) {
-   BOTAN_ARG_CHECK(mod.signum() > 0, "Modulus must be positive");
-
-   const size_t mod_words = mod.sig_words();
-
-   // Compute mu = floor(2^{2k} / m)
-   const size_t mu_bits = 2 * WordInfo<word>::bits * mod_words;
-   return Barrett_Reduction(mod, vartime_divide_pow2k(mu_bits, mod), mod_words);
+   return Barrett_Reduction::for_secret_modulus(mod);
 }
 
 namespace {

--- a/src/lib/math/numbertheory/barrett.h
+++ b/src/lib/math/numbertheory/barrett.h
@@ -19,15 +19,15 @@ class BOTAN_TEST_API Barrett_Reduction final {
       /**
       * Setup for reduction where the modulus itself is public
       *
+      * Currently implemented identically to for_secret_modulus; the
+      * distinction documents the caller's intent
+      *
       * Requires that m > 0
       */
       static Barrett_Reduction for_public_modulus(const BigInt& m);
 
       /**
       * Setup for reduction where the modulus itself is secret.
-      *
-      * This is slower than for_public_modulus since it must avoid using
-      * variable time division.
       *
       * Requires that m > 0
       */

--- a/src/lib/pubkey/dl_group/dl_group.cpp
+++ b/src/lib/pubkey/dl_group/dl_group.cpp
@@ -289,7 +289,7 @@ namespace {
 BigInt make_dsa_generator(const BigInt& p, const BigInt& q) {
    BigInt e;
    BigInt r;
-   vartime_divide(p - 1, q, e, r);
+   ct_divide(p - 1, q, e, r);
 
    if(e == 0 || r > 0) {
       throw Invalid_Argument("make_dsa_generator q does not divide p-1");

--- a/src/lib/utils/ct_utils.h
+++ b/src/lib/utils/ct_utils.h
@@ -515,17 +515,17 @@ class Mask final {
       /**
       * AND-combine two masks
       */
-      friend Mask<T> operator&(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() & y.value()); }
+      friend constexpr Mask<T> operator&(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() & y.value()); }
 
       /**
       * XOR-combine two masks
       */
-      friend Mask<T> operator^(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() ^ y.value()); }
+      friend constexpr Mask<T> operator^(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() ^ y.value()); }
 
       /**
       * OR-combine two masks
       */
-      friend Mask<T> operator|(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() | y.value()); }
+      friend constexpr Mask<T> operator|(Mask<T> x, Mask<T> y) { return Mask<T>(x.value() | y.value()); }
 
       /**
       * Negate this mask

--- a/src/tests/test_bigint.cpp
+++ b/src/tests/test_bigint.cpp
@@ -412,6 +412,79 @@ class BigInt_Div_Test final : public Text_Based_Test {
 
 BOTAN_REGISTER_TEST("math", "bn_div", BigInt_Div_Test);
 
+class BigInt_CtDivide_Test final : public Test {
+   public:
+      std::vector<Test::Result> run() override {
+         Test::Result result("BigInt ct_divide");
+
+         for(size_t y_bits = 1; y_bits <= 384; y_bits += 5) {
+            const BigInt y(rng(), y_bits, true);
+
+            const size_t x_bit_choices[] = {1, y_bits / 2 + 1, y_bits, y_bits + 1, y_bits + 65, 2 * y_bits + 3};
+
+            // Test some random inputs of varying sizes
+            for(const size_t x_bits : x_bit_choices) {
+               const BigInt x(rng(), x_bits, false);
+               check_divide(result, x, y);
+               check_divide(result, -x, y);
+               check_divide(result, x, -y);
+            }
+
+            const BigInt q(rng(), y_bits + 64, false);
+            check_divide(result, q * y, y);            // Exact multiple
+            check_divide(result, q * y + 1, y);        // Smallest non-zero remainder
+            check_divide(result, q * y + (y - 1), y);  // Largest possible remainder
+
+            // Cases where x and y are related
+            check_divide(result, (y << 64) - 1, y);
+            check_divide(result, (y << 128) - 1, y);
+            check_divide(result, y - 1, y);
+            check_divide(result, y, y);
+            check_divide(result, y + 1, y);
+
+            const BigInt x(rng(), y_bits + 130, false);
+
+            // Power of 2 and all-1s divisors
+            check_divide(result, x, BigInt::power_of_2(y_bits));
+            check_divide(result, x, BigInt::power_of_2(y_bits) - 1);
+
+            // Word sized divisors including 1 and the maximum word
+            check_divide(result, x, BigInt::one());
+            check_divide(result, x, BigInt::from_word(~static_cast<Botan::word>(0)));
+         }
+
+         return {result};
+      }
+
+   private:
+      static void check_divide(Test::Result& result, const BigInt& x, const BigInt& y) {
+         BigInt q;
+         BigInt r;
+         Botan::ct_divide(x, y, q, r);
+
+         result.test_bn_eq("ct_divide identity", q * y + r, x);
+         result.test_is_true("ct_divide r >= 0", r.signum() >= 0);
+         result.test_is_true("ct_divide r < |y|", r < y.abs());
+
+         if(y.sig_words() == 1 && y.signum() > 0) {
+            // Cross-check with ct_divide_word if possible
+            const Botan::word yw = y.word_at(0);
+
+            BigInt wq;
+            Botan::word wr = 0;
+            Botan::ct_divide_word(x, yw, wq, wr);
+            result.test_bn_eq("ct_divide_word q", wq, q);
+            result.test_bn_eq("ct_divide_word r", BigInt::from_word(wr), r);
+
+            if(x.signum() >= 0) {
+               result.test_bn_eq("ct_mod_word", BigInt::from_word(Botan::ct_mod_word(x, yw)), r);
+            }
+         }
+      }
+};
+
+BOTAN_REGISTER_TEST("math", "bn_ct_divide", BigInt_CtDivide_Test);
+
 class BigInt_DivPow2k_Test final : public Test {
    public:
       std::vector<Test::Result> run() override {
@@ -441,12 +514,11 @@ class BigInt_DivPow2k_Test final : public Test {
 
    private:
       static void testcase(size_t k, const BigInt& y, Test::Result& result) {
-         const BigInt ct_pow2k = ct_divide_pow2k(k, y);
-         const BigInt vt_pow2k = vartime_divide_pow2k(k, y);
-         const BigInt ref = BigInt::power_of_2(k) / y;
+         const BigInt q = ct_divide_pow2k(k, y);
+         const BigInt r = BigInt::power_of_2(k) - q * y;
 
-         result.test_bn_eq("ct_divide_pow2k matches Knuth division", ct_pow2k, ref);
-         result.test_bn_eq("vartime_divide_pow2k matches Knuth division", vt_pow2k, ref);
+         result.test_is_true("ct_divide_pow2k r >= 0", r.signum() >= 0);
+         result.test_is_true("ct_divide_pow2k r < y", r < y);
       }
 };
 

--- a/src/tests/test_mp.cpp
+++ b/src/tests/test_mp.cpp
@@ -230,7 +230,7 @@ class MP_Unit_Tests final : public Test {
          }
 
          for(const W d : divisors) {
-            const Botan::divide_precomp<W> div(d);
+            const auto div = Botan::divide_precomp<W>::setup_vartime(d);
 
             std::vector<std::pair<W, W>> cases{{0, 0},
                                                {0, max},
@@ -263,7 +263,12 @@ class MP_Unit_Tests final : public Test {
             for(const auto& [n1, n0] : cases) {
                // Check that q * d + r == (n1:n0) and r < d
 
-               const auto [q, r] = div.divmod_2to1(n1, n0);
+               const auto [q_ct, r_ct] = div.divmod_2to1_ct(n1, n0);
+
+               const auto [q, r] = div.divmod_2to1_vartime(n1, n0);
+
+               result.test_u64_eq("divmod_2to1 vartime and ct q agree", q, q_ct);
+               result.test_u64_eq("divmod_2to1 vartime and ct q agree", r, r_ct);
 
                W hi = r;
                const W lo = Botan::word_madd2(q, d, &hi);


### PR DESCRIPTION
With the new availability of a constant-time 2 word over 1 word division using Möller-Granlund, we can convert Knuth division to run in constant time (modulo handling negative inputs, which doesn't arise for cryptographic inputs) and additionally convert some special case constant time division algorithms, which previously worked 1 bit at a time, into word oriented algorithms.

Notably, improves RSA-2048 public key parsing by ~1.7x and private key parsing by ~3.5x.