### PR TITLE
Avoid heap churn in TLS record processing

### DIFF
--- a/src/lib/tls/tls12/tls_record.cpp
+++ b/src/lib/tls/tls12/tls_record.cpp
@@ -95,76 +95,79 @@ Connection_Cipher_State::Connection_Cipher_State(Protocol_Version version,
    m_aead->set_key(aead_key);
 }
 
-std::vector<uint8_t> Connection_Cipher_State::aead_nonce(uint64_t seq, RandomNumberGenerator& rng) {
+std::span<const uint8_t> Connection_Cipher_State::aead_nonce(uint64_t seq, RandomNumberGenerator& rng) {
+   // m_nonce_scratch is reused to avoid a heap allocation per record
    switch(m_nonce_format) {
       case Nonce_Format::NULL_CIPHER: {
-         return std::vector<uint8_t>{};
+         m_nonce_scratch.clear();
+         return m_nonce_scratch;
       }
       case Nonce_Format::CBC_MODE: {
-         std::vector<uint8_t> nonce(nonce_bytes_from_record());
-         rng.randomize(nonce.data(), nonce.size());
-         return nonce;
+         m_nonce_scratch.resize(nonce_bytes_from_record());
+         rng.randomize(m_nonce_scratch.data(), m_nonce_scratch.size());
+         return m_nonce_scratch;
       }
       case Nonce_Format::AEAD_XOR_12: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 12);
-         std::vector<uint8_t> nonce(12);
-         store_be(seq, nonce.data() + 4);
-         xor_buf(nonce, m_nonce.data(), m_nonce.size());
-         return nonce;
+         m_nonce_scratch.assign(12, 0);
+         store_be(seq, m_nonce_scratch.data() + 4);
+         xor_buf(m_nonce_scratch, m_nonce.data(), m_nonce.size());
+         return m_nonce_scratch;
       }
       case Nonce_Format::AEAD_IMPLICIT_4: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 4);
-         std::vector<uint8_t> nonce(12);
-         copy_mem(&nonce[0], m_nonce.data(), 4);  // NOLINT(*container-data-pointer)
-         store_be(seq, &nonce[nonce_bytes_from_handshake()]);
-         return nonce;
+         m_nonce_scratch.assign(12, 0);
+         copy_mem(m_nonce_scratch.data(), m_nonce.data(), 4);
+         store_be(seq, &m_nonce_scratch[nonce_bytes_from_handshake()]);
+         return m_nonce_scratch;
       }
    }
 
    throw Invalid_State("Unknown nonce format specified");
 }
 
-std::vector<uint8_t> Connection_Cipher_State::aead_nonce(const uint8_t record[], size_t record_len, uint64_t seq) {
+std::span<const uint8_t> Connection_Cipher_State::aead_nonce(const uint8_t record[], size_t record_len, uint64_t seq) {
    switch(m_nonce_format) {
       case Nonce_Format::NULL_CIPHER: {
-         return std::vector<uint8_t>{};
+         m_nonce_scratch.clear();
+         return m_nonce_scratch;
       }
       case Nonce_Format::CBC_MODE: {
          if(record_len < nonce_bytes_from_record()) {
             throw Decoding_Error("Invalid CBC packet too short to be valid");
          }
-         std::vector<uint8_t> nonce(record, record + nonce_bytes_from_record());
-         return nonce;
+         m_nonce_scratch.assign(record, record + nonce_bytes_from_record());
+         return m_nonce_scratch;
       }
       case Nonce_Format::AEAD_XOR_12: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 12);
-         std::vector<uint8_t> nonce(12);
-         store_be(seq, nonce.data() + 4);
-         xor_buf(nonce, m_nonce.data(), m_nonce.size());
-         return nonce;
+         m_nonce_scratch.assign(12, 0);
+         store_be(seq, m_nonce_scratch.data() + 4);
+         xor_buf(m_nonce_scratch, m_nonce.data(), m_nonce.size());
+         return m_nonce_scratch;
       }
       case Nonce_Format::AEAD_IMPLICIT_4: {
          BOTAN_ASSERT_NOMSG(m_nonce.size() == 4);
          if(record_len < nonce_bytes_from_record()) {
             throw Decoding_Error("Invalid AEAD packet too short to be valid");
          }
-         std::vector<uint8_t> nonce(12);
-         copy_mem(&nonce[0], m_nonce.data(), 4);  // NOLINT(*container-data-pointer)
-         copy_mem(&nonce[nonce_bytes_from_handshake()], record, nonce_bytes_from_record());
-         return nonce;
+         m_nonce_scratch.assign(12, 0);
+         copy_mem(m_nonce_scratch.data(), m_nonce.data(), 4);
+         copy_mem(&m_nonce_scratch[nonce_bytes_from_handshake()], record, nonce_bytes_from_record());
+         return m_nonce_scratch;
       }
    }
 
    throw Invalid_State("Unknown nonce format specified");
 }
 
-std::vector<uint8_t> Connection_Cipher_State::format_ad(uint64_t msg_sequence,
-                                                        Record_Type msg_type,
-                                                        Protocol_Version version,
-                                                        uint16_t msg_length) {
-   std::vector<uint8_t> ad(13);
+std::array<uint8_t, 13> Connection_Cipher_State::format_ad(uint64_t msg_sequence,
+                                                           Record_Type msg_type,
+                                                           Protocol_Version version,
+                                                           uint16_t msg_length) {
+   std::array<uint8_t, 13> ad{};
 
-   store_be(msg_sequence, &ad[0]);  // NOLINT(*container-data-pointer)
+   store_be(msg_sequence, ad.data());
    ad[8] = static_cast<uint8_t>(msg_type);
    ad[9] = version.major_version();
    ad[10] = version.minor_version();
@@ -227,7 +230,7 @@ void write_record(secure_vector<uint8_t>& output,
    write_record_header(output, record_type, version, record_sequence);
 
    AEAD_Mode& aead = cs.aead();
-   std::vector<uint8_t> aad = cs.format_ad(record_sequence, record_type, version, static_cast<uint16_t>(message_len));
+   const auto aad = cs.format_ad(record_sequence, record_type, version, static_cast<uint16_t>(message_len));
 
    const size_t ctext_size = aead.output_length(message_len);
 
@@ -235,13 +238,13 @@ void write_record(secure_vector<uint8_t>& output,
 
    aead.set_associated_data(aad);
 
-   const std::vector<uint8_t> nonce = cs.aead_nonce(record_sequence, rng);
+   const auto nonce = cs.aead_nonce(record_sequence, rng);
 
    append_u16_len(output, rec_size);
 
    if(cs.nonce_bytes_from_record() > 0) {
       if(cs.nonce_format() == Nonce_Format::CBC_MODE) {
-         output += nonce;
+         output.insert(output.end(), nonce.begin(), nonce.end());
       } else {
          output += std::make_pair(&nonce[cs.nonce_bytes_from_handshake()], cs.nonce_bytes_from_record());
       }
@@ -283,7 +286,7 @@ void decrypt_record(secure_vector<uint8_t>& output,
                     Connection_Cipher_State& cs) {
    AEAD_Mode& aead = cs.aead();
 
-   const std::vector<uint8_t> nonce = cs.aead_nonce(record_contents, record_len, record_sequence);
+   const auto nonce = cs.aead_nonce(record_contents, record_len, record_sequence);
    const size_t nonce_from_record = cs.nonce_bytes_from_record();
    if(record_len <= nonce_from_record) {
       throw TLS_Exception(Alert::BadRecordMac, "AEAD packet too short to be valid");

--- a/src/lib/tls/tls12/tls_record.h
+++ b/src/lib/tls/tls12/tls_record.h
@@ -14,8 +14,10 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_magic.h>
 #include <botan/tls_version.h>
+#include <array>
 #include <functional>
 #include <memory>
+#include <span>
 #include <vector>
 
 namespace Botan {
@@ -60,11 +62,17 @@ class Connection_Cipher_State final {
          return *m_aead;
       }
 
-      std::vector<uint8_t> aead_nonce(uint64_t seq, RandomNumberGenerator& rng);
+      /**
+      * The returned nonce is valid only until the next aead_nonce call
+      */
+      std::span<const uint8_t> aead_nonce(uint64_t seq, RandomNumberGenerator& rng);
 
-      std::vector<uint8_t> aead_nonce(const uint8_t record[], size_t record_len, uint64_t seq);
+      std::span<const uint8_t> aead_nonce(const uint8_t record[], size_t record_len, uint64_t seq);
 
-      std::vector<uint8_t> format_ad(uint64_t seq, Record_Type type, Protocol_Version version, uint16_t ptext_length);
+      std::array<uint8_t, 13> format_ad(uint64_t seq,
+                                        Record_Type type,
+                                        Protocol_Version version,
+                                        uint16_t ptext_length);
 
       size_t nonce_bytes_from_handshake() const { return m_nonce_bytes_from_handshake; }
 
@@ -76,6 +84,7 @@ class Connection_Cipher_State final {
       std::unique_ptr<AEAD_Mode> m_aead;
 
       std::vector<uint8_t> m_nonce;
+      std::vector<uint8_t> m_nonce_scratch;
       Nonce_Format m_nonce_format;
       size_t m_nonce_bytes_from_handshake;
       size_t m_nonce_bytes_from_record;

--- a/src/lib/tls/tls13/tls_cipher_state.cpp
+++ b/src/lib/tls/tls13/tls_cipher_state.cpp
@@ -245,7 +245,7 @@ auto current_nonce(const uint64_t seq_no, std::span<const uint8_t> iv) {
 
 }  // namespace
 
-uint64_t Cipher_State::encrypt_record_fragment(const std::vector<uint8_t>& header, secure_vector<uint8_t>& fragment) {
+uint64_t Cipher_State::encrypt_record_fragment(std::span<const uint8_t> header, secure_vector<uint8_t>& fragment) {
    BOTAN_ASSERT_NONNULL(m_encrypt);
 
    // RFC 8446 5.3
@@ -261,7 +261,7 @@ uint64_t Cipher_State::encrypt_record_fragment(const std::vector<uint8_t>& heade
    return m_write_seq_no++;
 }
 
-uint64_t Cipher_State::decrypt_record_fragment(const std::vector<uint8_t>& header,
+uint64_t Cipher_State::decrypt_record_fragment(std::span<const uint8_t> header,
                                                secure_vector<uint8_t>& encrypted_fragment) {
    BOTAN_ASSERT_NONNULL(m_decrypt);
    BOTAN_ARG_CHECK(encrypted_fragment.size() >= m_decrypt->minimum_final_size(), "fragment too short to decrypt");

--- a/src/lib/tls/tls13/tls_cipher_state.h
+++ b/src/lib/tls/tls13/tls_cipher_state.h
@@ -123,7 +123,7 @@ class BOTAN_TEST_API Cipher_State {
        *
        * @returns the sequence number of the encrypted record
        */
-      uint64_t encrypt_record_fragment(const std::vector<uint8_t>& header, secure_vector<uint8_t>& fragment);
+      uint64_t encrypt_record_fragment(std::span<const uint8_t> header, secure_vector<uint8_t>& fragment);
 
       /**
        * Decrypt a TLS record fragment (RFC 8446 5.2 -- TLSCiphertext.encrypted_record)
@@ -133,7 +133,7 @@ class BOTAN_TEST_API Cipher_State {
        *
        * @returns the sequence number of the decrypted record
        */
-      uint64_t decrypt_record_fragment(const std::vector<uint8_t>& header, secure_vector<uint8_t>& encrypted_fragment);
+      uint64_t decrypt_record_fragment(std::span<const uint8_t> header, secure_vector<uint8_t>& encrypted_fragment);
 
       /**
        * @returns number of bytes needed to encrypt \p input_length bytes

--- a/src/lib/tls/tls13/tls_record_layer_13.cpp
+++ b/src/lib/tls/tls13/tls_record_layer_13.cpp
@@ -17,6 +17,7 @@
 #include <botan/internal/loadstor.h>
 #include <botan/internal/tls_cipher_state.h>
 #include <algorithm>
+#include <array>
 
 namespace Botan::TLS {
 
@@ -54,12 +55,12 @@ Record_Type read_record_type(const uint8_t type_byte) {
  */
 class TLSPlaintext_Header final {
    public:
-      TLSPlaintext_Header(std::vector<uint8_t> hdr, const bool check_tls13_version) {
+      TLSPlaintext_Header(std::span<const uint8_t, TLS_HEADER_SIZE> hdr, const bool check_tls13_version) {
          // NOLINTBEGIN(*-prefer-member-initializer)
          m_type = read_record_type(hdr[0]);
          m_legacy_version = Protocol_Version(make_uint16(hdr[1], hdr[2]));
          m_fragment_length = make_uint16(hdr[3], hdr[4]);
-         m_serialized = std::move(hdr);
+         copy_mem(m_serialized.data(), hdr.data(), hdr.size());
          // NOLINTEND(*-prefer-member-initializer)
 
          // If no full version check is requested, we just verify the practically
@@ -121,13 +122,13 @@ class TLSPlaintext_Header final {
             m_legacy_version(use_compatibility_version ? 0x0301 : 0x0303)  // RFC 8446 5.1
             ,
             m_fragment_length(static_cast<uint16_t>(frgmnt_length)),
-            m_serialized({
+            m_serialized({{
                static_cast<uint8_t>(m_type),
                m_legacy_version.major_version(),
                m_legacy_version.minor_version(),
                get_byte<0>(m_fragment_length),
                get_byte<1>(m_fragment_length),
-            }) {}
+            }}) {}
 
       Record_Type type() const { return m_type; }
 
@@ -135,13 +136,13 @@ class TLSPlaintext_Header final {
 
       Protocol_Version legacy_version() const { return m_legacy_version; }
 
-      const std::vector<uint8_t>& serialized() const { return m_serialized; }
+      const std::array<uint8_t, TLS_HEADER_SIZE>& serialized() const { return m_serialized; }
 
    private:
       Record_Type m_type;
       Protocol_Version m_legacy_version;
       uint16_t m_fragment_length;
-      std::vector<uint8_t> m_serialized;
+      std::array<uint8_t, TLS_HEADER_SIZE> m_serialized{};
 };
 
 }  // namespace
@@ -332,7 +333,9 @@ Record_Layer::ReadResult<Record> Record_Layer::next_record(Cipher_State* cipher_
    // The first received record(s) are likely a client or server hello. To be able to
    // perform protocol downgrades we must be less vigorous with the record's
    // legacy version. Hence, `check_tls13_version` is `false` for the first record(s).
-   const TLSPlaintext_Header plaintext_header({header_begin, header_end}, !m_receiving_compat_mode);
+   const TLSPlaintext_Header plaintext_header(
+      std::span<const uint8_t, TLS_HEADER_SIZE>(m_read_buffer.data() + m_read_offset, TLS_HEADER_SIZE),
+      !m_receiving_compat_mode);
 
    // After the key exchange phase of the handshake is completed and record protection is engaged,
    // cipher_state is set. At this point, only protected traffic (and CCS) is allowed.
@@ -364,10 +367,11 @@ Record_Layer::ReadResult<Record> Record_Layer::next_record(Cipher_State* cipher_
    Record record(plaintext_header.type(), secure_vector<uint8_t>(fragment_begin, fragment_end));
    m_read_offset += TLS_HEADER_SIZE + plaintext_header.fragment_length();
 
-   // If all buffered data has been consumed, release the buffer memory
-   // to avoid retaining peak allocation on idle connections.
+   // Once all buffered data is consumed, keep the buffer's capacity for the
+   // next record rather than reallocating it every time. The memory is
+   // released via clear_read_buffer() when the connection closes.
    if(m_read_offset == m_read_buffer.size()) {
-      zap(m_read_buffer);
+      m_read_buffer.clear();
       m_read_offset = 0;
    }
 


### PR DESCRIPTION
It was doing a lot of per-record alloc+free that aren't really necessary.