### PR TITLE
Avoid copying each X509 extension body during decoding

### DIFF
--- a/src/lib/x509/pkix_types.h
+++ b/src/lib/x509/pkix_types.h
@@ -1047,10 +1047,8 @@ class BOTAN_PUBLIC_API(2, 0) Extensions final : public ASN1_Object {
             Extensions_Info(bool critical, std::unique_ptr<Certificate_Extension> ext) :
                   m_obj(std::move(ext)), m_bits(m_obj->encode_inner()), m_critical(critical) {}
 
-            Extensions_Info(bool critical,
-                            const std::vector<uint8_t>& encoding,
-                            std::unique_ptr<Certificate_Extension> ext) :
-                  m_obj(std::move(ext)), m_bits(encoding), m_critical(critical) {}
+            Extensions_Info(bool critical, std::vector<uint8_t> encoding, std::unique_ptr<Certificate_Extension> ext) :
+                  m_obj(std::move(ext)), m_bits(std::move(encoding)), m_critical(critical) {}
 
             bool is_critical() const { return m_critical; }
 

--- a/src/lib/x509/x509_ext.cpp
+++ b/src/lib/x509/x509_ext.cpp
@@ -346,14 +346,15 @@ void Extensions::decode_from(BER_Decoder& from_source, std::optional<Extension_C
       if(critical && obj->oid_name().empty()) {
          m_has_unknown_critical_extension = true;
       }
-      Extensions_Info info(critical, bits, std::move(obj));
+      Extensions_Info info(critical, std::move(bits), std::move(obj));
+
+      m_extension_oids.push_back(oid);
 
       // RFC 5280 4.2: "A certificate MUST NOT include more than one
       // instance of a particular extension."
-      if(!m_extension_info.emplace(oid, info).second) {
+      if(!m_extension_info.emplace(std::move(oid), std::move(info)).second) {
          throw Decoding_Error("Duplicate certificate extension encountered");
       }
-      m_extension_oids.push_back(oid);
    }
    sequence.verify_end();
 }


### PR DESCRIPTION
Extensions::decode_from copied the extension body into Extensions_Info, copied that into the map, and additionally copied the OID for the map key even though it was a local temporary; use moves instead.