### PR TITLE
Read in chunks in BER_Decoder::raw_bytes and discard_remaining

### DIFF
--- a/src/lib/asn1/ber_dec.cpp
+++ b/src/lib/asn1/ber_dec.cpp
@@ -487,8 +487,8 @@ BER_Decoder& BER_Decoder::verify_end(std::string_view err) {
 */
 BER_Decoder& BER_Decoder::discard_remaining() {
    m_pushed = BER_Object();
-   uint8_t buf = 0;
-   while(m_source->read_byte(buf) != 0) {}
+   uint8_t buf[64];
+   while(m_source->read(buf, sizeof(buf)) != 0) {}
    return (*this);
 }
 
@@ -500,6 +500,11 @@ std::optional<uint8_t> BER_Decoder::read_next_byte() {
    } else {
       return {};
    }
+}
+
+size_t BER_Decoder::read_bytes(std::span<uint8_t> out) {
+   BOTAN_ASSERT_NOMSG(m_source != nullptr);
+   return m_source->read(out.data(), out.size());
 }
 
 const BER_Object& BER_Decoder::peek_next_object() {

--- a/src/lib/asn1/ber_dec.h
+++ b/src/lib/asn1/ber_dec.h
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <memory>
 #include <optional>
+#include <span>
 #include <type_traits>
 #include <utility>
 
@@ -337,12 +338,9 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       template <typename Alloc>
       BER_Decoder& raw_bytes(std::vector<uint8_t, Alloc>& out) {
          out.clear();
-         for(;;) {
-            if(auto next = this->read_next_byte()) {
-               out.push_back(*next);
-            } else {
-               break;
-            }
+         uint8_t buf[64];
+         while(const size_t got = this->read_bytes(std::span{buf})) {
+            out.insert(out.end(), buf, buf + got);
          }
          return (*this);
       }
@@ -809,6 +807,8 @@ class BOTAN_PUBLIC_API(2, 0) BER_Decoder final {
       BER_Decoder(BER_Object&& obj, BER_Decoder* parent);
 
       std::optional<uint8_t> read_next_byte();
+
+      size_t read_bytes(std::span<uint8_t> out);
 
       BER_Object get_next_value(size_t sizeofT, ASN1_Type type_tag, ASN1_Class class_tag);
 


### PR DESCRIPTION
These previously executed a virtual call for each byte of the input. Amortize this by reading in small chunks instead.