### PR TITLE
Optimize Whirlpool base implementation on ARM64 and x86-64

### DIFF
--- a/src/lib/hash/whirlpool/whirlpool.cpp
+++ b/src/lib/hash/whirlpool/whirlpool.cpp
@@ -7,10 +7,12 @@
 
 #include <botan/internal/whirlpool.h>
 
+#include <botan/compiler.h>
 #include <botan/internal/bit_ops.h>
 #include <botan/internal/buffer_slicer.h>
 #include <botan/internal/loadstor.h>
 #include <botan/internal/rotate.h>
+#include <botan/internal/target_info.h>
 #include <array>
 
 #if defined(BOTAN_HAS_CPUID)
@@ -42,6 +44,12 @@ consteval std::array<uint8_t, 256> whirlpool_sbox() noexcept {
    return S;
 }
 
+#if defined(BOTAN_TARGET_ARCH_IS_ARM64) || defined(BOTAN_TARGET_ARCH_IS_X86_64) || defined(BOTAN_TARGET_ARCH_IS_PPC64)
+constexpr bool WhirlpoolUnalignedTables = true;
+#else
+constexpr bool WhirlpoolUnalignedTables = false;
+#endif
+
 // Combined S-box + MDS diffusion table
 consteval std::array<uint64_t, 256> whirlpool_T_table(const std::array<uint8_t, 256>& S) noexcept {
    // MDS circulant matrix first row: [1, 1, 4, 1, 8, 5, 2, 9] over GF(2^8)
@@ -54,6 +62,22 @@ consteval std::array<uint64_t, 256> whirlpool_T_table(const std::array<uint8_t, 
    return T;
 }
 
+constexpr size_t WHIRL_U_STRIDE = 2 * sizeof(uint64_t);
+
+[[maybe_unused]] consteval std::array<uint8_t, 256 * WHIRL_U_STRIDE> whirlpool_U_table(
+   const std::array<uint64_t, 256>& T) noexcept {
+   // Duplicating each entry permits unaligned loads to perform the rotations
+   std::array<uint8_t, 256 * WHIRL_U_STRIDE> U = {};
+
+   for(size_t i = 0; i != 256; ++i) {
+      for(size_t j = 0; j != sizeof(uint64_t); ++j) {
+         U[WHIRL_U_STRIDE * i + j] = static_cast<uint8_t>(T[i] >> (8 * j));
+         U[WHIRL_U_STRIDE * i + sizeof(uint64_t) + j] = static_cast<uint8_t>(T[i] >> (8 * j));
+      }
+   }
+   return U;
+}
+
 // Round constants are from the first 64 elements of the sbox
 consteval std::array<uint64_t, 10> whirlpool_rc(const std::array<uint8_t, 256>& S) noexcept {
    std::array<uint64_t, 10> RC = {};
@@ -64,20 +88,37 @@ consteval std::array<uint64_t, 10> whirlpool_rc(const std::array<uint8_t, 256>& 
 }
 
 constexpr auto WHIRL_S = whirlpool_sbox();
-alignas(256) constexpr auto WHIRL_T = whirlpool_T_table(WHIRL_S);
 constexpr auto WHIRL_RC = whirlpool_rc(WHIRL_S);
 
-uint64_t whirl(uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6, uint64_t x7) {
-   const uint64_t s0 = WHIRL_T[get_byte<0>(x0)];
-   const uint64_t s1 = WHIRL_T[get_byte<1>(x1)];
-   const uint64_t s2 = WHIRL_T[get_byte<2>(x2)];
-   const uint64_t s3 = WHIRL_T[get_byte<3>(x3)];
-   const uint64_t s4 = WHIRL_T[get_byte<4>(x4)];
-   const uint64_t s5 = WHIRL_T[get_byte<5>(x5)];
-   const uint64_t s6 = WHIRL_T[get_byte<6>(x6)];
-   const uint64_t s7 = WHIRL_T[get_byte<7>(x7)];
+BOTAN_FORCE_INLINE uint64_t
+whirl(uint64_t x0, uint64_t x1, uint64_t x2, uint64_t x3, uint64_t x4, uint64_t x5, uint64_t x6, uint64_t x7) {
+   if constexpr(WhirlpoolUnalignedTables) {
+      alignas(256) static constexpr auto WHIRL_U = whirlpool_U_table(whirlpool_T_table(WHIRL_S));
 
-   return s0 ^ rotr<8>(s1) ^ rotr<16>(s2) ^ rotr<24>(s3) ^ rotr<32>(s4) ^ rotr<40>(s5) ^ rotr<48>(s6) ^ rotr<56>(s7);
+      const uint64_t s0 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<0>(x0), 0);
+      const uint64_t s1 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<1>(x1) + 1, 0);
+      const uint64_t s2 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<2>(x2) + 2, 0);
+      const uint64_t s3 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<3>(x3) + 3, 0);
+      const uint64_t s4 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<4>(x4) + 4, 0);
+      const uint64_t s5 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<5>(x5) + 5, 0);
+      const uint64_t s6 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<6>(x6) + 6, 0);
+      const uint64_t s7 = load_le<uint64_t>(WHIRL_U.data() + WHIRL_U_STRIDE * get_byte<7>(x7) + 7, 0);
+
+      return s0 ^ s1 ^ s2 ^ s3 ^ s4 ^ s5 ^ s6 ^ s7;
+   } else {
+      alignas(256) static constexpr auto WHIRL_T = whirlpool_T_table(WHIRL_S);
+
+      const uint64_t s0 = WHIRL_T[get_byte<0>(x0)];
+      const uint64_t s1 = WHIRL_T[get_byte<1>(x1)];
+      const uint64_t s2 = WHIRL_T[get_byte<2>(x2)];
+      const uint64_t s3 = WHIRL_T[get_byte<3>(x3)];
+      const uint64_t s4 = WHIRL_T[get_byte<4>(x4)];
+      const uint64_t s5 = WHIRL_T[get_byte<5>(x5)];
+      const uint64_t s6 = WHIRL_T[get_byte<6>(x6)];
+      const uint64_t s7 = WHIRL_T[get_byte<7>(x7)];
+
+      return s0 ^ rotr<8>(s1) ^ rotr<16>(s2) ^ rotr<24>(s3) ^ rotr<32>(s4) ^ rotr<40>(s5) ^ rotr<48>(s6) ^ rotr<56>(s7);
+   }
 }
 
 }  // namespace
@@ -119,7 +160,7 @@ void Whirlpool::compress_n(digest_type& digest, std::span<const uint8_t> input, 
    for(size_t i = 0; i != blocks; ++i) {
       const auto block = in.take(block_bytes);
 
-      uint64_t K[11 * 8] = {0};
+      uint64_t K[8];
 
       K[0] = digest[0];
       K[1] = digest[1];
@@ -130,28 +171,7 @@ void Whirlpool::compress_n(digest_type& digest, std::span<const uint8_t> input, 
       K[6] = digest[6];
       K[7] = digest[7];
 
-      // Whirlpool key schedule:
-      for(size_t r = 1; r != 11; ++r) {
-         const uint64_t PK0 = K[8 * (r - 1) + 0];
-         const uint64_t PK1 = K[8 * (r - 1) + 1];
-         const uint64_t PK2 = K[8 * (r - 1) + 2];
-         const uint64_t PK3 = K[8 * (r - 1) + 3];
-         const uint64_t PK4 = K[8 * (r - 1) + 4];
-         const uint64_t PK5 = K[8 * (r - 1) + 5];
-         const uint64_t PK6 = K[8 * (r - 1) + 6];
-         const uint64_t PK7 = K[8 * (r - 1) + 7];
-
-         K[8 * r + 0] = whirl(PK0, PK7, PK6, PK5, PK4, PK3, PK2, PK1) ^ WHIRL_RC[r - 1];
-         K[8 * r + 1] = whirl(PK1, PK0, PK7, PK6, PK5, PK4, PK3, PK2);
-         K[8 * r + 2] = whirl(PK2, PK1, PK0, PK7, PK6, PK5, PK4, PK3);
-         K[8 * r + 3] = whirl(PK3, PK2, PK1, PK0, PK7, PK6, PK5, PK4);
-         K[8 * r + 4] = whirl(PK4, PK3, PK2, PK1, PK0, PK7, PK6, PK5);
-         K[8 * r + 5] = whirl(PK5, PK4, PK3, PK2, PK1, PK0, PK7, PK6);
-         K[8 * r + 6] = whirl(PK6, PK5, PK4, PK3, PK2, PK1, PK0, PK7);
-         K[8 * r + 7] = whirl(PK7, PK6, PK5, PK4, PK3, PK2, PK1, PK0);
-      }
-
-      uint64_t M[8] = {0};
+      uint64_t M[8];
       load_be(M, block.data(), 8);
 
       // First round (key masking)
@@ -164,15 +184,33 @@ void Whirlpool::compress_n(digest_type& digest, std::span<const uint8_t> input, 
       uint64_t B6 = M[6] ^ K[6];
       uint64_t B7 = M[7] ^ K[7];
 
-      for(size_t r = 1; r != 11; ++r) {
-         const uint64_t T0 = whirl(B0, B7, B6, B5, B4, B3, B2, B1) ^ K[8 * r + 0];
-         const uint64_t T1 = whirl(B1, B0, B7, B6, B5, B4, B3, B2) ^ K[8 * r + 1];
-         const uint64_t T2 = whirl(B2, B1, B0, B7, B6, B5, B4, B3) ^ K[8 * r + 2];
-         const uint64_t T3 = whirl(B3, B2, B1, B0, B7, B6, B5, B4) ^ K[8 * r + 3];
-         const uint64_t T4 = whirl(B4, B3, B2, B1, B0, B7, B6, B5) ^ K[8 * r + 4];
-         const uint64_t T5 = whirl(B5, B4, B3, B2, B1, B0, B7, B6) ^ K[8 * r + 5];
-         const uint64_t T6 = whirl(B6, B5, B4, B3, B2, B1, B0, B7) ^ K[8 * r + 6];
-         const uint64_t T7 = whirl(B7, B6, B5, B4, B3, B2, B1, B0) ^ K[8 * r + 7];
+      for(size_t r = 0; r != 10; ++r) {
+         const uint64_t K0 = whirl(K[0], K[7], K[6], K[5], K[4], K[3], K[2], K[1]) ^ WHIRL_RC[r];
+         const uint64_t K1 = whirl(K[1], K[0], K[7], K[6], K[5], K[4], K[3], K[2]);
+         const uint64_t K2 = whirl(K[2], K[1], K[0], K[7], K[6], K[5], K[4], K[3]);
+         const uint64_t K3 = whirl(K[3], K[2], K[1], K[0], K[7], K[6], K[5], K[4]);
+         const uint64_t K4 = whirl(K[4], K[3], K[2], K[1], K[0], K[7], K[6], K[5]);
+         const uint64_t K5 = whirl(K[5], K[4], K[3], K[2], K[1], K[0], K[7], K[6]);
+         const uint64_t K6 = whirl(K[6], K[5], K[4], K[3], K[2], K[1], K[0], K[7]);
+         const uint64_t K7 = whirl(K[7], K[6], K[5], K[4], K[3], K[2], K[1], K[0]);
+
+         const uint64_t T0 = whirl(B0, B7, B6, B5, B4, B3, B2, B1) ^ K0;
+         const uint64_t T1 = whirl(B1, B0, B7, B6, B5, B4, B3, B2) ^ K1;
+         const uint64_t T2 = whirl(B2, B1, B0, B7, B6, B5, B4, B3) ^ K2;
+         const uint64_t T3 = whirl(B3, B2, B1, B0, B7, B6, B5, B4) ^ K3;
+         const uint64_t T4 = whirl(B4, B3, B2, B1, B0, B7, B6, B5) ^ K4;
+         const uint64_t T5 = whirl(B5, B4, B3, B2, B1, B0, B7, B6) ^ K5;
+         const uint64_t T6 = whirl(B6, B5, B4, B3, B2, B1, B0, B7) ^ K6;
+         const uint64_t T7 = whirl(B7, B6, B5, B4, B3, B2, B1, B0) ^ K7;
+
+         K[0] = K0;
+         K[1] = K1;
+         K[2] = K2;
+         K[3] = K3;
+         K[4] = K4;
+         K[5] = K5;
+         K[6] = K6;
+         K[7] = K7;
 
          B0 = T0;
          B1 = T1;


### PR DESCRIPTION
## Summary

This improves the performance of Whirlpool's base compression function on ARM64 and x86-64.

The 256-entry transformation table is expanded from 2 KiB to 4 KiB by storing two consecutive copies of each 64-bit entry. This allows the byte rotations required by `whirl()` to be performed using loads at offsets 0 through 7, avoiding explicit rotate instructions.

The key-schedule and message-round loops are also fused. Instead of materializing all 11 round keys in an 88-word array, the implementation keeps the current eight-word key state and updates it alongside the message state during each round.

`whirl()` is force-inlined because GCC on ARM64 otherwise failed to inline it, resulting in a performance regression.

## Platform scope

The optimized implementation is limited to ARM64 and x86-64. Both platforms support efficient unaligned 64-bit loads and were benchmarked with this implementation.

Although the loads are alignment-safe at the C++ level, other architectures may lower them to slower byte-wise operations. The larger table could also regress performance on processors with smaller caches. Those platforms therefore retain the existing 2 KiB table, explicit rotations, and separate key schedule.

The x86-64 SIMD implementations are unchanged and bypass this base implementation. x86-64 base benchmarks were run with assembly disabled to prevent SIMD dispatch.

## Benchmarks

Representative 1024-byte Whirlpool results, rounded:

- Apple M3 ARM64, Apple Clang 21: **+22%**
- Debian ARM64 VM, GCC 14.2: **+14%**
- x86-64 Mac Pro, Apple Clang 21, assembly disabled: **+45%**

All 136 Whirlpool test vectors pass.