### PR TITLE
Measure password hashing tuning using a CPU or monotonic clock

### DIFF
--- a/doc/api_ref/pbkdf.rst
+++ b/doc/api_ref/pbkdf.rst
@@ -117,7 +117,14 @@ The ``PasswordHashFamily`` creates specific instances of ``PasswordHash``:
       This function works by running a short tuning loop to estimate the
       performance of the algorithm, then scaling the parameters appropriately to
       hit the target size. The length of time the tuning loop runs can be
-      controlled using the *tuning_msec* parameter.
+      controlled using the *tuning_msec* parameter, though it always runs at
+      least a few iterations and so may take longer for expensive functions.
+
+      The tuning loop measures the CPU time of the calling thread (where the
+      platform supports this) and uses the fastest iteration observed, so the
+      result reflects the capacity of the machine rather than its load at the
+      moment of tuning. On a heavily loaded system the returned parameters may
+      therefore take longer than requested.
 
    .. cpp:function:: std::unique_ptr<PasswordHash> tune( \
                      size_t output_len, \

--- a/news.rst
+++ b/news.rst
@@ -7,6 +7,11 @@ Version 3.14.0, Not Yet Released
 * Add new type ``PK_Signature_Options`` which allows precisely controlling how
   signatures are created and verified. (GH #5849)
 
+* Password hash tuning (``PasswordHashFamily::tune_params``) now measures the
+  CPU time of the calling thread where available (falling back to a monotonic
+  clock), and uses the fastest of several samples rather than the mean. This
+  makes the result much less sensitive to concurrent load and clock adjustments.
+
 * By default, ECDSA signatures are now randomized rather than deterministic even
   when RFC 6979 support is available at build time. Deterministic signatures can
   be requested using the API ``PK_Signature_Options::with_deterministic_signature``

--- a/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
+++ b/src/lib/pbkdf/pgp_s2k/pgp_s2k.cpp
@@ -15,6 +15,7 @@
 #include <botan/internal/mem_utils.h>
 #include <botan/internal/time_utils.h>
 #include <algorithm>
+#include <array>
 
 namespace Botan {
 
@@ -97,12 +98,27 @@ std::unique_ptr<PasswordHash> RFC4880_S2K_Family::tune_params(size_t output_len,
                                                               uint64_t desired_msec,
                                                               std::optional<size_t> /*max_memory*/,
                                                               uint64_t tuning_msec) const {
-   constexpr size_t buf_size = 1024;
-   std::vector<uint8_t> buffer(buf_size);
+   // Benchmark the real S2K, since hashing the salt and password in small
+   // pieces has a large per-call cost that bulk hashing would not reflect
+   constexpr size_t tuning_iterations = 1024 * 1024;
+   constexpr std::string_view tuning_password = "password";
+   const std::array<uint8_t, 8> tuning_salt{};
 
-   const uint64_t measured_nsec = measure_cost(tuning_msec, [&]() { m_hash->update(buffer); });
+   auto tuning_hash = m_hash->new_object();
+   std::vector<uint8_t> tuning_out(tuning_hash->output_length());
 
-   const double hash_bytes_per_second = (buf_size * 1000000000.0) / measured_nsec;
+   const uint64_t measured_nsec = measure_cost(tuning_msec, [&]() {
+      pgp_s2k(*tuning_hash,
+              tuning_out.data(),
+              tuning_out.size(),
+              tuning_password.data(),
+              tuning_password.size(),
+              tuning_salt.data(),
+              tuning_salt.size(),
+              tuning_iterations);
+   });
+
+   const double hash_bytes_per_second = (tuning_iterations * 1000000000.0) / measured_nsec;
    const uint64_t desired_nsec = desired_msec * 1000000;
 
    const size_t hash_size = m_hash->output_length();

--- a/src/lib/pbkdf/pwdhash.h
+++ b/src/lib/pbkdf/pwdhash.h
@@ -232,7 +232,14 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHashFamily /* NOLINT(*-special-member-funct
       * This function works by running a short tuning loop to estimate the
       * performance of the algorithm, then scaling the parameters appropriately
       * to hit the target size. The length of time the tuning loop runs can be
-      * controlled using the @p tuning_msec parameter.
+      * controlled using the @p tuning_msec parameter, though it always runs at
+      * least a few iterations and so may take longer for expensive functions.
+      *
+      * The tuning loop measures the CPU time of the calling thread (where the
+      * platform supports this) and uses the fastest iteration observed, so the
+      * result reflects the capacity of the machine rather than its load at the
+      * moment of tuning. On a heavily loaded system the returned parameters
+      * may therefore take longer than requested.
       *
       * @param output_length how long the output length will be
       * @param desired_runtime_msec the desired execution time in milliseconds
@@ -264,7 +271,14 @@ class BOTAN_PUBLIC_API(2, 8) PasswordHashFamily /* NOLINT(*-special-member-funct
       * This function works by running a short tuning loop to estimate the
       * performance of the algorithm, then scaling the parameters appropriately
       * to hit the target size. The length of time the tuning loop runs can be
-      * controlled using the @p tuning_msec parameter.
+      * controlled using the @p tuning_msec parameter, though it always runs at
+      * least a few iterations and so may take longer for expensive functions.
+      *
+      * The tuning loop measures the CPU time of the calling thread (where the
+      * platform supports this) and uses the fastest iteration observed, so the
+      * result reflects the capacity of the machine rather than its load at the
+      * moment of tuning. On a heavily loaded system the returned parameters
+      * may therefore take longer than requested.
       *
       * @param output_length how long the output length will be
       * @param msec the desired execution time in milliseconds

--- a/src/lib/utils/os_utils/os_utils.cpp
+++ b/src/lib/utils/os_utils/os_utils.cpp
@@ -341,6 +341,27 @@ uint64_t OS::get_system_timestamp_ns() {
 #endif
 }
 
+std::optional<uint64_t> OS::get_thread_cpu_time_ns() {
+#if defined(BOTAN_TARGET_OS_HAS_CLOCK_GETTIME) && defined(CLOCK_THREAD_CPUTIME_ID)
+   // Tick-based accounting is useless for timing a single call, so only
+   // use this clock if it claims fine resolution
+   static const bool usable = []() {
+      struct timespec res {};
+      return ::clock_getres(CLOCK_THREAD_CPUTIME_ID, &res) == 0 && res.tv_sec == 0 && res.tv_nsec <= 10000;
+   }();
+
+   if(usable) {
+      struct timespec ts {};
+
+      if(::clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) == 0) {
+         return (static_cast<uint64_t>(ts.tv_sec) * 1000000000) + static_cast<uint64_t>(ts.tv_nsec);
+      }
+   }
+#endif
+
+   return std::nullopt;
+}
+
 std::string OS::format_time(time_t time, const std::string& format) {
    std::tm tm{};
 

--- a/src/lib/utils/os_utils/os_utils.h
+++ b/src/lib/utils/os_utils/os_utils.h
@@ -87,6 +87,15 @@ uint64_t BOTAN_TEST_API get_high_resolution_clock();
 uint64_t BOTAN_TEST_API get_system_timestamp_ns();
 
 /**
+* @return CPU time consumed by the calling thread, normalized to
+* nanoseconds resolution, or nullopt if the system does not support
+* it or if the reported resolution is too coarse.
+*
+* The epoch is arbitrary; only differences between calls are meaningful.
+*/
+std::optional<uint64_t> BOTAN_TEST_API get_thread_cpu_time_ns();
+
+/**
 * Format a time
 *
 * Converts the time_t to a local time representation,

--- a/src/lib/utils/time_utils.h
+++ b/src/lib/utils/time_utils.h
@@ -8,6 +8,11 @@
 #define BOTAN_TIME_UTILS_H_
 
 #include <botan/exceptn.h>
+#include <botan/internal/target_info.h>
+#include <algorithm>
+#include <chrono>
+#include <limits>
+#include <optional>
 
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>
@@ -15,28 +20,63 @@
 
 namespace Botan {
 
+/**
+* Estimate the cost, in nanoseconds, of a single invocation of func
+*
+* Runs func repeatedly for roughly trial_msec (but always at least a few
+* times) and returns the fastest invocation observed. Interference from other
+* processes or threads can only ever make an invocation slower, so the minimum
+* is the best estimate of the cost of the work itself. Each invocation is timed
+* using the CPU time of the calling thread where available, otherwise using a
+* monotonic clock.
+*/
 template <typename F>
 uint64_t measure_cost(uint64_t trial_msec, F func) {
-#if defined(BOTAN_HAS_OS_UTILS)
+#if defined(BOTAN_TARGET_OS_HAS_SYSTEM_CLOCK)
+   auto steady_ns = []() -> uint64_t {
+      const auto now = std::chrono::steady_clock::now().time_since_epoch();
+      return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+   };
+
+   auto thread_cpu_ns = []() -> std::optional<uint64_t> {
+   #if defined(BOTAN_HAS_OS_UTILS)
+      return OS::get_thread_cpu_time_ns();
+   #else
+      return std::nullopt;
+   #endif
+   };
+
+   bool use_cpu_time = thread_cpu_ns().has_value();
+
+   auto sample_ns = [&]() -> uint64_t {
+      if(use_cpu_time) {
+         return thread_cpu_ns().value_or(0);
+      }
+      return steady_ns();
+   };
+
+   constexpr size_t min_samples = 3;
    const uint64_t trial_nsec = trial_msec * 1000000;
+   const uint64_t trial_start = steady_ns();
 
-   uint64_t total_nsec = 0;
-   uint64_t trials = 0;
-
-   auto trial_start = OS::get_system_timestamp_ns();
+   uint64_t best = std::numeric_limits<uint64_t>::max();
+   size_t samples = 0;
 
    for(;;) {
-      const auto start = OS::get_system_timestamp_ns();
+      const uint64_t start = sample_ns();
       func();
-      const auto end = OS::get_system_timestamp_ns();
+      const uint64_t end = sample_ns();
 
-      if(end >= start) {
-         total_nsec += (end - start);
-         trials += 1;
+      if(end > start) {
+         best = std::min(best, end - start);
+         samples += 1;
+      } else if(use_cpu_time) {
+         // The thread CPU clock cannot resolve a single invocation
+         use_cpu_time = false;
+      }
 
-         if((end - trial_start) >= trial_nsec) {
-            return (total_nsec / trials);
-         }
+      if(samples >= min_samples && (steady_ns() - trial_start) >= trial_nsec) {
+         return best;
       }
    }
 

--- a/src/tests/test_os_utils.cpp
+++ b/src/tests/test_os_utils.cpp
@@ -10,6 +10,12 @@
 #if defined(BOTAN_HAS_OS_UTILS)
    #include <botan/internal/os_utils.h>
    #include <botan/internal/target_info.h>
+   #include <botan/internal/time_utils.h>
+   #include <chrono>
+#endif
+
+#if defined(BOTAN_TARGET_OS_HAS_THREADS)
+   #include <thread>
 #endif
 
 namespace Botan_Tests {
@@ -38,6 +44,8 @@ class OS_Utils_Tests final : public Test {
          results.push_back(test_get_high_resolution_clock());
          results.push_back(test_get_cpu_numbers());
          results.push_back(test_get_system_timestamp());
+         results.push_back(test_get_thread_cpu_time());
+         results.push_back(test_measure_cost());
          results.push_back(test_memory_locking());
          results.push_back(test_cpu_instruction_probe());
 
@@ -133,6 +141,89 @@ class OS_Utils_Tests final : public Test {
          const uint64_t sys_ts2 = Botan::OS::get_system_timestamp_ns();
 
          result.test_is_true("System time moves forward", sys_ts1 <= sys_ts2);
+
+         return result;
+      }
+
+      // A little CPU work whose result is observed so it cannot be optimized away
+      static uint64_t burn_cpu(uint64_t x, size_t rounds) {
+         for(size_t i = 0; i != rounds; ++i) {
+            x ^= x << 13;
+            x ^= x >> 7;
+            x ^= x << 17;
+         }
+         return x;
+      }
+
+      static uint64_t steady_clock_ns() {
+         const auto now = std::chrono::steady_clock::now().time_since_epoch();
+         return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(now).count());
+      }
+
+      static Test::Result test_get_thread_cpu_time() {
+         Test::Result result("OS::get_thread_cpu_time_ns");
+
+         const auto cpu_ts1 = Botan::OS::get_thread_cpu_time_ns();
+
+         if(!cpu_ts1.has_value()) {
+            result.test_note("Thread CPU time not available on this platform");
+            return result;
+         }
+
+         const uint64_t wall_start = steady_clock_ns();
+         uint64_t state = 0x9E3779B97F4A7C15;
+         while(steady_clock_ns() - wall_start < 2000000) {
+            state = burn_cpu(state, 1000);
+         }
+         const uint64_t wall_elapsed = steady_clock_ns() - wall_start;
+         result.test_is_true("Work loop produced a value", state != 0);
+
+         const auto cpu_ts2 = Botan::OS::get_thread_cpu_time_ns();
+         result.test_is_true("Thread CPU time remains available", cpu_ts2.has_value());
+
+         if(cpu_ts2.has_value()) {
+            result.test_is_true("Thread CPU time advances while busy", *cpu_ts2 > *cpu_ts1);
+            result.test_is_true("Thread CPU time does not exceed wall time",
+                                (*cpu_ts2 - *cpu_ts1) <= wall_elapsed + 1000000);
+         }
+
+   #if defined(BOTAN_TARGET_OS_HAS_THREADS)
+         const auto cpu_ts3 = Botan::OS::get_thread_cpu_time_ns();
+         std::this_thread::sleep_for(std::chrono::milliseconds(20));
+         const auto cpu_ts4 = Botan::OS::get_thread_cpu_time_ns();
+
+         if(cpu_ts3.has_value() && cpu_ts4.has_value()) {
+            result.test_is_true("Thread CPU time barely advances while sleeping", (*cpu_ts4 - *cpu_ts3) < 5000000);
+         }
+   #endif
+
+         return result;
+      }
+
+      static Test::Result test_measure_cost() {
+         Test::Result result("measure_cost");
+
+         size_t calls = 0;
+         uint64_t state = 0x9E3779B97F4A7C15;
+         auto fn = [&]() {
+            calls += 1;
+            state = burn_cpu(state, 20000);
+         };
+
+         const uint64_t cost = Botan::measure_cost(0, fn);
+         result.test_sz_gte("Minimum number of samples taken even with no time budget", calls, 3);
+         result.test_is_true("Cost estimate is nonzero", cost > 0);
+
+         calls = 0;
+         const uint64_t wall_start = steady_clock_ns();
+         const uint64_t cost2 = Botan::measure_cost(5, fn);
+         const uint64_t wall_elapsed = steady_clock_ns() - wall_start;
+
+         result.test_is_true("Tuning loop ran for at least the requested time", wall_elapsed >= 5000000);
+         result.test_is_true("Several samples taken", calls >= 3);
+         result.test_is_true("Cost estimate is nonzero", cost2 > 0);
+         result.test_is_true("Cost estimate is below wall time of the loop", cost2 < wall_elapsed);
+         result.test_is_true("Work loop produced a value", state != 0);
 
          return result;
       }


### PR DESCRIPTION
If clock_gettime's CLOCK_THREAD_CPUTIME_ID is available, measure the time consumed for the computation using that. Otherwise use std::steady_clock.

Also tweak the measurement methodology; previously it ran several times and returned the average of the runs. However in this context the useful thing to do is to measure the fastest run.