### PR TITLE
Feature: `TLS::Callbacks::tls_register_deferred_operation`

### DIFF
--- a/doc/api_ref/tls.rst
+++ b/doc/api_ref/tls.rst
@@ -192,6 +192,37 @@ additional information about the connection.
      This callback is optional, and can be used to examine extensions sent by
      the peer.
 
+ .. cpp:function:: void tls_register_deferred_operation(uint64_t monotonic_delay_ms, \
+                                                        std::function<void()> op)
+
+     Optional, but recommended for DTLS. This callback is used to schedule a
+     deferred operation to be invoked after a specified number of milliseconds.
+     This is used by DTLS to schedule retransmissions of handshake messages that
+     are considered lost in transit.
+
+     If this is not used, the application must call ``Channel::timeout_check()``
+     independently and regularly whenever a DTLS handshake is in progress. In
+     contrast, if it is implemented by the application, make sure to never call
+     ``Channel::timeout_check()`` directly.
+
+     The TLS implementation is not re-entrant. The ``op`` must be invoked in a
+     thread-safe manner when no other thread is concurrently interacting with
+     the respective instance of the TLS channel.
+
+     Invoking ``op`` might throw an exception. Typically this indicates that the
+     maximum number of retransmission attempts has been reached (see also
+     ``Policy::dtls_maximum_retransmissions()``) and the association is being
+     abandoned.
+
+     During an invocation of ``op`` the DTLS implementation might call
+     ``tls_register_deferred_operation()`` again to schedule another operation.
+     This must be supported by the user implementation.
+
+     Since its introduction in Botan 3.14.0, this is the recommended approach to
+     handle DTLS retransmissions, as it allows the library to transparently and
+     asynchronously invoke the deferred operations without relying on the down-
+     stream application.
+
  .. cpp:function:: void tls_log_error(const char* msg)
 
      Optional logging for an error message. (Not currently used)
@@ -286,6 +317,11 @@ available:
       This function does nothing unless the channel represents a DTLS
       connection with a handshake in progress. Returns true if a timeout
       condition occurred and handshake packets were retransmitted.
+
+      Consider using ``Callbacks::tls_register_deferred_operation`` to
+      handle retransmission timers transparently instead of polling this
+      function at regular intervals. Never do both, either implement the
+      callback or poll this function, but not both.
 
    .. cpp:function:: void renegotiate(bool force_full_renegotiation = false)
 

--- a/src/bogo_shim/bogo_shim.cpp
+++ b/src/bogo_shim/bogo_shim.cpp
@@ -2168,6 +2168,37 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks {
       // cookie path throws and every DTLS server test fails.
       std::string tls_peer_network_identity() override { return "bogo-shim-peer"; }
 
+      // Botan registers DTLS retransmission timers here. They are only queued:
+      // the runner must not see packets between AdvanceClock ('T') and its 't'
+      // ACK, so ops are invoked from fire_due_deferred_operations() after the
+      // ACK, never from this callback (also not for a zero delay).
+      void tls_register_deferred_operation(uint64_t monotonic_delay_ms, std::function<void()> op) override {
+         const uint64_t deadline_ms = tls_current_monotonic_clock_ms() + monotonic_delay_ms;
+         m_deferred_operations.emplace_back(Deferred_Operation{deadline_ms, std::move(op)});
+      }
+
+      // Invoke every queued operation whose deadline is within the fudge
+      // interval of the current virtual clock time, earliest first. BoGo's
+      // DTLS-Retransmit-Fudge test advances the clock to timeout-10ms and
+      // expects a retransmit; the library's next_retransmission_timeout()
+      // already treats a <=15ms remainder as expired, so firing the op a
+      // bit early makes the retransmission happen.
+      void fire_due_deferred_operations() {
+         const uint64_t now_ms = tls_current_monotonic_clock_ms();
+         const uint64_t fudge_ms = std::min<uint64_t>(15, m_policy.dtls_initial_timeout() / 2);
+
+         std::stable_sort(m_deferred_operations.begin(), m_deferred_operations.end());
+
+         while(!m_deferred_operations.empty() && m_deferred_operations.front().deadline_ms <= now_ms + fudge_ms) {
+            // Pop the operation from the queue only, then invoke it. op() might
+            // throw an exception or register new deferred operations. Both of
+            // which must happen only after m_deferred_operations got updated.
+            auto op = std::move(m_deferred_operations.front().op);
+            m_deferred_operations.erase(m_deferred_operations.begin());
+            op();
+         }
+      }
+
       void tls_inspect_handshake_msg(const Botan::TLS::Handshake_Message& msg) override {
          if(msg.type() == Botan::TLS::Handshake_Type::HelloRetryRequest) {
             m_hello_retry_request = true;
@@ -2175,6 +2206,15 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks {
       }
 
    private:
+      struct Deferred_Operation {
+            uint64_t deadline_ms;
+            std::function<void()> op;
+
+            friend auto operator<=>(const Deferred_Operation& lhs, const Deferred_Operation& rhs) {
+               return lhs.deadline_ms <=> rhs.deadline_ms;
+            }
+      };
+
       Botan::TLS::Channel* m_channel;
       const Shim_Arguments& m_args;
       Shim_Policy& m_policy;
@@ -2189,6 +2229,7 @@ class Shim_Callbacks final : public Botan::TLS::Callbacks {
       // Virtual clock for the DTLS retransmit timer. Tracked in nanoseconds
       // (BoGo's wire unit) to avoid rounding errors
       uint64_t m_dtls_timer_ns = 0;
+      std::vector<Deferred_Operation> m_deferred_operations;
 };
 
 }  // namespace
@@ -2295,11 +2336,10 @@ int main(int /*argc*/, char* argv[]) {
                      chan->received_data(buf.data(), packet_len);
                   } else if(opcode == 'T') {
                      // AdvanceClock: bump the virtual DTLS timer, ACK, and
-                     // THEN fire timeout_check. Any packets emitted during
-                     // the AdvanceClock window (between 'T' and 't' ACK) are
-                     // treated by the runner as unexpected; the retransmit
-                     // packets must arrive only after the ACK, where the
-                     // runner's ReadRetransmit picks them up.
+                     // THEN fire any deferred retransmission ops. Packets
+                     // emitted between 'T' and the 't' ACK are treated by the
+                     // runner as unexpected; retransmits must arrive only
+                     // after the ACK, where ReadRetransmit picks them up.
                      uint8_t timeout_bytes[8];
                      socket.read_exactly(timeout_bytes, sizeof(timeout_bytes));
                      const uint64_t nsec = Botan::load_be<uint64_t>(timeout_bytes, 0);
@@ -2307,7 +2347,7 @@ int main(int /*argc*/, char* argv[]) {
                      callbacks->advance_dtls_timer_ns(nsec);
                      const uint8_t timeout_ack = 't';
                      socket.write(&timeout_ack, 1);
-                     chan->timeout_check();
+                     callbacks->fire_due_deferred_operations();
                   } else if(opcode == 'E') {
                      // ExpectNextTimeout: runner-side self-check that the next
                      // timeout matches its model. Botan doesn't expose the

--- a/src/lib/tls/tls12/tls_channel_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_channel_impl_12.cpp
@@ -370,6 +370,62 @@ bool Channel_Impl_12::timeout_check() {
    return false;
 }
 
+void Channel_Impl_12::maybe_arm_dtls_retransmission_timer(TimerGeneration generation_policy) {
+   auto next_timeout = next_retransmission_timeout();
+
+   // If there is no timeout, the handshake is complete or there is no handshake
+   // in progress, so there is nothing to arm a timer for.
+   if(!next_timeout.has_value()) {
+      return;
+   }
+
+   // If a new timer generation was requested, we increment the channel-wide
+   // generation counter to invalidate any other timer chain that might still be
+   // running from a backoff interval that has been cut short by incoming data
+   // from the peer.
+   if(generation_policy == TimerGeneration::Advance) {
+      ++m_retransmission_timer_generation;
+   }
+
+   // The actual asynchronous operation:
+   auto on_timer = [self = weak_from_this(), generation = m_retransmission_timer_generation]() mutable {
+      // If this operation is called after the channel implementation is gone,
+      // the channel magically became some other type, or the operation was
+      // called more than once (see below) just return.
+      auto channel = std::dynamic_pointer_cast<Channel_Impl_12>(self.lock());
+      if(!channel) {
+         return;
+      }
+
+      // Drop the reference to the channel in this deferred operation. If the
+      // user accidentally calls the operation more than once, the second
+      // invocation will be a harmless no-op.
+      self.reset();
+
+      // This timer-chain may have been superseded by a newer one, when a
+      // backoff interval was reset by the arrival of a belated handshake
+      // message. This generation is no longer active and ends here.
+      if(generation != channel->m_retransmission_timer_generation) {
+         return;
+      }
+
+      // Now we know that we're on the active retransmission/backoff
+      // chain...
+      if(channel->timeout_check()) {
+         // ... and a retransmission was performed: Spawn the next timer
+         // generation for the next backoff interval in this chain.
+         channel->maybe_arm_dtls_retransmission_timer(TimerGeneration::Advance);
+      } else {
+         // ... but no retransmission was performed. Probably, because the
+         // operation was invoked too-early. Re-spawn this generation's
+         // timer for the remaining time until the next deadline.
+         channel->maybe_arm_dtls_retransmission_timer(TimerGeneration::Keep);
+      }
+   };
+
+   m_callbacks->tls_register_deferred_operation(next_timeout->count(), on_timer);
+}
+
 void Channel_Impl_12::renegotiate(bool force_full_renegotiation) {
    if(pending_state() != nullptr) {  // currently in handshake?
       return;

--- a/src/lib/tls/tls12/tls_channel_impl_12.h
+++ b/src/lib/tls/tls12/tls_channel_impl_12.h
@@ -161,6 +161,17 @@ class Channel_Impl_12 : public Channel_Impl {
       Handshake_State& create_handshake_state(Protocol_Version version, bool epoch0_restart = false);
       virtual std::unique_ptr<Handshake_State> new_handshake_state(std::unique_ptr<Handshake_IO> io) = 0;
 
+      enum class TimerGeneration : bool {
+         Advance,
+         Keep,
+      };
+
+      /**
+      * Ask the user to asynchronously and transparently invoke the time-based
+      * retransmission mechanism.
+      */
+      void maybe_arm_dtls_retransmission_timer(TimerGeneration generation_policy = TimerGeneration::Advance);
+
       void inspect_handshake_message(const Handshake_Message& msg);
 
       void activate_session();
@@ -250,6 +261,7 @@ class Channel_Impl_12 : public Channel_Impl {
 
       /* pending handshake state (null when no handshake is in progress) */
       std::unique_ptr<Handshake_State> m_pending_state;
+      size_t m_retransmission_timer_generation = 0;
 
       /* handle under which this connection's session is cached, if any */
       std::optional<Session_Handle> m_resumption_handle;

--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -141,6 +141,11 @@ std::shared_ptr<Client_Impl_12> Client_Impl_12::create_for_downgrade(
 
       self->secure_renegotiation_check(state.client_hello());
       state.set_expected_next(Handshake_Type::ServerHello);
+
+      // The downgraded DTLS 1.3 session might have armed a retransmission timer
+      // before deciding to downgrade. We have no means to cancel this operation
+      // but it will notice that the DTLS 1.3 state is gone and act as no-op.
+      self->maybe_arm_dtls_retransmission_timer();
    } else {
       // Downgrade initiated after a TLS 1.2 session was found. No communication
       // has happened yet but the found session should be used for resumption.
@@ -232,6 +237,11 @@ void Client_Impl_12::send_client_hello(Handshake_State& state_base,
    }
 
    secure_renegotiation_check(state.client_hello());
+
+   // We just sent our first message that might get lost in transit. Hence, we
+   // kick-off a retransmission timer chain for users that implement the
+   // asynchronous timer callback introduced in Botan 3.14.0.
+   maybe_arm_dtls_retransmission_timer();
 }
 
 namespace {
@@ -319,6 +329,9 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
 
       const Hello_Verify_Request hello_verify_request(contents);
       state.hello_verify_request(hello_verify_request);
+
+      // Cookie ClientHello is a new outgoing flight with a fresh deadline.
+      maybe_arm_dtls_retransmission_timer();
    } else if(type == Handshake_Type::ServerHello) {
       state.server_hello(std::make_unique<Server_Hello_12>(contents));
 
@@ -684,6 +697,10 @@ void Client_Impl_12::process_handshake_msg(Handshake_State& state_base,
       change_cipher_spec_writer(Connection_Side::Client);
 
       state.client_finished(std::make_unique<Finished_12>(state.handshake_io(), state, Connection_Side::Client));
+
+      // Flight is complete, we're now waiting for the peer to respond or for
+      // our timer to cause a retransmission.
+      maybe_arm_dtls_retransmission_timer();
 
       if(state.server_hello()->supports_session_ticket()) {
          state.set_expected_next(Handshake_Type::NewSessionTicket);

--- a/src/lib/tls/tls12/tls_handshake_io.cpp
+++ b/src/lib/tls/tls12/tls_handshake_io.cpp
@@ -218,9 +218,20 @@ Protocol_Version Datagram_Handshake_IO::initial_record_version() const {
 }
 
 std::optional<size_t> Datagram_Handshake_IO::last_completed_flight_index() const {
-   // m_flights keeps an empty trailing slot while waiting for the peer, so the
-   // last completed flight is normally the one before it.
-   const size_t flight_idx = (m_flights.size() == 1) ? 0 : (m_flights.size() - 2);
+   BOTAN_DEBUG_ASSERT(!m_flights.empty());
+
+   // A non-empty current slot is the flight just compiled (the first ClientHello
+   // lives in m_flights[0] the same way). An empty trailing slot is the WAITING
+   // placeholder get_next_record() adds; retransmit the flight before it.
+   if(!m_flights.rbegin()->empty()) {
+      return m_flights.size() - 1;
+   }
+
+   if(m_flights.size() == 1) {
+      return std::nullopt;
+   }
+
+   const size_t flight_idx = m_flights.size() - 2;
 
    // A peer can ask us to replay a flight before we have sent one, eg
    // with a ClientHello whose message_seq is past the reassembly
@@ -350,9 +361,8 @@ std::optional<std::chrono::milliseconds> Datagram_Handshake_IO::next_retransmiss
       return std::nullopt;
    }
 
-   // Without an outgoing flight, or while constructing one, there is nothing
-   // complete that timeout_check() could retransmit.
-   if(!m_last_write.has_value() || (m_flights.size() > 1 && !m_flights.rbegin()->empty())) {
+   // Without an outgoing flight there is nothing timeout_check() could retransmit.
+   if(!m_last_write.has_value() || !last_completed_flight_index().has_value()) {
       return std::nullopt;
    }
 

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -469,6 +469,15 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
 
          pending_state.client_hello(nullptr);
          pending_state.set_expected_next(Handshake_Type::ClientHello);
+
+         // RFC 6346 3.2.1
+         //    Note that timeout and retransmission do not apply to the
+         //    HelloVerifyRequest, because this would require creating state on
+         //    the server.
+         //
+         // We don't kick-off a retransmission timer for a HelloVerifyRequest,
+         // if it gets lost in transit the client will retransmit the initial
+         // ClientHello anyway.
          return;
       }
    }
@@ -532,6 +541,11 @@ void Server_Impl_12::process_client_hello_msg(Server_Handshake_State& pending_st
       // new session
       this->session_create(pending_state);
    }
+
+   // We just sent our first flight that might get lost in transit. Hence, we
+   // kick-off a retransmission timer chain for users that implement the
+   // asynchronous timer callback introduced in Botan 3.14.0.
+   maybe_arm_dtls_retransmission_timer();
 }
 
 void Server_Impl_12::process_certificate_msg(Server_Handshake_State& pending_state,

--- a/src/lib/tls/tls_callbacks.cpp
+++ b/src/lib/tls/tls_callbacks.cpp
@@ -67,6 +67,11 @@ uint64_t TLS::Callbacks::tls_current_monotonic_clock_ms() {
    return std::chrono::duration_cast<std::chrono::milliseconds>(now).count();
 }
 
+void TLS::Callbacks::tls_register_deferred_operation(uint64_t monotonic_delay_ms,
+                                                     std::function<void()> op /* NOLINT(*-value-param) */) {
+   BOTAN_UNUSED(monotonic_delay_ms, op);  // no-op
+}
+
 void TLS::Callbacks::tls_modify_extensions(Extensions& /*unused*/,
                                            Connection_Side /*unused*/,
                                            Handshake_Type /*unused*/) {}

--- a/src/lib/tls/tls_callbacks.h
+++ b/src/lib/tls/tls_callbacks.h
@@ -19,6 +19,7 @@
 #include <botan/tls_algos.h>
 #include <botan/tls_magic.h>
 #include <chrono>
+#include <functional>
 #include <memory>
 #include <optional>
 #include <variant>
@@ -673,6 +674,44 @@ class BOTAN_PUBLIC_API(2, 0) Callbacks /* NOLINT(*-special-member-functions) */ 
        * code should not need to.
        */
       virtual uint64_t tls_current_monotonic_clock_ms();
+
+      /**
+       * Optional callback: Channel registers a deferred operation to be
+       * invoked by the user exactly once after a given delay.
+       *
+       * @note The TLS implementation is not re-entrant. The @p op must be
+       *       invoked in a thread-safe manner when no other thread is
+       *       concurrently interacting with the respective instance of the
+       *       TLS channel.
+       *
+       * @note Invoking @p op might throw an exception. Typically this indicates
+       *       that the maximum number of retransmission attempts has been
+       *       reached (see also Policy::dtls_maximum_retransmissions()) and the
+       *       association is being abandoned.
+       *
+       * @note During an invocation of @p op the DTLS implementation might call
+       *       tls_register_deferred_operation() again to schedule another
+       *       operation. This must be supported by the user implementation.
+       *
+       * By default, this callback does nothing. If the downstream application
+       * chooses not to override and implement this callback, it has to
+       * independently invoke Channel::timeout_check() regularly whenever a DTLS
+       * handshake is in progress. In contrast, if the downstream application
+       * implements this callback, it must never invoke Channel::timeout_check()
+       * directly!
+       *
+       * TODO(Botan4): Change the default to throw an exception to force users
+       *               of DTLS to implement this callback and remove the public
+       *               ::timeout_check() and ::next_retransmission_timeout()
+       *               mechanisms from the Channel.
+       *
+       * @param monotonic_delay_ms the delay in milliseconds with respect to
+       *                           tls_current_monotonic_clock_ms() after which
+       *                           the operation @p op should be invoked
+       * @param op                 the operation to be executed by the user
+       *                           after the delay @p monotonic_delay_ms
+       */
+      virtual void tls_register_deferred_operation(uint64_t monotonic_delay_ms, std::function<void()> op);
 
       /**
        * Optional callback: error logging. (not currently called)

--- a/src/lib/tls/tls_channel.h
+++ b/src/lib/tls/tls_channel.h
@@ -205,6 +205,10 @@ class BOTAN_PUBLIC_API(2, 0) Channel {
       * This function does nothing unless the channel represents a DTLS connection with
       * a handshake in progress.
       *
+      * Consider using ``Callbacks::tls_register_deferred_operation`` introduced
+      * in Botan 3.14.0 to handle retransmission timers transparently instead of
+      * polling this function at regular intervals. Never do both, though!
+      *
       * By default after a certain interval where no progress has been made in the
       * handshake (controlled by the policy values `TLS::Policy::dtls_initial_timeout`,
       * `TLS::Policy::dtls_maximum_timeout`, and `TLS::Policy::dtls_maximum_retransmissions`),


### PR DESCRIPTION
This introduces a new more flexible and less error-prone way of handling retransmission timers for DTLS. Instead of relying on the application to call `Channel::timeout_check()` at regular intervals, the new `TLS::Callbacks` method lets the DTLS implementation request to be called after a given number of milliseconds. Care has been taken to leave the existing approach intact so that applications don't break, but the goal of this is to eventually deprecate `Channel::timeout_check()` and `Channel::next_retransmission_timeout()` in the public API (and perhaps remove it with Botan4).

The reason for this is DTLS 1.3 (#5000) which requires finer grained control over the timer behavior, for two central reasons:

1. ACKs: they should be sent after "1/4 the current retransmit timer" ([RFC 9147 Section 7.1](https://www.rfc-editor.org/rfc/rfc9147.html#name-sending-acks)) to speed up progress and to ensure that multiple received records can be coalesced into a single ACK message.
2. Post-Handshake Messages: Especially KeyUpdate, which may be sent completely transparently to the application (#5877), and that must be retransmitted if it is not ACKed by the peer.

With just the existing polling-API, these requirements seemed cumbersome and awfully error-prone to implement. Essentially, an application would have to be aware when to resume polling `timeout_check()` and when to even speed up the polling interval.

Deliberately there's no public timer cancellation, which keeps the new API straight-forward and avoids overly complicated state handling internally. But it introduces some complication in the usage: essentially, for most timers we need to first determine whether they are still valid or if they can just collapse into a NOOP. Details are exhaustively commented in the code, I hope.

### Pull Request Dependency

* #5916