### PR TITLE
Chore: use `std::enable_shared_from_this` for internal TLS impls

### DIFF
--- a/src/lib/tls/tls12/tls_client_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_client_impl_12.cpp
@@ -97,40 +97,40 @@ class Client_Handshake_State_12 final : public Handshake_State {
 
 }  // namespace
 
-/*
-* TLS 1.2 Client  Constructor
-*/
-Client_Impl_12::Client_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
-                               const std::shared_ptr<Session_Manager>& session_manager,
-                               const std::shared_ptr<Credentials_Manager>& creds,
-                               const std::shared_ptr<const Policy>& policy,
-                               const std::shared_ptr<RandomNumberGenerator>& rng,
-                               Server_Information info,
-                               bool datagram,
-                               const std::vector<std::string>& next_protocols,
-                               size_t io_buf_sz) :
-      Channel_Impl_12(callbacks, session_manager, rng, policy, false, datagram, io_buf_sz),
-      m_creds(creds),
-      m_info(std::move(info)) {
-   BOTAN_ASSERT_NONNULL(m_creds);
+std::shared_ptr<Client_Impl_12> Client_Impl_12::create(const std::shared_ptr<Callbacks>& callbacks,
+                                                       const std::shared_ptr<Session_Manager>& session_manager,
+                                                       const std::shared_ptr<Credentials_Manager>& creds,
+                                                       const std::shared_ptr<const Policy>& policy,
+                                                       const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                       Server_Information server_info,
+                                                       bool datagram,
+                                                       const std::vector<std::string>& next_protocols,
+                                                       size_t reserved_io_buffer_size) {
+   auto self = std::make_shared<Client_Impl_12>(Private{},
+                                                callbacks,
+                                                session_manager,
+                                                creds,
+                                                policy,
+                                                rng,
+                                                std::move(server_info),
+                                                datagram,
+                                                reserved_io_buffer_size);
+
+   BOTAN_ASSERT_NONNULL(self->m_creds);
    const auto version = datagram ? Protocol_Version::DTLS_V12 : Protocol_Version::TLS_V12;
-   Handshake_State& state = create_handshake_state(version);
-   send_client_hello(state, false, version, std::nullopt /* no a-priori session to resume */, next_protocols);
+   Handshake_State& state = self->create_handshake_state(version);
+   self->send_client_hello(state, false, version, std::nullopt /* no a-priori session to resume */, next_protocols);
+
+   return self;
 }
 
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
 
-Client_Impl_12::Client_Impl_12(Channel_Impl::Downgrade_Information& downgrade_info) :
-      Channel_Impl_12(downgrade_info.callbacks,
-                      downgrade_info.session_manager,
-                      downgrade_info.rng,
-                      downgrade_info.policy,
-                      false /* is_server */,
-                      false /* datagram -- not supported by Botan in TLS 1.3 */,
-                      downgrade_info.io_buffer_size),
-      m_creds(downgrade_info.creds),
-      m_info(downgrade_info.server_info) {
-   Handshake_State& state = create_handshake_state(Protocol_Version::TLS_V12);
+std::shared_ptr<Client_Impl_12> Client_Impl_12::create_for_downgrade(
+   Channel_Impl::Downgrade_Information& downgrade_info) {
+   auto self = std::make_shared<Client_Impl_12>(Private{}, downgrade_info);
+
+   Handshake_State& state = self->create_handshake_state(Protocol_Version::TLS_V12);
 
    if(downgrade_info.client_hello.has_value()) {
       // Downgrade detected after receiving a TLS 1.2 server hello. We need to
@@ -139,19 +139,21 @@ Client_Impl_12::Client_Impl_12(Channel_Impl::Downgrade_Information& downgrade_in
       state.client_hello(std::make_unique<Client_Hello_12>(
          std::exchange(downgrade_info.client_hello, {}).value(), state.handshake_io(), state.hash()));
 
-      secure_renegotiation_check(state.client_hello());
+      self->secure_renegotiation_check(state.client_hello());
       state.set_expected_next(Handshake_Type::ServerHello);
    } else {
       // Downgrade initiated after a TLS 1.2 session was found. No communication
       // has happened yet but the found session should be used for resumption.
       BOTAN_ASSERT_NOMSG(downgrade_info.tls12_session.has_value() &&
                          downgrade_info.tls12_session->session.version().is_pre_tls_13());
-      send_client_hello(state,
-                        false,
-                        downgrade_info.tls12_session->session.version(),
-                        downgrade_info.tls12_session,
-                        downgrade_info.next_protocols);
+      self->send_client_hello(state,
+                              false,
+                              downgrade_info.tls12_session->session.version(),
+                              downgrade_info.tls12_session,
+                              downgrade_info.next_protocols);
    }
+
+   return self;
 }
 
 #endif

--- a/src/lib/tls/tls12/tls_client_impl_12.h
+++ b/src/lib/tls/tls12/tls_client_impl_12.h
@@ -46,19 +46,43 @@ class Client_Impl_12 final : public Channel_Impl_12 {
       *        be preallocated for the read and write buffers. Smaller
       *        values just mean reallocations and copies are more likely.
       */
-      explicit Client_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
-                              const std::shared_ptr<Session_Manager>& session_manager,
-                              const std::shared_ptr<Credentials_Manager>& creds,
-                              const std::shared_ptr<const Policy>& policy,
-                              const std::shared_ptr<RandomNumberGenerator>& rng,
-                              Server_Information server_info = Server_Information(),
-                              bool datagram = false,
-                              const std::vector<std::string>& next_protocols = {},
-                              size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE);
+      static std::shared_ptr<Client_Impl_12> create(const std::shared_ptr<Callbacks>& callbacks,
+                                                    const std::shared_ptr<Session_Manager>& session_manager,
+                                                    const std::shared_ptr<Credentials_Manager>& creds,
+                                                    const std::shared_ptr<const Policy>& policy,
+                                                    const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                    Server_Information server_info = Server_Information(),
+                                                    bool datagram = false,
+                                                    const std::vector<std::string>& next_protocols = {},
+                                                    size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE);
+
+      Client_Impl_12([[maybe_unused]] Private dont_call_me,
+                     const std::shared_ptr<Callbacks>& callbacks,
+                     const std::shared_ptr<Session_Manager>& session_manager,
+                     const std::shared_ptr<Credentials_Manager>& creds,
+                     const std::shared_ptr<const Policy>& policy,
+                     const std::shared_ptr<RandomNumberGenerator>& rng,
+                     Server_Information server_info,
+                     bool datagram,
+                     size_t reserved_io_buffer_size) :
+            Channel_Impl_12(callbacks, session_manager, rng, policy, false, datagram, reserved_io_buffer_size),
+            m_creds(creds),
+            m_info(std::move(server_info)) {}
 
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
 
-      explicit Client_Impl_12(Channel_Impl::Downgrade_Information& downgrade_info);
+      static std::shared_ptr<Client_Impl_12> create_for_downgrade(Channel_Impl::Downgrade_Information& downgrade_info);
+
+      Client_Impl_12([[maybe_unused]] Private dont_call_me, Channel_Impl::Downgrade_Information& downgrade_info) :
+            Channel_Impl_12(downgrade_info.callbacks,
+                            downgrade_info.session_manager,
+                            downgrade_info.rng,
+                            downgrade_info.policy,
+                            false /* is_server */,
+                            false /* datagram -- not supported by Botan in TLS 1.3 */,
+                            downgrade_info.io_buffer_size),
+            m_creds(downgrade_info.creds),
+            m_info(downgrade_info.server_info) {}
 
 #endif
 

--- a/src/lib/tls/tls12/tls_server_impl_12.cpp
+++ b/src/lib/tls/tls12/tls_server_impl_12.cpp
@@ -283,36 +283,26 @@ secure_vector<uint8_t> load_dtls_cookie_secret(Credentials_Manager& creds) {
 
 }  // namespace
 
-Server_Impl_12::Server_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
-                               const std::shared_ptr<Session_Manager>& session_manager,
-                               const std::shared_ptr<Credentials_Manager>& creds,
-                               const std::shared_ptr<const Policy>& policy,
-                               const std::shared_ptr<RandomNumberGenerator>& rng,
-                               bool is_datagram,
-                               size_t io_buf_sz) :
-      Channel_Impl_12(callbacks, session_manager, rng, policy, true, is_datagram, io_buf_sz), m_creds(creds) {
-   BOTAN_ASSERT_NONNULL(m_creds);
+std::shared_ptr<Server_Impl_12> Server_Impl_12::create(const std::shared_ptr<Callbacks>& callbacks,
+                                                       const std::shared_ptr<Session_Manager>& session_manager,
+                                                       const std::shared_ptr<Credentials_Manager>& creds,
+                                                       const std::shared_ptr<const Policy>& policy,
+                                                       const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                       bool is_datagram,
+                                                       size_t reserved_io_buffer_size)  //
+{
+   auto self = std::make_shared<Server_Impl_12>(
+      Private{}, callbacks, session_manager, creds, policy, rng, is_datagram, reserved_io_buffer_size);
+   BOTAN_ASSERT_NONNULL(self->m_creds);
 
    // Try to load the cookie secret on initialization, rather than waiting to fail
    // until the first client connects.
    if(is_datagram && policy->dtls_server_require_cookie_exchange()) {
-      load_dtls_cookie_secret(*m_creds);
+      load_dtls_cookie_secret(*self->m_creds);
    }
+
+   return self;
 }
-
-#if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
-
-Server_Impl_12::Server_Impl_12(const Channel_Impl::Downgrade_Information& downgrade_info) :
-      Channel_Impl_12(downgrade_info.callbacks,
-                      downgrade_info.session_manager,
-                      downgrade_info.rng,
-                      downgrade_info.policy,
-                      true /* is_server*/,
-                      false /* TLS 1.3 does not support DTLS yet */,
-                      downgrade_info.io_buffer_size),
-      m_creds(downgrade_info.creds) {}
-
-#endif
 
 std::unique_ptr<Handshake_State> Server_Impl_12::new_handshake_state(std::unique_ptr<Handshake_IO> io) {
    auto state = std::make_unique<Server_Handshake_State>(std::move(io), callbacks());

--- a/src/lib/tls/tls12/tls_server_impl_12.h
+++ b/src/lib/tls/tls12/tls_server_impl_12.h
@@ -44,16 +44,42 @@ class Server_Impl_12 final : public Channel_Impl_12 {
       *        be preallocated for the read and write buffers. Smaller
       *        values just mean reallocations and copies are more likely.
       */
-      explicit Server_Impl_12(const std::shared_ptr<Callbacks>& callbacks,
-                              const std::shared_ptr<Session_Manager>& session_manager,
-                              const std::shared_ptr<Credentials_Manager>& creds,
-                              const std::shared_ptr<const Policy>& policy,
-                              const std::shared_ptr<RandomNumberGenerator>& rng,
-                              bool is_datagram = false,
-                              size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE);
+      static std::shared_ptr<Server_Impl_12> create(const std::shared_ptr<Callbacks>& callbacks,
+                                                    const std::shared_ptr<Session_Manager>& session_manager,
+                                                    const std::shared_ptr<Credentials_Manager>& creds,
+                                                    const std::shared_ptr<const Policy>& policy,
+                                                    const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                    bool is_datagram = false,
+                                                    size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE);
+
+      Server_Impl_12([[maybe_unused]] Private dont_call_me,
+                     const std::shared_ptr<Callbacks>& callbacks,
+                     const std::shared_ptr<Session_Manager>& session_manager,
+                     const std::shared_ptr<Credentials_Manager>& creds,
+                     const std::shared_ptr<const Policy>& policy,
+                     const std::shared_ptr<RandomNumberGenerator>& rng,
+                     bool is_datagram = false,
+                     size_t reserved_io_buffer_size = TLS::Channel::IO_BUF_DEFAULT_SIZE) :
+            Channel_Impl_12(callbacks, session_manager, rng, policy, true, is_datagram, reserved_io_buffer_size),
+            m_creds(creds) {}
 
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
-      explicit Server_Impl_12(const Channel_Impl::Downgrade_Information& downgrade_info);
+
+      static std::shared_ptr<Server_Impl_12> create_for_downgrade(
+         const Channel_Impl::Downgrade_Information& downgrade_info) {
+         return std::make_shared<Server_Impl_12>(Private{}, downgrade_info);
+      }
+
+      Server_Impl_12([[maybe_unused]] Private dont_call_me, const Channel_Impl::Downgrade_Information& downgrade_info) :
+            Channel_Impl_12(downgrade_info.callbacks,
+                            downgrade_info.session_manager,
+                            downgrade_info.rng,
+                            downgrade_info.policy,
+                            true /* is_server*/,
+                            false /* TLS 1.3 does not support DTLS yet */,
+                            downgrade_info.io_buffer_size),
+            m_creds(downgrade_info.creds) {}
+
 #endif
 
    private:

--- a/src/lib/tls/tls13/tls_client_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_client_impl_13.cpp
@@ -23,48 +23,50 @@
 
 namespace Botan::TLS {
 
-Client_Impl_13::Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
-                               const std::shared_ptr<Session_Manager>& session_manager,
-                               const std::shared_ptr<Credentials_Manager>& creds,
-                               const std::shared_ptr<const Policy>& policy,
-                               const std::shared_ptr<RandomNumberGenerator>& rng,
-                               Server_Information info,
-                               const std::vector<std::string>& next_protocols) :
-      Channel_Impl_13(callbacks, session_manager, creds, rng, policy, false /* is_server */),
-      m_info(std::move(info)),
-      m_handshake(std::make_unique<Pending_Handshake>()) {
+std::shared_ptr<Client_Impl_13> Client_Impl_13::create(const std::shared_ptr<Callbacks>& callbacks,
+                                                       const std::shared_ptr<Session_Manager>& session_manager,
+                                                       const std::shared_ptr<Credentials_Manager>& creds,
+                                                       const std::shared_ptr<const Policy>& policy,
+                                                       const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                       Server_Information server_info,
+                                                       const std::vector<std::string>& next_protocols) {
+   auto self = std::make_shared<Client_Impl_13>(
+      Private{}, callbacks, session_manager, creds, policy, rng, std::move(server_info));
+
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
    if(policy->allow_tls12()) {
-      expect_downgrade(m_info, next_protocols);
+      self->expect_downgrade(self->m_info, next_protocols);
    }
 #endif
 
-   if(auto session = find_session_for_resumption()) {
+   if(auto session = self->find_session_for_resumption()) {
       if(session->session.version().is_tls_13_or_later()) {
-         m_handshake->resumed_session = std::move(session);
+         self->m_handshake->resumed_session = std::move(session);
       }
 #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
-      else if(expects_downgrade()) {
+      else if(self->expects_downgrade()) {
          // If we found a session that was created with TLS 1.2, we downgrade
          // the implementation right away, before even issuing a Client Hello.
-         request_downgrade_for_resumption(std::move(session.value()));
-         return;
+         self->request_downgrade_for_resumption(std::move(session.value()));
+         return self;
       }
 #endif
    }
 
-   send_handshake_message(m_handshake->state.sending(
+   self->send_handshake_message(self->m_handshake->state.sending(
       Client_Hello_13(*policy,
                       *callbacks,
                       *rng,
-                      m_info.hostname(),
+                      self->m_info.hostname(),
                       next_protocols,
-                      m_handshake->resumed_session,
-                      creds->find_preshared_keys(m_info.hostname(), Connection_Side::Client))));
+                      self->m_handshake->resumed_session,
+                      creds->find_preshared_keys(self->m_info.hostname(), Connection_Side::Client))));
 
-   maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingFirstClientHello);
+   self->maybe_handle_compatibility_mode(Compat_Mode_Situation::AfterSendingFirstClientHello);
 
-   m_handshake->transitions.set_expected_next({Handshake_Type::ServerHello, Handshake_Type::HelloRetryRequest});
+   self->m_handshake->transitions.set_expected_next({Handshake_Type::ServerHello, Handshake_Type::HelloRetryRequest});
+
+   return self;
 }
 
 void Client_Impl_13::process_handshake_msg(Handshake_Message_13 message) {

--- a/src/lib/tls/tls13/tls_client_impl_13.h
+++ b/src/lib/tls/tls13/tls_client_impl_13.h
@@ -44,13 +44,24 @@ class Client_Impl_13 final : public Channel_Impl_13 {
       *
       * @param next_protocols specifies protocols to advertise with ALPN
       */
-      explicit Client_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
-                              const std::shared_ptr<Session_Manager>& session_manager,
-                              const std::shared_ptr<Credentials_Manager>& creds,
-                              const std::shared_ptr<const Policy>& policy,
-                              const std::shared_ptr<RandomNumberGenerator>& rng,
-                              Server_Information server_info = Server_Information(),
-                              const std::vector<std::string>& next_protocols = {});
+      static std::shared_ptr<Client_Impl_13> create(const std::shared_ptr<Callbacks>& callbacks,
+                                                    const std::shared_ptr<Session_Manager>& session_manager,
+                                                    const std::shared_ptr<Credentials_Manager>& creds,
+                                                    const std::shared_ptr<const Policy>& policy,
+                                                    const std::shared_ptr<RandomNumberGenerator>& rng,
+                                                    Server_Information server_info = Server_Information(),
+                                                    const std::vector<std::string>& next_protocols = {});
+
+      Client_Impl_13([[maybe_unused]] Private dont_call_me,
+                     const std::shared_ptr<Callbacks>& callbacks,
+                     const std::shared_ptr<Session_Manager>& session_manager,
+                     const std::shared_ptr<Credentials_Manager>& creds,
+                     const std::shared_ptr<const Policy>& policy,
+                     const std::shared_ptr<RandomNumberGenerator>& rng,
+                     Server_Information server_info = Server_Information()) :
+            Channel_Impl_13(callbacks, session_manager, creds, rng, policy, false /* is_server */),
+            m_info(std::move(server_info)),
+            m_handshake(std::make_unique<Pending_Handshake>()) {}
 
       /**
       * @return network protocol as advertised by the TLS server, if server sent the ALPN extension

--- a/src/lib/tls/tls13/tls_server_impl_13.cpp
+++ b/src/lib/tls/tls13/tls_server_impl_13.cpp
@@ -20,20 +20,23 @@
 
 namespace Botan::TLS {
 
-Server_Impl_13::Server_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
-                               const std::shared_ptr<Session_Manager>& session_manager,
-                               const std::shared_ptr<Credentials_Manager>& credentials_manager,
-                               const std::shared_ptr<const Policy>& policy,
-                               const std::shared_ptr<RandomNumberGenerator>& rng) :
-      Channel_Impl_13(callbacks, session_manager, credentials_manager, rng, policy, true /* is_server */),
-      m_handshake(std::make_unique<Pending_Handshake>()) {
+std::shared_ptr<Server_Impl_13> Server_Impl_13::create(const std::shared_ptr<Callbacks>& callbacks,
+                                                       const std::shared_ptr<Session_Manager>& session_manager,
+                                                       const std::shared_ptr<Credentials_Manager>& credentials_manager,
+                                                       const std::shared_ptr<const Policy>& policy,
+                                                       const std::shared_ptr<RandomNumberGenerator>& rng) {
+   auto self =
+      std::make_shared<Server_Impl_13>(Private{}, callbacks, session_manager, credentials_manager, policy, rng);
+
 #if defined(BOTAN_HAS_TLS_12)
    if(policy->allow_tls12()) {
-      expect_downgrade({}, {});
+      self->expect_downgrade({}, {});
    }
 #endif
 
-   m_handshake->transitions.set_expected_next(Handshake_Type::ClientHello);
+   self->m_handshake->transitions.set_expected_next(Handshake_Type::ClientHello);
+
+   return self;
 }
 
 std::string Server_Impl_13::application_protocol() const {

--- a/src/lib/tls/tls13/tls_server_impl_13.h
+++ b/src/lib/tls/tls13/tls_server_impl_13.h
@@ -20,11 +20,20 @@ namespace Botan::TLS {
 */
 class Server_Impl_13 final : public Channel_Impl_13 {
    public:
-      explicit Server_Impl_13(const std::shared_ptr<Callbacks>& callbacks,
-                              const std::shared_ptr<Session_Manager>& session_manager,
-                              const std::shared_ptr<Credentials_Manager>& credentials_manager,
-                              const std::shared_ptr<const Policy>& policy,
-                              const std::shared_ptr<RandomNumberGenerator>& rng);
+      static std::shared_ptr<Server_Impl_13> create(const std::shared_ptr<Callbacks>& callbacks,
+                                                    const std::shared_ptr<Session_Manager>& session_manager,
+                                                    const std::shared_ptr<Credentials_Manager>& credentials_manager,
+                                                    const std::shared_ptr<const Policy>& policy,
+                                                    const std::shared_ptr<RandomNumberGenerator>& rng);
+
+      Server_Impl_13([[maybe_unused]] Private dont_call_me,
+                     const std::shared_ptr<Callbacks>& callbacks,
+                     const std::shared_ptr<Session_Manager>& session_manager,
+                     const std::shared_ptr<Credentials_Manager>& credentials_manager,
+                     const std::shared_ptr<const Policy>& policy,
+                     const std::shared_ptr<RandomNumberGenerator>& rng) :
+            Channel_Impl_13(callbacks, session_manager, credentials_manager, rng, policy, true /* is_server */),
+            m_handshake(std::make_unique<Pending_Handshake>()) {}
 
       std::string application_protocol() const override;
       std::vector<X509_Certificate> peer_cert_chain() const override;

--- a/src/lib/tls/tls_channel_impl.h
+++ b/src/lib/tls/tls_channel_impl.h
@@ -35,7 +35,16 @@ namespace TLS {
 class Client;
 class Server;
 
-class Channel_Impl {
+class Channel_Impl : public std::enable_shared_from_this<Channel_Impl> {
+   protected:
+      /**
+      * Sentinel object to make constructors of derived classes un-callable by
+      * other classes.
+      */
+      struct Private {
+            explicit Private() = default;
+      };
+
    public:
       virtual ~Channel_Impl() = default;
 

--- a/src/lib/tls/tls_client.cpp
+++ b/src/lib/tls/tls_client.cpp
@@ -41,8 +41,7 @@ Client::Client(const std::shared_ptr<Callbacks>& callbacks,
 
 #if defined(BOTAN_HAS_TLS_13)
    if(offer_version == Protocol_Version::TLS_V13) {
-      m_impl = std::make_unique<Client_Impl_13>(
-         callbacks, session_manager, creds, policy, rng, std::move(info), next_protocols);
+      m_impl = Client_Impl_13::create(callbacks, session_manager, creds, policy, rng, std::move(info), next_protocols);
 
    #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
       if(m_impl->expects_downgrade()) {
@@ -62,15 +61,15 @@ Client::Client(const std::shared_ptr<Callbacks>& callbacks,
 
 #if defined(BOTAN_HAS_TLS_12)
    if(offer_version.is_pre_tls_13()) {
-      m_impl = std::make_unique<Client_Impl_12>(callbacks,
-                                                session_manager,
-                                                creds,
-                                                policy,
-                                                rng,
-                                                std::move(info),
-                                                offer_version.is_datagram_protocol(),
-                                                next_protocols,
-                                                io_buf_sz);
+      m_impl = Client_Impl_12::create(callbacks,
+                                      session_manager,
+                                      creds,
+                                      policy,
+                                      rng,
+                                      std::move(info),
+                                      offer_version.is_datagram_protocol(),
+                                      next_protocols,
+                                      io_buf_sz);
       return;
    }
 #endif
@@ -87,7 +86,7 @@ size_t Client::downgrade() {
    BOTAN_ASSERT_NOMSG(m_impl->is_downgrading());
 
    auto info = m_impl->extract_downgrade_info();
-   m_impl = std::make_unique<Client_Impl_12>(*info);
+   m_impl = Client_Impl_12::create_for_downgrade(*info);
 
    if(!info->peer_transcript.empty()) {
       // replay peer data received so far

--- a/src/lib/tls/tls_client.h
+++ b/src/lib/tls/tls_client.h
@@ -144,7 +144,7 @@ class BOTAN_PUBLIC_API(2, 0) Client final : public Channel {
 #endif
 
    private:
-      std::unique_ptr<Channel_Impl> m_impl;
+      std::shared_ptr<Channel_Impl> m_impl;
 };
 }  // namespace Botan::TLS
 

--- a/src/lib/tls/tls_server.cpp
+++ b/src/lib/tls/tls_server.cpp
@@ -38,7 +38,7 @@ Server::Server(const std::shared_ptr<Callbacks>& callbacks,
 
 #if defined(BOTAN_HAS_TLS_13)
    if(!max_version.is_pre_tls_13()) {
-      m_impl = std::make_unique<Server_Impl_13>(callbacks, session_manager, creds, policy, rng);
+      m_impl = Server_Impl_13::create(callbacks, session_manager, creds, policy, rng);
 
    #if defined(BOTAN_HAS_TLS_DOWNGRADE_SUPPORT)
       if(m_impl->expects_downgrade()) {
@@ -52,7 +52,7 @@ Server::Server(const std::shared_ptr<Callbacks>& callbacks,
 
 #if defined(BOTAN_HAS_TLS_12)
    if(max_version.is_pre_tls_13()) {
-      m_impl = std::make_unique<Server_Impl_12>(callbacks, session_manager, creds, policy, rng, is_datagram, io_buf_sz);
+      m_impl = Server_Impl_12::create(callbacks, session_manager, creds, policy, rng, is_datagram, io_buf_sz);
       return;
    }
 #endif
@@ -71,7 +71,7 @@ size_t Server::from_peer(std::span<const uint8_t> data) {
    // won't even be created and `is_downgrading()` would always return false.
    if(m_impl->is_downgrading()) {
       auto info = m_impl->extract_downgrade_info();
-      m_impl = std::make_unique<Server_Impl_12>(*info);
+      m_impl = Server_Impl_12::create_for_downgrade(*info);
 
       // replay peer data received so far
       read = m_impl->from_peer(info->peer_transcript);

--- a/src/lib/tls/tls_server.h
+++ b/src/lib/tls/tls_server.h
@@ -130,7 +130,7 @@ class BOTAN_PUBLIC_API(2, 0) Server final : public Channel {
       Server& operator=(Server&& other) = delete;
 
    private:
-      std::unique_ptr<Channel_Impl> m_impl;
+      std::shared_ptr<Channel_Impl> m_impl;
 };
 }  // namespace Botan::TLS
 


### PR DESCRIPTION
This is done as a preparation to share weak_ptr handles to the concrete implementations in asynchronous operations to-be-invoked by the user (see #5915). It will help systematically avoid lifetime issues in such asynchronous calls.

Note that this moved the initialization code that previously ran within the constructors into the newly added factory methods. That ensures that any initialization (e.g. creating a ClientHello) happens after the shared_ptr is fully constructed and shared_from_this works as expected.