### PR TITLE
Add EC_Group::register_custom_group

### DIFF
--- a/src/examples/tls_custom_curves_client.cpp
+++ b/src/examples/tls_custom_curves_client.cpp
@@ -120,7 +120,7 @@ int main() {
    const Botan::OID oid("1.3.6.1.4.1.25258.4.1");
 
    // create EC_Group object to register the curve
-   const Botan::EC_Group numsp256d1(oid, p, a, b, g_x, g_y, n);
+   const auto numsp256d1 = Botan::EC_Group::register_custom_group(oid, p, a, b, g_x, g_y, n);
 
    if(!numsp256d1.verify_group(*rng)) {
       return 1;

--- a/src/lib/ffi/ffi_ec.cpp
+++ b/src/lib/ffi/ffi_ec.cpp
@@ -61,7 +61,7 @@ int botan_ec_group_from_params(botan_ec_group_t* ec_group,
          return BOTAN_FFI_ERROR_NULL_POINTER;
       }
 
-      Botan::EC_Group group(
+      auto group = Botan::EC_Group::register_custom_group(
          safe_get(oid), safe_get(p), safe_get(a), safe_get(b), safe_get(base_x), safe_get(base_y), safe_get(order));
 
       auto group_ptr = std::make_unique<Botan::EC_Group>(std::move(group));

--- a/src/lib/pubkey/ec_group/ec_group.cpp
+++ b/src/lib/pubkey/ec_group/ec_group.cpp
@@ -625,7 +625,17 @@ EC_Group::EC_Group(const OID& oid,
                    const BigInt& b,
                    const BigInt& base_x,
                    const BigInt& base_y,
-                   const BigInt& order) {
+                   const BigInt& order) :
+      EC_Group(std::move(EC_Group::register_custom_group(oid, p, a, b, base_x, base_y, order).m_data)) {}
+
+//static
+EC_Group EC_Group::register_custom_group(const OID& oid,
+                                         const BigInt& p,
+                                         const BigInt& a,
+                                         const BigInt& b,
+                                         const BigInt& base_x,
+                                         const BigInt& base_y,
+                                         const BigInt& order) {
    BOTAN_ARG_CHECK(oid.has_value(), "An OID is required for creating an EC_Group");
 
    // TODO(Botan4) remove this and require 192 bits minimum
@@ -689,8 +699,8 @@ EC_Group::EC_Group(const OID& oid,
 
    const BigInt cofactor(1);
 
-   m_data =
-      ec_group_data().lookup_or_create(p, a, b, base_x, base_y, order, cofactor, oid, EC_Group_Source::ExternalSource);
+   return EC_Group(
+      ec_group_data().lookup_or_create(p, a, b, base_x, base_y, order, cofactor, oid, EC_Group_Source::ExternalSource));
 }
 
 EC_Group::EC_Group(std::span<const uint8_t> der) {

--- a/src/lib/pubkey/ec_group/ec_group.h
+++ b/src/lib/pubkey/ec_group/ec_group.h
@@ -97,7 +97,7 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       * @warning Support for explicitly encoded curve parameters is deprecated.
       * An OID must be assigned.
       */
-      BOTAN_DEPRECATED("Use alternate constructor")
+      BOTAN_DEPRECATED("Use EC_Group::register_custom_group")
       EC_Group(const BigInt& p,
                const BigInt& a,
                const BigInt& b,
@@ -112,19 +112,78 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       *
       * This is used for example to create custom (application-specific) curves.
       *
+      * Calling this function registers these parameters within the persistent state
+      * of the library; for example once this call completes, an ECDSA key
+      * specifying its namedCurve matching the provided OID can be decoded, and
+      * this remains true even after the EC_Group created has been destroyed.
+      * If necessary you can unregister the group using EC_Group::unregister.
+      *
       * Some build configurations do not support application specific curves, in
-      * which case this constructor will throw an exception. You can check for
+      * which case this function will throw an exception. You can check for
       * this situation beforehand using the function
       * EC_Group::supports_application_specific_group()
       *
-      * Unlike the deprecated constructor, this constructor imposes additional
+      * The following constraints are imposed on the parameters:
+      *
+      *  - An object identifier must be provided
+      *
+      *  - The prime must be at least 192 bits and at most 512 bits, and a multiple
+      *    of 32 bits.
+      *
+      *  - As an extension of the above restriction, the prime can also be exactly
+      *    the 521-bit Mersenne prime (2**521-1) or exactly the 239-bit prime used in
+      *    X9.62 239 bit groups (2**239 - 2**143 - 2**95 + 2**47 - 1)
+      *
+      *  - The prime must be congruent to 3 modulo 4
+      *
+      *  - The group order must have the same bit length as the prime. It is allowed
+      *    for the order to be larger than p, but they must have the same bit length.
+      *
+      *  - Only prime order curves (with cofactor == 1) are allowed
+      *
+      * @warning use only elliptic curve parameters that you trust
+      *
+      * @param oid an object identifier used to identify this curve
+      * @param p the elliptic curve prime (at most 521 bits)
+      * @param a the elliptic curve a param
+      * @param b the elliptic curve b param
+      * @param base_x the x coordinate of the group generator
+      * @param base_y the y coordinate of the group generator
+      * @param order the order of the group
+      */
+      BOTAN_DEPRECATED("Use EC_Group::register_custom_group")
+      EC_Group(const OID& oid,
+               const BigInt& p,
+               const BigInt& a,
+               const BigInt& b,
+               const BigInt& base_x,
+               const BigInt& base_y,
+               const BigInt& order);
+
+      /**
+      * Construct elliptic curve from the specified parameters
+      *
+      * This is used for example to create custom (application-specific) curves.
+      *
+      * This function registers these parameters within the persistent state
+      * of the library; for example once this call completes, an ECDSA key
+      * specifying its namedCurve matching the provided OID can be decoded, and
+      * this remains true even after the EC_Group returned here has been destroyed.
+      * If necessary you can unregister the group using EC_Group::unregister.
+      *
+      * Some build configurations do not support application specific curves, in
+      * which case this function will throw an exception. You can check for
+      * this situation beforehand using the function
+      * EC_Group::supports_application_specific_group()
+      *
+      * Unlike the deprecated constructor, this function imposes additional
       * restrictions on the parameters, namely:
       *
       *  - An object identifier must be provided
       *
       *  - The prime must be at least 192 bits and at most 512 bits, and a multiple
       *    of 32 bits. Currently, as long as BOTAN_DISABLE_DEPRECATED_FEATURES is not
-      *    set, this constructor accepts primes as small as 128 bits - this lower
+      *    set, this function will accept primes as small as 128 bits - this lower
       *    bound will be removed in the next major release.
       *
       *  - As an extension of the above restriction, the prime can also be exactly
@@ -148,13 +207,13 @@ class BOTAN_PUBLIC_API(2, 0) EC_Group final {
       * @param base_y the y coordinate of the group generator
       * @param order the order of the group
       */
-      EC_Group(const OID& oid,
-               const BigInt& p,
-               const BigInt& a,
-               const BigInt& b,
-               const BigInt& base_x,
-               const BigInt& base_y,
-               const BigInt& order);
+      static EC_Group register_custom_group(const OID& oid,
+                                            const BigInt& p,
+                                            const BigInt& a,
+                                            const BigInt& b,
+                                            const BigInt& base_x,
+                                            const BigInt& base_y,
+                                            const BigInt& order);
 
       /**
       * Decode a DER encoded ECC domain parameter set

--- a/src/tests/test_ec_group.cpp
+++ b/src/tests/test_ec_group.cpp
@@ -237,13 +237,13 @@ class EC_Group_Tests : public Test {
             result.test_is_true("Same group is same", group == Botan::EC_Group::from_name(group_name));
 
             try {
-               const Botan::EC_Group copy(group.get_curve_oid(),
-                                          group.get_p(),
-                                          group.get_a(),
-                                          group.get_b(),
-                                          group.get_g_x(),
-                                          group.get_g_y(),
-                                          group.get_order());
+               const auto copy = Botan::EC_Group::register_custom_group(group.get_curve_oid(),
+                                                                        group.get_p(),
+                                                                        group.get_a(),
+                                                                        group.get_b(),
+                                                                        group.get_g_x(),
+                                                                        group.get_g_y(),
+                                                                        group.get_order());
 
                result.test_is_true("Same group is same even with copy", group == copy);
             } catch(Botan::Invalid_Argument&) {}
@@ -536,7 +536,7 @@ class EC_Group_Registration_Tests final : public Test {
          const Botan::OID oid("1.3.6.1.4.1.25258.4.1");
 
          // Creating this object implicitly registers the curve for future use ...
-         const Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);
+         const auto reg_group = Botan::EC_Group::register_custom_group(oid, p, a, b, g_x, g_y, order);
 
          auto group = Botan::EC_Group::from_OID(oid);
 
@@ -589,7 +589,7 @@ class EC_Group_Registration_Tests final : public Test {
          const Botan::OID oid("1.2.840.10045.3.1.7");
 
          try {
-            const Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);
+            const auto reg_group = Botan::EC_Group::register_custom_group(oid, p, a, b, g_x, g_y, order);
             result.test_failure("Should have failed");
          } catch(Botan::Invalid_Argument&) {
             result.test_success("Got expected exception");
@@ -640,7 +640,7 @@ class EC_Group_Registration_Tests final : public Test {
 
          const Botan::OID oid("1.3.6.1.4.1.25258.100.0");  // some other random OID
 
-         const Botan::EC_Group reg_group(oid, p, a, b, g_x, g_y, order);
+         const auto reg_group = Botan::EC_Group::register_custom_group(oid, p, a, b, g_x, g_y, order);
          result.test_success("Registration success");
          result.test_is_true("Group has correct OID", reg_group.get_curve_oid() == oid);
 
@@ -669,13 +669,13 @@ class EC_Group_Registration_Tests final : public Test {
 
          Botan::OID::register_oid(custom_oid, "secp256r1");
 
-         const Botan::EC_Group reg_group(custom_oid,
-                                         secp256r1.get_p(),
-                                         secp256r1.get_a(),
-                                         secp256r1.get_b(),
-                                         secp256r1.get_g_x(),
-                                         secp256r1.get_g_y(),
-                                         secp256r1.get_order());
+         const auto reg_group = Botan::EC_Group::register_custom_group(custom_oid,
+                                                                       secp256r1.get_p(),
+                                                                       secp256r1.get_a(),
+                                                                       secp256r1.get_b(),
+                                                                       secp256r1.get_g_x(),
+                                                                       secp256r1.get_g_y(),
+                                                                       secp256r1.get_order());
 
          result.test_success("Registration success");
          result.test_is_true("Group has correct OID", reg_group.get_curve_oid() == custom_oid);
@@ -854,7 +854,7 @@ class EC_Group_Registration_Tests final : public Test {
          const Botan::BigInt g_x("0x01");
          const Botan::BigInt g_y("0x696F1853C1E466D7FC82C96CCEEEDD6BD02C2F9375894EC10BF46306C2B56C77");
 
-         const Botan::EC_Group reg_group(custom_oid, p, a, b, g_x, g_y, order);
+         const auto reg_group = Botan::EC_Group::register_custom_group(custom_oid, p, a, b, g_x, g_y, order);
 
          result.test_is_true("After registration the custom name is supported",
                              Botan::EC_Group::supports_named_group(custom_name));
@@ -930,13 +930,13 @@ class EC_Group_Registration_Tests final : public Test {
          const Botan::OID custom_oid("1.3.6.1.4.1.25258.100.99");
          Botan::OID::register_oid(custom_oid, "secp256r1");
 
-         const Botan::EC_Group reg_group(custom_oid,
-                                         secp256r1.get_p(),
-                                         secp256r1.get_a(),
-                                         secp256r1.get_b(),
-                                         secp256r1.get_g_x(),
-                                         secp256r1.get_g_y(),
-                                         secp256r1.get_order());
+         const auto reg_group = Botan::EC_Group::register_custom_group(custom_oid,
+                                                                       secp256r1.get_p(),
+                                                                       secp256r1.get_a(),
+                                                                       secp256r1.get_b(),
+                                                                       secp256r1.get_g_x(),
+                                                                       secp256r1.get_g_y(),
+                                                                       secp256r1.get_order());
 
          const Botan::EC_Group group_from_oid = Botan::EC_Group::from_OID(custom_oid);
 

--- a/src/tests/test_ecies.cpp
+++ b/src/tests/test_ecies.cpp
@@ -139,7 +139,7 @@ class ECIES_ISO_Tests final : public Text_Based_Test {
          const std::vector<uint8_t> c0 = vars.get_req_bin("C0");  // expected encoded (ephemeral) public key
          const std::vector<uint8_t> k = vars.get_req_bin("K");    // expected derived secret
 
-         const Botan::EC_Group domain(oid, p, a, b, gx, gy, order);
+         const auto domain = Botan::EC_Group::register_custom_group(oid, p, a, b, gx, gy, order);
 
          // keys of bob
          const Botan::ECDH_PrivateKey other_private_key(this->rng(), domain, x);

--- a/src/tests/test_sm2.cpp
+++ b/src/tests/test_sm2.cpp
@@ -32,10 +32,10 @@ std::unique_ptr<Botan::Private_Key> load_sm2_private_key(const VarMap& vars) {
    const BigInt x = vars.get_req_bn("x");
    const Botan::OID oid = Botan::OID(vars.get_req_str("Oid"));
 
-   const Botan::EC_Group domain(oid, p, a, b, xG, yG, order);
+   const auto group = Botan::EC_Group::register_custom_group(oid, p, a, b, xG, yG, order);
 
    Botan::Null_RNG null_rng;
-   return std::make_unique<Botan::SM2_PrivateKey>(null_rng, domain, x);
+   return std::make_unique<Botan::SM2_PrivateKey>(null_rng, group, x);
 }
 
 class SM2_Signature_KAT_Tests final : public PK_Signature_Generation_Test {

--- a/src/tests/test_x509_path.cpp
+++ b/src/tests/test_x509_path.cpp
@@ -1903,7 +1903,7 @@ class CVE_2020_0601_Tests final : public Test {
 
          const auto& secp384r1 = Botan::EC_Group::from_name("secp384r1");
          const Botan::OID curveball_oid("1.3.6.1.4.1.25258.4.2020.0601");
-         const Botan::EC_Group curveball(
+         const auto curveball = Botan::EC_Group::register_custom_group(
             curveball_oid,
             secp384r1.get_p(),
             secp384r1.get_a(),

--- a/src/tests/unit_tls.cpp
+++ b/src/tests/unit_tls.cpp
@@ -2126,7 +2126,7 @@ class TLS_Unit_Tests final : public Test {
             Botan::OID::register_oid(oid, "numsp256d1");
 
             // Creating this object implicitly registers the curve for future use ...
-            const Botan::EC_Group reg_numsp256d1(oid, p, a, b, g_x, g_y, order);
+            const auto group = Botan::EC_Group::register_custom_group(oid, p, a, b, g_x, g_y, order);
 
             test_modern_versions("AES-256/GCM numsp256d1",
                                  results,


### PR DESCRIPTION
This is the same functionality as exposed by the EC_Group constructor taking the same parameters. However the registration aspect of the constructor, that creating such an object allows a curve with those parameters to be used persistently, is not necessarily obvious.