### PR TITLE
Fix rng zero entropy reseed

### DIFF
--- a/doc/api_ref/rng.rst
+++ b/doc/api_ref/rng.rst
@@ -34,12 +34,27 @@ Random Number Generators
       function several times is much slower than calling ``randomize`` once to
       produce multiple bytes at a time.
 
-   .. cpp:function:: void add_entropy(const uint8_t* data, size_t length)
+   .. cpp:function:: void add_entropy(const uint8_t* data, size_t length, \
+                     Entropy_Estimate estimate = Entropy_Estimate::Full())
 
       Incorporates provided data into the state of the PRNG, if at all possible.
       This works for most RNG types, including the system and TPM RNGs. But if
       the RNG doesn't support this operation, the data is dropped, no error is
       indicated.
+
+      The ``estimate`` describes how much entropy the caller assumes the data to
+      contain. By default the data is assumed to have full entropy, in which
+      case a stateful RNG such as ``HMAC_DRBG`` considers itself seeded if at
+      least ``security_level()`` bits are provided in a single call. Passing an
+      explicit ``Entropy_Estimate::Bits(n)`` credits the data with ``n`` bits
+      instead (capped at the length of the data; estimates are not accumulated
+      across calls). In particular ``Entropy_Estimate::Bits(0)`` mixes the data into
+      the RNG state without affecting whether the RNG is considered seeded,
+      which is the appropriate choice for data of unknown or untrusted quality.
+      RNGs which do not track a seeded state ignore the estimate.
+
+      .. versionadded:: 3.14.0
+         The ``estimate`` parameter
 
    .. cpp:function:: bool accepts_input() const
 
@@ -286,6 +301,16 @@ source can perform polling and pass whatever it gathers to the RNG using the
 object's ``add_entropy`` function. The source then returns a best estimate of
 the number of bits of entropy gathered; this can be zero if the source should be
 used but not counted.
+
+The estimate passed to ``add_entropy`` should be consistent with the value
+returned from ``poll``. A source which should be used but not counted passes
+``Entropy_Estimate::Bits(0)`` to ``add_entropy`` and returns zero; the data is then
+mixed into the RNG state without marking the RNG as seeded. Note that
+``add_entropy`` assumes full entropy by default, so a source passing data of
+sufficient length without an explicit estimate would mark a stateful RNG as
+seeded regardless of the value it returns from ``poll``. A stateful RNG which
+polls its entropy sources considers itself seeded once the estimates returned
+by the polled sources sum up to at least its security level.
 
 Note for writers of ``EntropySource`` subclasses: it isn't necessary
 to use any kind of cryptographic hash on your output. The data

--- a/news.rst
+++ b/news.rst
@@ -1,8 +1,8 @@
 Release Notes
-========================================
+=============
 
 Version 3.14.0, Not Yet Released
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add new type ``PK_Signature_Options`` which allows precisely controlling how
   signatures are created and verified. (GH #5849)
@@ -60,8 +60,27 @@ Version 3.14.0, Not Yet Released
   eviction order of the certificate cache shared with the Windows store.
   (GH #5541)
 
+* Add an optional ``Entropy_Estimate`` parameter to
+  ``RandomNumberGenerator::add_entropy`` which allows mixing data into a
+  stateful RNG without crediting it towards the seeded state
+  (``Entropy_Estimate::Bits(0)``) or with an explicit estimate; the default
+  (full entropy) retains the previous behavior. The estimate is delivered
+  through a new virtual function
+  ``RandomNumberGenerator::add_entropy_with_estimate``, whose default
+  implementation forwards the input to ``fill_bytes_with_input`` and ignores the
+  estimate. Classes derived from ``Stateful_RNG`` inherit the new handling and
+  need no change; custom RNG implementations derived directly from
+  ``RandomNumberGenerator`` which track a seeded state of their own must
+  override ``add_entropy_with_estimate`` to receive the estimate. The RDSEED,
+  processor RNG and Windows system statistics entropy sources now pass an
+  estimate of zero. This fixes a bug where the data provided by these sources
+  marked a ``Stateful_RNG`` (``HMAC_DRBG``, ``ChaCha_RNG``, ``AutoSeeded_RNG``)
+  as seeded based only on its length, even though the sources report no entropy,
+  so that ``PRNG_Unseeded`` was not thrown when no counted entropy source was
+  available. (GH #5928)
+
 Version 3.13.0, 2026-08-13
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Fix a blind SSRF during OCSP request processing. A malicious OCSP responder or
   network attacker could cause the application to perform a blind GET to an
@@ -231,7 +250,7 @@ Version 3.13.0, 2026-08-13
 * Upgrade to TLS-Anvil 1.5 (GH #5630)
 
 Version 3.12.0, 2026-05-06
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2026-44378: Resolve a CPU based denial of service when decoding
   BER encoded data.
@@ -307,7 +326,7 @@ Version 3.12.0, 2026-05-06
   headers without the ``botan-3/`` subdirectory (GH #5528)
 
 Version 3.11.1, 2026-03-31
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2026-34580: Resolve certificate verification bypass bug introduced in 3.11.0 (GH #5500)
 
@@ -353,7 +372,7 @@ Version 3.11.1, 2026-03-31
 * Enable explicit_bzero, getentropy, getrandom on Hurd (GH #5488)
 
 Version 3.11.0, 2026-03-15
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2026-32877: Fix a heap over-read during SM2 decryption (GH #5450)
 
@@ -462,7 +481,7 @@ Version 3.11.0, 2026-03-15
 * Fix various clang-tidy and cppcheck warnings (GH #5172 #5207 #5204 #5205)
 
 Version 3.10.0, 2025-11-06
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add support for Ascon AEAD, hash and XOF from NIST SP 800-232 (GH #5061 #5076 #5097)
 
@@ -517,7 +536,7 @@ Version 3.10.0, 2025-11-06
 * Add a ``.devcontainer`` setup (GH #5094)
 
 Version 3.9.0, 2025-08-05
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add SHA-1 implementation using AVX2/BMI2 (GH #4852)
 
@@ -578,7 +597,7 @@ Version 3.9.0, 2025-08-05
 * CI improvements (GH #4920 #4294 #4926 #4929)
 
 Version 3.8.1, 2025-05-07
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Fix a bug that prevented building using the ``fips140`` or ``modern`` module
   policies. (GH #4854 #4856)
@@ -587,7 +606,7 @@ Version 3.8.1, 2025-05-07
   (GH #4855 #4857)
 
 Version 3.8.0, 2025-05-06
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Discussion has started regarding plans for Botan4, current ETA 2027. Check the
   tracking ticket in https://github.com/randombit/botan/issues/4666 for the
@@ -710,13 +729,13 @@ Version 3.8.0, 2025-05-06
 * Update GHA CodeQL actions (GH #4644)
 
 Version 3.7.1, 2025-02-05
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Revert a change that prevented ``build.h`` from being usable from
   C applications. (GH #4636 #4637)
 
 Version 3.7.0, 2025-02-04
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add post-quantum scheme Classic McEliece (GH #3883 #4448 #4458 #4508 #4605)
 
@@ -823,7 +842,7 @@ Version 3.7.0, 2025-02-04
 * Address some new warnings from Clang 19 (GH #4544 #4545 #4548)
 
 Version 3.6.1, 2024-10-26
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Notice: Botan 3.7.0 will remove support for the currently supported
   experimental Kyber r3 TLS ciphersuites, leaving only the standardized
@@ -842,7 +861,7 @@ Version 3.6.1, 2024-10-26
   (GH #4381)
 
 Version 3.6.0, 2024-10-21
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Fully integrate and further optimize the new ECC library first introduced in
   3.5.0. For common curves, operations are 2 to 3 times faster. This also
@@ -925,7 +944,7 @@ Version 3.6.0, 2024-10-21
 * Add compile time option to disable all use of inline assembly (GH #4273 #4265)
 
 Version 3.5.0, 2024-07-08
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2024-34702: Fix a DoS caused by excessive name constraints. (GH #4186)
 
@@ -1049,7 +1068,7 @@ Version 3.5.0, 2024-07-08
 * Fix Roughtime to not reference a deprecated Cloudflare server. (GH #4002 #3937)
 
 Version 3.4.0, 2024-04-08
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add Ed448 signatures and X448 key exchange (GH #3933)
 
@@ -1096,7 +1115,7 @@ Version 3.4.0, 2024-04-08
   (GH #3935 #3910)
 
 Version 3.3.0, 2024-02-20
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * CVE-2024-34703 Fix a potential denial of service caused by accepting
   arbitrary length primes as potential elliptic curve parameters in
@@ -1228,7 +1247,7 @@ Version 3.3.0, 2024-02-20
   (GH #3783 #3833 #3888)
 
 Version 3.2.0, 2023-10-09
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add support for (experimental!) post-quantum secure key exchange
   in TLS 1.3 (GH #3609 #3732 #3733 #3739)
@@ -1324,14 +1343,14 @@ Version 3.2.0, 2023-10-09
   due to spurious warnings in that version. (GH #3711 #3709)
 
 Version 3.1.1, 2023-07-13
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Fix two tests which were insufficiently serialized. This would
   cause sporadic test failures, particularly on machines with
   many cores. (GH #3625 #3623)
 
 Version 3.1.0, 2023-07-11
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Add SPHINCS+ post quantum hash based signature scheme (GH #3564 #3549)
 
@@ -1404,13 +1423,13 @@ Version 3.1.0, 2023-07-11
 * Remove the (undocumented, unsupported) support for CMake (GH #3501)
 
 Version 3.0.0, 2023-04-11
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * Botan is now a C++20 codebase; compiler requirements have been
   increased to GCC 11, Clang 14, or MSVC 2022. (GH #2455 #3086)
 
 Breaking Changes
-----------------------------------------
+----------------
 
 * Remove many deprecated headers. In particular all algorithm specific
   headers (such as ``aes.h``) are no longer available; instead objects
@@ -1452,7 +1471,7 @@ Breaking Changes
   (GH #3186)
 
 TLS Changes
-----------------------------------------
+-----------
 
 * Added support for TLS v1.3
 
@@ -1465,7 +1484,7 @@ TLS Changes
   DHE_PSK suites (GH #2512), CECPQ1 ciphersuites (GH #3094)
 
 New Cryptographic Algorithms
-----------------------------------------
+----------------------------
 
 * Add support for Kyber post-quantum KEM (GH #2872 #2500)
 
@@ -1477,7 +1496,7 @@ New Cryptographic Algorithms
 * Add support for keyed BLAKE2b (GH #2524)
 
 New APIs
-----------------------------------------
+--------
 
 * Add new interface ``T::new_object`` which supplants ``T::clone``. The
   difference is that ``new_object`` returns a ``unique_ptr<T>`` instead of a raw
@@ -1504,7 +1523,7 @@ New APIs
 * Many new functions in the C89 interface; see the API reference for more details.
 
 Implementation Improvements
-----------------------------------------
+---------------------------
 
 * Add AVX2 implementation of Argon2 (GH #3205)
 
@@ -1527,7 +1546,7 @@ Implementation Improvements
   are always chosen to be 8-bit aligned. (GH #2545)
 
 Other Improvements
-----------------------------------------
+------------------
 
 * Changes to ``TLS::Stream`` to make it compatible with generic completion tokens.
   (GH #2667 #2648)
@@ -1539,7 +1558,7 @@ Other Improvements
   provided for each message. (GH #2908)
 
 Older Versions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^
 
 * The release notes for versions 2.0.0 through 2.19.5 can be found in
   ``doc/news_2x.rst``

--- a/src/examples/entropy.cpp
+++ b/src/examples/entropy.cpp
@@ -46,10 +46,13 @@ class Hardware_RNG_Entropy_Source final : public Botan::Entropy_Source {
 
          uint8_t buf[poll_goal / 8];
          const size_t written = call_hardware_specific_rng(buf, sizeof(buf));
-         rng.add_entropy(buf, written);
 
-         // return estimate of bits of entropy written to rng state
-         return written * 8;
+         // estimate of bits of entropy written to rng state
+         const size_t entropy_bits = written * 8;
+
+         rng.add_entropy(buf, written, Botan::Entropy_Estimate::Bits(entropy_bits));
+
+         return entropy_bits;
       }
 };
 
@@ -118,8 +121,10 @@ class Timer_Entropy_Source final : public Botan::Entropy_Source {
             // Examine the output of this approach on your system before trusting it!
             // printf("%016lX %016X\n", timer, counter);
 
-            rng.add_entropy_T(timer);
-            rng.add_entropy_T(counter);
+            // The individual values are not credited with any entropy here;
+            // the overall estimate for the poll is returned below instead.
+            rng.add_entropy_T(timer, Botan::Entropy_Estimate::Bits(0));
+            rng.add_entropy_T(counter, Botan::Entropy_Estimate::Bits(0));
          }
 
          // return estimate of entropy written to rng state

--- a/src/lib/entropy/entropy_src.h
+++ b/src/lib/entropy/entropy_src.h
@@ -42,6 +42,15 @@ class BOTAN_PUBLIC_API(2, 0) Entropy_Source {
       * @param rng will be provided with entropy via calls to add_entropy
       * @return conservative estimate of actual entropy added to rng during poll
       *
+      * The data should be passed to add_entropy together with an
+      * Entropy_Estimate consistent with the estimate returned from this
+      * function. A source which should be used but not counted passes
+      * Entropy_Estimate::Bits(0) and returns zero; this mixes the data into the
+      * RNG state without marking the RNG as seeded. Note that add_entropy
+      * assumes full entropy by default, so an input of sufficient length
+      * would otherwise mark a stateful RNG as seeded regardless of the
+      * estimate returned here.
+      *
       * Any implementation of this function should be thread safe; it may be
       * called concurrently in multiple threads if multiple stateful RNGs reseed
       * across different threads.

--- a/src/lib/entropy/entropy_srcs.cpp
+++ b/src/lib/entropy/entropy_srcs.cpp
@@ -76,8 +76,10 @@ class Processor_RNG_EntropySource final : public Entropy_Source {
          * may be tweaked if and when such conditions become publicly known.
          */
          const size_t poll_bits = 65536;
-         rng.reseed_from_rng(m_hwrng, poll_bits);
-         // Avoid trusting a black box, don't count this as contributing entropy:
+         if(rng.accepts_input()) {
+            // Avoid trusting a black box, don't count this as contributing entropy:
+            rng.add_entropy(m_hwrng.random_vec(poll_bits / 8), Entropy_Estimate::Bits(0));
+         }
          return 0;
       }
 

--- a/src/lib/entropy/rdseed/rdseed.cpp
+++ b/src/lib/entropy/rdseed/rdseed.cpp
@@ -87,7 +87,9 @@ size_t Intel_Rdseed::poll(RandomNumberGenerator& rng) {
       }
 
       if(!seed.empty()) {
-         rng.add_entropy(reinterpret_cast<const uint8_t*>(seed.data()), seed.size() * sizeof(uint32_t));
+         // RDSEED is used but not trusted, so its output is not credited
+         rng.add_entropy(
+            reinterpret_cast<const uint8_t*>(seed.data()), seed.size() * sizeof(uint32_t), Entropy_Estimate::Bits(0));
       }
    }
 

--- a/src/lib/entropy/win32_stats/es_win32.cpp
+++ b/src/lib/entropy/win32_stats/es_win32.cpp
@@ -15,31 +15,34 @@
 namespace Botan {
 
 size_t Win32_EntropySource::poll(RandomNumberGenerator& rng) {
-   rng.add_entropy_T(::GetTickCount());
-   rng.add_entropy_T(::GetMessagePos());
-   rng.add_entropy_T(::GetMessageTime());
-   rng.add_entropy_T(::GetInputState());
+   // We assume all of the below is basically junk, so none of it is credited
+   constexpr Entropy_Estimate uncounted(Entropy_Estimate::Bits(0));
 
-   rng.add_entropy_T(::GetCurrentProcessId());
-   rng.add_entropy_T(::GetCurrentThreadId());
+   rng.add_entropy_T(::GetTickCount(), uncounted);
+   rng.add_entropy_T(::GetMessagePos(), uncounted);
+   rng.add_entropy_T(::GetMessageTime(), uncounted);
+   rng.add_entropy_T(::GetInputState(), uncounted);
+
+   rng.add_entropy_T(::GetCurrentProcessId(), uncounted);
+   rng.add_entropy_T(::GetCurrentThreadId(), uncounted);
 
    SYSTEM_INFO sys_info{};
    ::GetSystemInfo(&sys_info);  // no return value
-   rng.add_entropy_T(sys_info);
+   rng.add_entropy_T(sys_info, uncounted);
 
    MEMORYSTATUSEX mem_info{};
    mem_info.dwLength = sizeof(mem_info);
    if(::GlobalMemoryStatusEx(&mem_info) != 0) {
-      rng.add_entropy_T(mem_info);
+      rng.add_entropy_T(mem_info, uncounted);
    }
 
    POINT point{};
    if(::GetCursorPos(&point) != 0) {
-      rng.add_entropy_T(point);
+      rng.add_entropy_T(point, uncounted);
    }
 
    if(::GetCaretPos(&point) != 0) {
-      rng.add_entropy_T(point);
+      rng.add_entropy_T(point, uncounted);
    }
 
    /*

--- a/src/lib/rng/auto_rng/auto_rng.cpp
+++ b/src/lib/rng/auto_rng/auto_rng.cpp
@@ -103,6 +103,10 @@ size_t AutoSeeded_RNG::reseed_from_sources(Entropy_Sources& srcs, size_t poll_bi
    return m_rng->reseed_from_sources(srcs, poll_bits);
 }
 
+void AutoSeeded_RNG::add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate) {
+   m_rng->add_entropy(input, estimate);
+}
+
 void AutoSeeded_RNG::fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) {
    if(out.empty() && in.empty()) {
       return;

--- a/src/lib/rng/auto_rng/auto_rng.h
+++ b/src/lib/rng/auto_rng/auto_rng.h
@@ -117,6 +117,8 @@ class BOTAN_PUBLIC_API(2, 0) AutoSeeded_RNG final : public RandomNumberGenerator
    private:
       void fill_bytes_with_input(std::span<uint8_t> out, std::span<const uint8_t> in) override;
 
+      void add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate) override;
+
    private:
       std::unique_ptr<Stateful_RNG> m_rng;
 };

--- a/src/lib/rng/rng.cpp
+++ b/src/lib/rng/rng.cpp
@@ -66,6 +66,11 @@ size_t RandomNumberGenerator::reseed_from_sources(Entropy_Sources& srcs, size_t 
    return 0;
 }
 
+void RandomNumberGenerator::add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate) {
+   BOTAN_UNUSED(estimate);
+   this->fill_bytes_with_input({}, input);
+}
+
 void RandomNumberGenerator::reseed_from_rng(RandomNumberGenerator& rng, size_t poll_bits) {
    if(this->accepts_input()) {
       this->add_entropy(rng.random_vec(poll_bits / 8));

--- a/src/lib/rng/rng.h
+++ b/src/lib/rng/rng.h
@@ -34,6 +34,82 @@ namespace Botan {
 class Entropy_Sources;
 
 /**
+* Estimate of the amount of entropy contained in an input passed to
+* RandomNumberGenerator::add_entropy
+*
+* Stateful RNGs such as HMAC_DRBG use this estimate to decide whether the
+* provided input is sufficient to consider the RNG as seeded. RNGs which do
+* not track a seeded state ignore the estimate.
+*/
+class BOTAN_PUBLIC_API(3, 14) Entropy_Estimate final {
+   public:
+      /**
+      * Specifies that the input is assumed to contain full entropy, ie as
+      * many bits of entropy as it has bits. This is the default used by
+      * add_entropy.
+      */
+      class Full final {};
+
+      /**
+      * A number of bits of entropy
+      *
+      * Entropy_Estimate is constructed from this type rather than from a
+      * plain integer so that the unit is explicit at the call site, eg
+      * Entropy_Estimate::Bits(128).
+      */
+      class Bits final {
+         public:
+            constexpr explicit Bits(size_t bits) : m_bits(bits) {}
+
+            constexpr size_t value() const { return m_bits; }
+
+         private:
+            size_t m_bits;
+      };
+
+      /**
+      * The input is assumed to contain full entropy.
+      *
+      * The conversion from Full is implicit so that Entropy_Estimate::Full()
+      * can be passed directly to add_entropy.
+      */
+      constexpr Entropy_Estimate(Full /*unused*/) : m_full(true), m_bits(0) {}  // NOLINT(*-explicit-conversions)
+
+      /**
+      * The input is estimated to contain the given number of bits of entropy.
+      *
+      * An estimate of zero bits means that the input is mixed into the RNG
+      * state but is not credited towards the RNG being considered seeded.
+      *
+      * The conversion from Bits is implicit so that Entropy_Estimate::Bits(n)
+      * can be passed directly to add_entropy.
+      */
+      constexpr Entropy_Estimate(Bits bits) : m_full(false), m_bits(bits.value()) {}  // NOLINT(*-explicit-conversions)
+
+      /**
+      * @return true if this estimate assumes full entropy
+      */
+      constexpr bool is_full() const { return m_full; }
+
+      /**
+      * @return the number of bits of entropy credited for an input of
+      * @p input_len bytes. A numeric estimate is capped at the bit length
+      * of the input.
+      */
+      constexpr size_t bits_for_input(size_t input_len) const {
+         const size_t input_bits = 8 * input_len;
+         if(is_full() || m_bits > input_bits) {
+            return input_bits;
+         }
+         return m_bits;
+      }
+
+   private:
+      bool m_full;
+      size_t m_bits;
+};
+
+/**
 * An interface to a cryptographic random number generator
 */
 class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
@@ -108,25 +184,40 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       * A few RNG types do not accept any externally provided input,
       * in which case this function is a no-op.
       *
+      * By default the input is assumed to contain full entropy; for a
+      * stateful RNG such as HMAC_DRBG an input of at least security_level()
+      * bits then marks the RNG as seeded. Pass an explicit Entropy_Estimate
+      * to credit the input differently. In particular Entropy_Estimate::Bits(0)
+      * mixes the input into the RNG state without affecting the seeded state,
+      * which is appropriate for data of unknown or untrusted quality.
+      *
       * @param input a byte array containing the entropy to be added
+      * @param estimate the amount of entropy assumed to be contained in input
       * @throws Exception may throw if the RNG accepts input, but adding the entropy failed.
       */
-      void add_entropy(std::span<const uint8_t> input) { this->fill_bytes_with_input({}, input); }
+      void add_entropy(std::span<const uint8_t> input, Entropy_Estimate estimate = Entropy_Estimate::Full()) {
+         this->add_entropy_with_estimate(input, estimate);
+      }
 
       /**
       * Incorporate some additional data into the RNG state
       * @param input a byte array containing the entropy to be added
       * @param length the number of bytes in input
+      * @param estimate the amount of entropy assumed to be contained in input
       */
-      void add_entropy(const uint8_t input[], size_t length) { this->add_entropy(std::span(input, length)); }
+      void add_entropy(const uint8_t input[], size_t length, Entropy_Estimate estimate = Entropy_Estimate::Full()) {
+         this->add_entropy(std::span(input, length), estimate);
+      }
 
       /**
       * Incorporate some additional data into the RNG state.
+      * @param t the object whose representation is added to the RNG state
+      * @param estimate the amount of entropy assumed to be contained in t
       */
       template <typename T>
          requires std::is_standard_layout_v<T> && std::is_trivial_v<T>
-      void add_entropy_T(const T& t) {
-         this->add_entropy(reinterpret_cast<const uint8_t*>(&t), sizeof(T));
+      void add_entropy_T(const T& t, Entropy_Estimate estimate = Entropy_Estimate::Full()) {
+         this->add_entropy(reinterpret_cast<const uint8_t*>(&t), sizeof(T), estimate);
       }
 
       /**
@@ -351,6 +442,22 @@ class BOTAN_PUBLIC_API(2, 0) RandomNumberGenerator {
       */
       virtual size_t reseed_from_sources(Entropy_Sources& srcs,
                                          size_t poll_bits = RandomNumberGenerator::DefaultPollBits);
+
+      /**
+      * Incorporate the provided input into the RNG state, crediting it with
+      * the given entropy estimate.
+      *
+      * The default implementation ignores the estimate and forwards the input
+      * to fill_bytes_with_input with an empty output buffer. This is the
+      * correct behavior for RNGs which do not track whether they are seeded,
+      * such as system or hardware RNGs. RNGs which do track a seeded state
+      * should override this function and credit the input according to the
+      * estimate.
+      *
+      * @param input the data to incorporate
+      * @param estimate the amount of entropy assumed to be contained in input
+      */
+      virtual void add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate);
 
       /**
       * Generic interface to provide entropy to a concrete implementation and to

--- a/src/lib/rng/stateful_rng/stateful_rng.cpp
+++ b/src/lib/rng/stateful_rng/stateful_rng.cpp
@@ -60,16 +60,23 @@ void Stateful_RNG::generate_batched_output(std::span<uint8_t> output, std::span<
    }
 }
 
+void Stateful_RNG::add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate) {
+   const lock_guard_type<recursive_mutex_type> lock(m_mutex);
+
+   this->update(input);
+
+   if(estimate.bits_for_input(input.size()) >= security_level()) {
+      reset_reseed_counter();
+   }
+}
+
 void Stateful_RNG::fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) {
    const lock_guard_type<recursive_mutex_type> lock(m_mutex);
 
    if(output.empty()) {
-      // Special case for exclusively adding entropy to the stateful RNG.
-      this->update(input);
-
-      if(8 * input.size() >= security_level()) {
-         reset_reseed_counter();
-      }
+      // Special case for exclusively adding entropy to the stateful RNG,
+      // eg via randomize_with_input with an empty output buffer
+      add_entropy_with_estimate(input, Entropy_Estimate::Full());
    } else {
       generate_batched_output(output, input);
    }

--- a/src/lib/rng/stateful_rng/stateful_rng.h
+++ b/src/lib/rng/stateful_rng/stateful_rng.h
@@ -168,6 +168,8 @@ class BOTAN_PUBLIC_API(2, 0) Stateful_RNG : public RandomNumberGenerator {
 
       void fill_bytes_with_input(std::span<uint8_t> output, std::span<const uint8_t> input) final;
 
+      void add_entropy_with_estimate(std::span<const uint8_t> input, Entropy_Estimate estimate) final;
+
       void reset_reseed_counter();
 
       mutable recursive_mutex_type m_mutex;

--- a/src/tests/test_rng_behavior.cpp
+++ b/src/tests/test_rng_behavior.cpp
@@ -70,6 +70,8 @@ class Stateful_RNG_Tests : public Test {
          results.push_back(test_reseed_interval_limits());
          results.push_back(test_max_number_of_bytes_per_request());
          results.push_back(test_broken_entropy_input());
+         results.push_back(test_add_entropy_estimate());
+         results.push_back(test_entropy_source_estimate());
          results.push_back(test_check_nonce());
          results.push_back(test_prediction_resistance());
          results.push_back(test_randomize_with_ts_input());
@@ -227,6 +229,220 @@ class Stateful_RNG_Tests : public Test {
          result.test_throws("underlying rng and entropy sources broken", [&rng_with_broken_rng_and_broken_es]() {
             rng_with_broken_rng_and_broken_es->random_vec(16);
          });
+   #endif
+
+         return result;
+      }
+
+      Test::Result test_add_entropy_estimate() {
+         Test::Result result(rng_name() + " Entropy Estimate");
+
+         auto rng = create_rng(nullptr, nullptr, 0);
+         const size_t sec_level = rng->security_level();
+         const std::vector<uint8_t> input(64, 0x42);
+
+         rng->clear();
+         result.test_is_false("not seeded", rng->is_seeded());
+
+         rng->add_entropy(input, Botan::Entropy_Estimate::Bits(0));
+         result.test_is_false("uncounted input does not seed", rng->is_seeded());
+         result.test_throws<Botan::PRNG_Unseeded>("no output after uncounted input", [&]() { rng->random_vec(16); });
+
+         rng->add_entropy(input, Botan::Entropy_Estimate::Bits(sec_level / 2));
+         result.test_is_false("insufficient estimate does not seed", rng->is_seeded());
+         rng->add_entropy(input, Botan::Entropy_Estimate::Bits(sec_level / 2));
+         result.test_is_false("estimates are not accumulated", rng->is_seeded());
+
+         rng->add_entropy(std::vector<uint8_t>(8, 0x42), Botan::Entropy_Estimate::Bits(sec_level));
+         result.test_is_false("estimate is capped at the input length", rng->is_seeded());
+
+         rng->add_entropy(std::vector<uint8_t>(sec_level / 8, 0x42), Botan::Entropy_Estimate::Bits(sec_level));
+         result.test_is_true("sufficient estimate seeds", rng->is_seeded());
+         result.test_no_throw("output after seeding", [&]() { rng->random_vec(16); });
+
+         rng->clear();
+         rng->add_entropy(input);
+         result.test_is_true("full entropy is the default", rng->is_seeded());
+
+         // uncounted input is nonetheless mixed into the state
+         {
+            const std::vector<uint8_t> seed(sec_level / 8, 0xA5);
+
+            auto rng1 = create_rng(nullptr, nullptr, 0);
+            auto rng2 = create_rng(nullptr, nullptr, 0);
+            auto rng3 = create_rng(nullptr, nullptr, 0);
+
+            rng1->initialize_with(seed);
+            rng2->initialize_with(seed);
+            rng3->initialize_with(seed);
+
+            rng2->add_entropy(input, Botan::Entropy_Estimate::Bits(0));
+
+            const auto out1 = rng1->random_vec(32);
+            const auto out2 = rng2->random_vec(32);
+            const auto out3 = rng3->random_vec(32);
+
+            result.test_is_true("same seed produces same output", out1 == out3);
+            result.test_is_true("uncounted input changes the output", out1 != out2);
+         }
+
+         // uncounted input does not reset the reseed interval, full entropy input does
+         {
+            Request_Counting_RNG counting_rng;
+            auto rng4 = make_rng(counting_rng, 4);
+
+            rng4->random_vec(1);
+            rng4->random_vec(1);
+            result.test_sz_eq("initial seeding", counting_rng.randomize_count(), 1);
+
+            rng4->add_entropy(input, Botan::Entropy_Estimate::Bits(0));
+            result.test_is_true("still seeded", rng4->is_seeded());
+
+            rng4->random_vec(1);
+            rng4->random_vec(1);
+            result.test_sz_eq("no reseed within interval", counting_rng.randomize_count(), 1);
+            rng4->random_vec(1);
+            result.test_sz_eq("uncounted input did not reset the reseed interval", counting_rng.randomize_count(), 2);
+
+            rng4->random_vec(1);
+            rng4->add_entropy(input);
+
+            rng4->random_vec(1);
+            rng4->random_vec(1);
+            rng4->random_vec(1);
+            result.test_sz_eq("full entropy input reset the reseed interval", counting_rng.randomize_count(), 2);
+            rng4->random_vec(1);
+            result.test_sz_eq("reseed after reset interval", counting_rng.randomize_count(), 3);
+         }
+
+         return result;
+      }
+
+      Test::Result test_entropy_source_estimate() {
+         Test::Result result(rng_name() + " Entropy Source Estimate");
+
+   #if defined(BOTAN_HAS_ENTROPY_SOURCE)
+         // Provides a fixed amount of data and claims a fixed entropy estimate for it
+         class Fixed_Estimate_Entropy_Source final : public Botan::Entropy_Source {
+            public:
+               Fixed_Estimate_Entropy_Source(size_t bytes, size_t estimate) : m_bytes(bytes), m_estimate(estimate) {}
+
+               std::string name() const override { return "Fixed Estimate Entropy Source"; }
+
+               size_t poll(Botan::RandomNumberGenerator& rng) override {
+                  m_polls++;
+                  const std::vector<uint8_t> buf(m_bytes, 0x42);
+                  rng.add_entropy(buf, Botan::Entropy_Estimate::Bits(m_estimate));
+                  return m_estimate;
+               }
+
+               size_t polls() const { return m_polls; }
+
+            private:
+               size_t m_bytes;
+               size_t m_estimate;
+               size_t m_polls = 0;
+         };
+
+         // Like a timer based source: many small inputs, credited only via the poll estimate
+         class Chunked_Entropy_Source final : public Botan::Entropy_Source {
+            public:
+               explicit Chunked_Entropy_Source(size_t estimate) : m_estimate(estimate) {}
+
+               std::string name() const override { return "Chunked Entropy Source"; }
+
+               size_t poll(Botan::RandomNumberGenerator& rng) override {
+                  for(uint64_t i = 0; i != 64; ++i) {
+                     rng.add_entropy_T(i, Botan::Entropy_Estimate::Bits(0));
+                  }
+                  return m_estimate;
+               }
+
+            private:
+               size_t m_estimate;
+         };
+
+         const size_t sec_level = create_rng(nullptr, nullptr, 0)->security_level();
+         // well above the length at which add_entropy would by default consider the RNG seeded
+         const size_t big = 2 * sec_level / 8;
+
+         // a source providing plenty of data but claiming no entropy does not seed the RNG
+         {
+            Botan::Entropy_Sources srcs;
+            auto src = std::make_unique<Fixed_Estimate_Entropy_Source>(big, 0);
+            const auto* src_ptr = src.get();
+            srcs.add_source(std::move(src));
+
+            auto rng = make_rng(srcs);
+            result.test_throws<Botan::PRNG_Unseeded>("uncounted source does not seed", [&]() { rng->random_vec(16); });
+            result.test_sz_gte("source was polled", src_ptr->polls(), 1);
+            result.test_is_false("not seeded after uncounted poll", rng->is_seeded());
+            result.test_throws<Botan::PRNG_Unseeded>("still not seeded", [&]() { rng->random_vec(16); });
+         }
+
+         // a source providing small chunks is credited via its poll estimate
+         {
+            Botan::Entropy_Sources srcs;
+            srcs.add_source(std::make_unique<Chunked_Entropy_Source>(sec_level));
+
+            auto rng = make_rng(srcs);
+            result.test_no_throw("chunked source seeds", [&]() { rng->random_vec(16); });
+            result.test_is_true("seeded via poll estimate", rng->is_seeded());
+         }
+
+         // a counted source seeds the RNG
+         {
+            Botan::Entropy_Sources srcs;
+            srcs.add_source(std::make_unique<Fixed_Estimate_Entropy_Source>(sec_level / 8, sec_level));
+
+            auto rng = make_rng(srcs);
+            result.test_no_throw("counted source seeds", [&]() { rng->random_vec(16); });
+            result.test_is_true("seeded", rng->is_seeded());
+         }
+
+         // an uncounted source followed by a counted source seeds the RNG
+         {
+            Botan::Entropy_Sources srcs;
+            srcs.add_source(std::make_unique<Fixed_Estimate_Entropy_Source>(big, 0));
+            srcs.add_source(std::make_unique<Fixed_Estimate_Entropy_Source>(sec_level / 8, sec_level));
+
+            auto rng = make_rng(srcs);
+            result.test_no_throw("mixed sources seed", [&]() { rng->random_vec(16); });
+            result.test_is_true("seeded", rng->is_seeded());
+         }
+
+         // an insufficient estimate does not seed the RNG
+         {
+            Botan::Entropy_Sources srcs;
+            srcs.add_source(std::make_unique<Fixed_Estimate_Entropy_Source>(big, sec_level / 2));
+
+            auto rng = make_rng(srcs);
+            result.test_throws<Botan::PRNG_Unseeded>("insufficient estimate does not seed",
+                                                     [&]() { rng->random_vec(16); });
+         }
+
+         // explicitly reseeding from an uncounted source keeps the RNG seeded
+         // but does not reset the reseed interval
+         {
+            Botan::Entropy_Sources srcs;
+            srcs.add_source(std::make_unique<Fixed_Estimate_Entropy_Source>(big, 0));
+
+            Request_Counting_RNG counting_rng;
+            auto rng = make_rng(counting_rng, 4);
+
+            rng->random_vec(1);
+            rng->random_vec(1);
+            result.test_sz_eq("initial seeding", counting_rng.randomize_count(), 1);
+
+            result.test_sz_eq("no entropy reported", rng->reseed_from_sources(srcs, sec_level), 0);
+            result.test_is_true("remains seeded", rng->is_seeded());
+
+            rng->random_vec(1);
+            rng->random_vec(1);
+            result.test_sz_eq("no reseed within interval", counting_rng.randomize_count(), 1);
+            rng->random_vec(1);
+            result.test_sz_eq("uncounted poll did not reset the reseed interval", counting_rng.randomize_count(), 2);
+         }
    #endif
 
          return result;


### PR DESCRIPTION
partly fixes https://github.com/randombit/botan/issues/5928

- Fixes the problem described in #5928 manifest in Botan
  - by adding an entropy estimate parameter to the `add_entropy()` function family (where call sites are forced to indicate that the unit of measurement is bits)
  - whose entropy_estimate parameter defaults to "Full", thus retaining the previous behaviour if not specified,
  - but is set properly to zero when seeded by the uncounted entropy sources.
- The fix leaves the following gaps:
  - The logic for determining when a reseed is completed is still duplicated. Duplication of security-critical logic is an error prone design and thus this should be resolved in the future. Resolving it now would have to address the following remaining gap.
  - The next gap (referred to by the item above this one) is that repeated seedings with and entropy_estimate < security_level() are not accumulated inside the RNG and thus do not lead a reseed. That has no negative effect in current Botan, but prevents the removal of the duplicated reseeding logic (as mentioned in the item above).
  -  This fix still exhibits the problem that if there is an RNG implementation that doesn't override the implementation of `Stateful_RNG::fill_bytes_with_input()` (or alternatively that of `RandomNumberGenerator::add_entropy()`), it will still potentially enable the failure scenario. The problem lies in the routing of `RandomNumberGenerator::add_entropy()` through `RandomNumberGenerator::add_entropy_with_estimate()` and then `Stateful_RNG::fill_bytes_with_input()` (which sets entropy_estimate to "Full" regardless of the estimate provided in the call of `add_entropy()` )). There is no RNG existing in Botan that uses `Stateful_RNG::fill_bytes_with_input()`, however, since all non-virtual RNG classes are overriding it. Fixing this gap conclusively for all potential user RNGs by making `RandomNumberGenerator::add_entropy()` or `Stateful_RNG::fill_bytes_with_input()` purely virtual would result in incompatibilities with user-defined RNGs for Botan and thus be a breaking change.

<img width="3680" height="2829" alt="entropy_call_hierarchy" src="https://github.com/user-attachments/assets/1de78542-e35b-4d7f-8834-f5b7297d14aa" />
